### PR TITLE
[13.0] Add backorder link when partial quantities are released

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Camptocamp (https://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class StockPicking(models.Model):
@@ -25,3 +25,13 @@ class StockPicking(models.Model):
             if not key.startswith("default_")
         }
         self.mapped("move_lines").with_context(context).release_available_to_promise()
+
+    def _release_link_backorder(self, origin_picking):
+        self.backorder_id = origin_picking
+        origin_picking.message_post(
+            body=_(
+                "The backorder <a href=# data-oe-model=stock.picking"
+                " data-oe-id=%d>%s</a> has been created."
+            )
+            % (self.id, self.name)
+        )

--- a/stock_available_to_promise_release/readme/CONFIGURE.rst
+++ b/stock_available_to_promise_release/readme/CONFIGURE.rst
@@ -1,4 +1,4 @@
-In Inventory > Configuration > Warehouses, activate the option "Release based on Available to Promise"
-when you want to use the feature.
+In Inventory > Configuration > Routes, activate the option "Release based on
+Available to Promise" on the routes where you want to use the feature.
 
 To modify the horizon go to "Inventory > Settings" and change "Stock reservation horizon".

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -342,15 +342,13 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
         )
 
         cust_picking.release_available_to_promise()
-        out_pickings = sorted(
-            self._pickings_in_group(pickings.group_id) - cust_picking,
-            key=lambda x: x.move_lines.product_qty,
+        split_cust_picking = cust_picking.backorder_ids
+        self.assertEqual(len(split_cust_picking), 1)
+        out_picking = (
+            self._pickings_in_group(pickings.group_id)
+            - cust_picking
+            - split_cust_picking
         )
-        # 2 pickings instead of just one because remaining qty to process
-        # is split into a new one.
-        self.assertEqual(len(out_pickings), 2)
-        out_picking = out_pickings[0]
-        split_out_picking = out_pickings[1]
 
         # the complete one is assigned and placed into stock output
         self.assertRecordValues(
@@ -365,7 +363,7 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
         )
         # the split once stays in the original location
         self.assertRecordValues(
-            split_out_picking,
+            split_cust_picking,
             [
                 {
                     "state": "waiting",
@@ -376,7 +374,7 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
         )
 
         self.assertRecordValues(out_picking.move_lines, [{"product_qty": 7.0}])
-        self.assertRecordValues(split_out_picking.move_lines, [{"product_qty": 13.0}])
+        self.assertRecordValues(split_cust_picking.move_lines, [{"product_qty": 13.0}])
 
         # let's deliver what we can
         self._deliver(out_picking)
@@ -391,19 +389,19 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
                     "product_qty": 7.0,
                     "reserved_availability": 7.0,
                     "procure_method": "make_to_order",
-                },
+                }
             ],
         )
-        self.assertRecordValues(split_out_picking, [{"state": "waiting"}])
+        self.assertRecordValues(split_cust_picking, [{"state": "waiting"}])
         self.assertRecordValues(
-            split_out_picking.move_lines,
+            split_cust_picking.move_lines,
             [
                 {
                     "state": "waiting",
                     "product_qty": 13.0,
                     "reserved_availability": 0.0,
                     "procure_method": "make_to_order",
-                },
+                }
             ],
         )
 
@@ -521,15 +519,14 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
         )
 
         cust_picking.move_lines.release_available_to_promise()
-        out_pickings = sorted(
-            self._pickings_in_group(pickings.group_id) - cust_picking,
-            key=lambda x: x.move_lines.product_qty,
+        split_cust_picking = cust_picking.backorder_ids
+        self.assertEqual(len(split_cust_picking), 1)
+        out_picking = (
+            self._pickings_in_group(pickings.group_id)
+            - cust_picking
+            - split_cust_picking
         )
-        # 2 pickings instead of just one because remaining qty to process
-        # is split into a new one.
-        self.assertEqual(len(out_pickings), 2)
-        out_picking = out_pickings[0]
-        split_out_picking = out_pickings[1]
+
         self.assertRecordValues(
             out_picking.move_lines,
             [
@@ -542,7 +539,7 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
             ],
         )
         self.assertRecordValues(
-            split_out_picking.move_lines,
+            split_cust_picking.move_lines,
             [
                 {
                     "state": "waiting",


### PR DESCRIPTION
To reproduce

* Order 100x [E-COM10]
* Update quantities in stock to have 70 [E-COM10] in Stock/Shelf 1
* Release the moves

Actual result:

2 transfer, the backorder for the waiting 30 [E-COM10] has no backorder link with the original transfer

Expected result:

2 transfer, the backorder for the waiting 30 [E-COM10] has a backorder link with the original transfer

