### PR TITLE
[13.0] Fix update of need_release on stock moves

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -5,8 +5,6 @@ from odoo import api, fields, models
 from odoo.osv import expression
 from odoo.tools import date_utils, float_compare
 
-from odoo.addons import decimal_precision as dp
-
 
 class StockMove(models.Model):
     _inherit = "stock.move"
@@ -21,7 +19,7 @@ class StockMove(models.Model):
     ordered_available_to_promise = fields.Float(
         string="Ordered Available to Promise",
         compute="_compute_ordered_available_to_promise",
-        digits=dp.get_precision("Product Unit of Measure"),
+        digits="Product Unit of Measure",
         help="Available to Promise quantity minus quantities promised "
         " to older promised operations.",
     )

--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -33,11 +33,11 @@ class StockRule(models.Model):
                 actions_to_run.append((procurement, rule))
 
         super()._run_pull(actions_to_run)
-        # use first of list of ids and browse it for performance
+        # use first a list of ids and browse it afterwards for performance
         move_ids = [
             move.id
-            for move in procurement.values.get("move_dest_ids", [])
-            for procurement, _rule in actions_to_run
+            for proc, _rule in actions_to_run
+            for move in proc.values.get("move_dest_ids", [])
         ]
         if move_ids:
             moves = self.env["stock.move"].browse(move_ids)


### PR DESCRIPTION
When stock moves have been released, their 'need_release' flag must be
set to False. Due to a coding mistake, they were not. The most visible
effect was the "Release" button still visible on transfers and moves,
but other vicious effects can't be excluded.

The issue come from an inversion in the order of the list comprehension,
added up to the fact that the 'procurement' variable name was recycled
from the code above: 'procurement' was always equal to the latest
procurement used in the loop before the list comprehension.