### PR TITLE
[13.0] Add stock_picking_type_shipping_policy - alpha

### DIFF
--- a/setup/stock_picking_type_shipping_policy/odoo/addons/stock_picking_type_shipping_policy
+++ b/setup/stock_picking_type_shipping_policy/odoo/addons/stock_picking_type_shipping_policy
@@ -1,0 +1,1 @@
+../../../../stock_picking_type_shipping_policy

--- a/setup/stock_picking_type_shipping_policy/setup.py
+++ b/setup/stock_picking_type_shipping_policy/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_picking_type_shipping_policy/__init__.py
+++ b/stock_picking_type_shipping_policy/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_type_shipping_policy/__manifest__.py
+++ b/stock_picking_type_shipping_policy/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Picking Type Shipping Policy",
+    "summary": "Define different shipping policies according to picking type",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["stock"],
+    "data": ["views/stock_picking_type.xml"],
+}

--- a/stock_picking_type_shipping_policy/models/__init__.py
+++ b/stock_picking_type_shipping_policy/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_move
+from . import stock_picking_type

--- a/stock_picking_type_shipping_policy/models/stock_move.py
+++ b/stock_picking_type_shipping_policy/models/stock_move.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockMove(models.Model):
+
+    _inherit = "stock.move"
+
+    def _get_new_picking_values(self):
+        res = super()._get_new_picking_values()
+        picking_type = self.mapped("picking_type_id")
+        if picking_type.shipping_policy == "force_as_soon_as_possible":
+            res["move_type"] = "direct"
+        elif picking_type.shipping_policy == "force_all_products_ready":
+            res["move_type"] = "one"
+        return res

--- a/stock_picking_type_shipping_policy/models/stock_picking_type.py
+++ b/stock_picking_type_shipping_policy/models/stock_picking_type.py
@@ -2,12 +2,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import api, fields, models
 
-SHIPPING_POLICY_SELECTION = [
-    ("procurement_group", "Take from procurement group"),
-    ("force_as_soon_as_possible", "Force to as soon as possible"),
-    ("force_all_products_ready", "Force to when all products are ready"),
-]
-
 
 class StockPickingType(models.Model):
 
@@ -17,8 +11,16 @@ class StockPickingType(models.Model):
     def _default_shipping_policy(self):
         return "procurement_group"
 
+    @api.model
+    def _selection_shipping_policy(self):
+        return [
+            ("procurement_group", "Take from procurement group"),
+            ("force_as_soon_as_possible", "Force to as soon as possible"),
+            ("force_all_products_ready", "Force to when all products are ready"),
+        ]
+
     shipping_policy = fields.Selection(
-        SHIPPING_POLICY_SELECTION,
+        selection="_selection_shipping_policy",
         default=lambda r: r._default_shipping_policy(),
         help="Allows to force the shipping policy on pickings according to the"
         " picking type.",

--- a/stock_picking_type_shipping_policy/models/stock_picking_type.py
+++ b/stock_picking_type_shipping_policy/models/stock_picking_type.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import api, fields, models
+
+SHIPPING_POLICY_SELECTION = [
+    ("procurement_group", "Take from procurement group"),
+    ("force_as_soon_as_possible", "Force to as soon as possible"),
+    ("force_all_products_ready", "Force to when all products are ready"),
+]
+
+
+class StockPickingType(models.Model):
+
+    _inherit = "stock.picking.type"
+
+    @api.model
+    def _default_shipping_policy(self):
+        return "procurement_group"
+
+    shipping_policy = fields.Selection(
+        SHIPPING_POLICY_SELECTION,
+        default=lambda r: r._default_shipping_policy(),
+        help="Allows to force the shipping policy on pickings according to the"
+        " picking type.",
+    )

--- a/stock_picking_type_shipping_policy/readme/CONTRIBUTORS.rst
+++ b/stock_picking_type_shipping_policy/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/stock_picking_type_shipping_policy/readme/DESCRIPTION.rst
+++ b/stock_picking_type_shipping_policy/readme/DESCRIPTION.rst
@@ -1,2 +1,8 @@
 This module adds a Shipping Policy field on Operations Types in order to force
 a specific Shipping Policy on Pickings according to their types.
+
+This is especially useful if you use a pick-pack-ship setup with the release
+of operation (stock_available_to_promise_release) module along side with
+the stock_routing_operation that may split operations by zone of the warehouse.
+In that case, you want to be sure the pack operations will wait all different
+picks to be processed before releasing the availability of the pack operation.

--- a/stock_picking_type_shipping_policy/readme/DESCRIPTION.rst
+++ b/stock_picking_type_shipping_policy/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module adds a Shipping Policy field on Operations Types in order to force
+a specific Shipping Policy on Pickings according to their types.

--- a/stock_picking_type_shipping_policy/tests/__init__.py
+++ b/stock_picking_type_shipping_policy/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)

--- a/stock_picking_type_shipping_policy/tests/test_stock_picking_type_shipping_policy.py
+++ b/stock_picking_type_shipping_policy/tests/test_stock_picking_type_shipping_policy.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests import SavepointCase
+
+
+class TestPickingTypeShippingPolicy(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        ref = cls.env.ref
+        cls.warehouse = ref("stock.warehouse0")
+        # set pick-pack-ship on warehouse
+        cls.warehouse.delivery_steps = "pick_pack_ship"
+        cls.pick_type = cls.warehouse.pick_type_id
+        cls.pack_type = cls.warehouse.pack_type_id
+        cls.ship_type = cls.warehouse.out_type_id
+
+        cls.customers_location = cls.env.ref("stock.stock_location_customers")
+        cls.output_location = cls.warehouse.wh_output_stock_loc_id
+
+        cls.product = cls.env.ref("product.product_product_9")
+        # Create ir.default for procure_method as make_to_order in order to
+        #  generate chained moves
+        cls.env["ir.default"].create(
+            {
+                "field_id": cls.env.ref("stock.field_stock_move__procure_method").id,
+                "json_value": '"make_to_order"',
+            }
+        )
+
+    def test_shipping_policy(self):
+        self.pack_type.shipping_policy = "force_all_products_ready"
+        self.pick_type.shipping_policy = "force_as_soon_as_possible"
+        # Create picking
+        out_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.ship_type.id,
+                "location_id": self.output_location.id,
+                "location_dest_id": self.customers_location.id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_uom_qty": 10.0,
+                            "product_uom": self.product.uom_id.id,
+                        },
+                    )
+                ],
+            }
+        )
+        out_picking.action_confirm()
+
+        pack_picking = out_picking.move_lines.move_orig_ids.picking_id
+        pick_picking = pack_picking.move_lines.move_orig_ids.picking_id
+        self.assertEqual(pack_picking.picking_type_id, self.pack_type)
+        self.assertEqual(pack_picking.move_type, "one")
+        self.assertEqual(pick_picking.picking_type_id, self.pick_type)
+        self.assertEqual(pick_picking.move_type, "direct")

--- a/stock_picking_type_shipping_policy/views/stock_picking_type.xml
+++ b/stock_picking_type_shipping_policy/views/stock_picking_type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record model="ir.ui.view" id="view_picking_type_form_inherit">
+        <field name="name">Operation Types inherit</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <field name="show_reserved" position="after">
+                <field name="shipping_policy" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This module adds a Shipping Policy field on Operations Types in order to force
a specific Shipping Policy on Pickings according to their types.