### PR TITLE
[13.0][WIP][ADD] stock_picking_type_shipping_policy_group_by

### DIFF
--- a/stock_picking_type_shipping_policy_group_by/__init__.py
+++ b/stock_picking_type_shipping_policy_group_by/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_type_shipping_policy_group_by/__manifest__.py
+++ b/stock_picking_type_shipping_policy_group_by/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Picking Type Shipping Policy Group By Partner & Carrier",
+    "summary": "Glue module between shipping policies and grouping of operations.",
+    "version": "13.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "stock_picking_type_shipping_policy",
+        "stock_picking_group_by_partner_by_carrier",
+    ],
+}

--- a/stock_picking_type_shipping_policy_group_by/models/__init__.py
+++ b/stock_picking_type_shipping_policy_group_by/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_move

--- a/stock_picking_type_shipping_policy_group_by/models/stock_move.py
+++ b/stock_picking_type_shipping_policy_group_by/models/stock_move.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _domain_search_picking_handle_move_type(self):
+        """Hook overloaded to build the move_type criteria based on the
+        shipping policy of the picking type.
+        """
+        shipping_policy = self.picking_type_id.shipping_policy
+        move_types_mapping = {
+            "force_as_soon_as_possible": "direct",
+            "force_all_products_ready": "one",
+            "procurement_group": self.group_id.move_type,
+        }
+        return [("move_type", "=", move_types_mapping[shipping_policy])]


### PR DESCRIPTION
Glue module between [stock_picking_type_shipping_policy](https://github.com/OCA/wms/tree/13.0/stock_picking_type_shipping_policy) and [stock_picking_group_by_partner_by_carrier](https://github.com/OCA/stock-logistics-workflow/pull/641).