### PR TITLE
[13.0] Allow to select locations with 'none' strategy in putaway sequence

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -203,7 +203,8 @@ class StockLocation(models.Model):
         if not package_locations:
             return dest_location
 
-        for pref_loc in package_locations.mapped("location_id"):
+        for package_sequence in package_locations:
+            pref_loc = package_sequence.location_id
             if (
                 pref_loc.pack_putaway_strategy == "none"
                 and pref_loc.select_allowed_locations(

--- a/stock_storage_type/models/stock_package_level.py
+++ b/stock_storage_type/models/stock_package_level.py
@@ -86,3 +86,13 @@ class StockPackageLevel(models.Model):
             )
             all_allowed_locations.update(allowed_locations.ids)
         return self.env["stock.location"].browse(all_allowed_locations)
+
+    def recompute_pack_putaway(self):
+        for level in self:
+            if not level.package_id.quant_ids:
+                continue
+            level.location_dest_id = level.location_dest_id._get_pack_putaway_strategy(
+                level.location_dest_id,
+                level.package_id.quant_ids,
+                level.mapped("move_line_ids.product_id"),
+            )

--- a/stock_storage_type/models/stock_quant.py
+++ b/stock_storage_type/models/stock_quant.py
@@ -36,6 +36,7 @@ class StockQuant(models.Model):
                 [
                     ("location_id", "=", location.id),
                     ("id", "not in", package_quants.ids),
+                    ("quantity", ">", 0),
                 ]
             )
             products_in_location = other_quants_in_location.mapped("product_id")
@@ -47,7 +48,7 @@ class StockQuant(models.Model):
                     lst_fails.append(
                         _(
                             "Location storage type %s is flagged 'only empty'"
-                            " with other quants in location." % loc_storage_type
+                            " with other quants in location." % loc_storage_type.name
                         )
                     )
                     continue
@@ -60,7 +61,7 @@ class StockQuant(models.Model):
                         _(
                             "Location storage type %s is flagged 'do not mix"
                             " products' but there are other products in "
-                            "location." % loc_storage_type
+                            "location." % loc_storage_type.name
                         )
                     )
                     continue
@@ -73,7 +74,7 @@ class StockQuant(models.Model):
                         _(
                             "Location storage type %s is flagged 'do not mix"
                             " lots' but there are other lots in "
-                            "location." % loc_storage_type
+                            "location." % loc_storage_type.name
                         )
                     )
                     continue
@@ -87,7 +88,7 @@ class StockQuant(models.Model):
                             "Location storage type %s defines max height of %s"
                             " but the package is bigger: %s."
                             % (
-                                loc_storage_type,
+                                loc_storage_type.name,
                                 loc_storage_type.max_height,
                                 quant.package_id.height,
                             )
@@ -103,7 +104,7 @@ class StockQuant(models.Model):
                             "Location storage type %s defines max weight of %s"
                             " but the package is heavier: %s."
                             % (
-                                loc_storage_type,
+                                loc_storage_type.name,
                                 loc_storage_type.max_weight,
                                 quant.package_id.pack_weight,
                             )

--- a/stock_storage_type/models/stock_storage_location_sequence.py
+++ b/stock_storage_type/models/stock_storage_location_sequence.py
@@ -13,10 +13,9 @@ class StockStorageLocationSequence(models.Model):
         "stock.package.storage.type", required=True
     )
     sequence = fields.Integer(required=True)
-    location_id = fields.Many2one(
-        "stock.location",
-        required=True,
-        domain="[('pack_putaway_strategy', '!=', 'none')]",
+    location_id = fields.Many2one("stock.location", required=True,)
+    location_putaway_strategy = fields.Selection(
+        related="location_id.pack_putaway_strategy"
     )
 
     def _format_package_storage_type_message(self, last=False):

--- a/stock_storage_type/readme/CONFIGURATION.rst
+++ b/stock_storage_type/readme/CONFIGURATION.rst
@@ -25,3 +25,7 @@ location (according to restrictions) will be used to put away.
 A good practice here, is to set a location accepting this storage type without
 any restriction as the last location in the sequence, to act as a fallback
 if no other location could be found before.
+
+If a location with a 'none' strategy is set in the sequence and matches with the
+move line's destination, it will stop evaluating the next locations in the
+sequence.

--- a/stock_storage_type/readme/CONTRIBUTORS.rst
+++ b/stock_storage_type/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/stock_storage_type/tests/common.py
+++ b/stock_storage_type/tests/common.py
@@ -100,3 +100,32 @@ class TestStorageTypeCommon(SavepointCase):
         cls.receipts_picking_type.write(
             {"show_entire_packs": True, "show_reserved": True}
         )
+
+    @classmethod
+    def _update_qty_in_location(
+        cls, location, product, quantity, package=None, lot=None
+    ):
+        quants = cls.env["stock.quant"]._gather(
+            product, location, lot_id=lot, package_id=package, strict=True
+        )
+        # this method adds the quantity to the current quantity, so remove it
+        quantity -= sum(quants.mapped("quantity"))
+        cls.env["stock.quant"]._update_available_quantity(
+            product, location, quantity, package_id=package, lot_id=lot
+        )
+
+    @classmethod
+    def _create_single_move(cls, product):
+        picking_type = cls.warehouse.int_type_id
+        move_vals = {
+            "name": product.name,
+            "picking_type_id": picking_type.id,
+            "product_id": product.id,
+            "product_uom_qty": 2.0,
+            "product_uom": product.uom_id.id,
+            "location_id": cls.input_location.id,
+            "location_dest_id": picking_type.default_location_dest_id.id,
+            "state": "confirmed",
+            "procure_method": "make_to_stock",
+        }
+        return cls.env["stock.move"].create(move_vals)

--- a/stock_storage_type/tests/test_storage_type_move.py
+++ b/stock_storage_type/tests/test_storage_type_move.py
@@ -12,35 +12,6 @@ class TestStorageTypeMove(TestStorageTypeCommon):
         super().setUpClass()
         cls.areas.write({"pack_putaway_strategy": "ordered_locations"})
 
-    @classmethod
-    def _update_qty_in_location(
-        cls, location, product, quantity, package=None, lot=None
-    ):
-        quants = cls.env["stock.quant"]._gather(
-            product, location, lot_id=lot, package_id=package, strict=True
-        )
-        # this method adds the quantity to the current quantity, so remove it
-        quantity -= sum(quants.mapped("quantity"))
-        cls.env["stock.quant"]._update_available_quantity(
-            product, location, quantity, package_id=package, lot_id=lot
-        )
-
-    @classmethod
-    def _create_single_move(cls, product):
-        picking_type = cls.warehouse.int_type_id
-        move_vals = {
-            "name": product.name,
-            "picking_type_id": picking_type.id,
-            "product_id": product.id,
-            "product_uom_qty": 2.0,
-            "product_uom": product.uom_id.id,
-            "location_id": cls.input_location.id,
-            "location_dest_id": picking_type.default_location_dest_id.id,
-            "state": "confirmed",
-            "procure_method": "make_to_stock",
-        }
-        return cls.env["stock.move"].create(move_vals)
-
     def assert_package_level_domain(self, json_domain, expected_locations):
         domain = const_eval(json_domain)
         self.assertEqual(len(domain), 1)

--- a/stock_storage_type/views/stock_package_level.xml
+++ b/stock_storage_type/views/stock_package_level.xml
@@ -24,6 +24,14 @@
             <field name="location_dest_id" position="attributes">
                 <attribute name="domain">allowed_location_dest_domain</attribute>
             </field>
+            <field name="location_dest_id" position="after">
+                <button
+                    name="recompute_pack_putaway"
+                    type="object"
+                    icon="fa-arrow-circle-o-down"
+                    string="Recompute Putaway"
+                />
+            </field>
         </field>
     </record>
 </odoo>

--- a/stock_storage_type/views/stock_storage_location_sequence.xml
+++ b/stock_storage_type/views/stock_storage_location_sequence.xml
@@ -12,6 +12,7 @@
                     force_save="1"
                 />
                 <field name="location_id" />
+                <field name="location_putaway_strategy" />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
The putaway sequence for a package storage types defines where the goods
can be put and in which order.

For instance, if the "cardbox" storage type has this sequence:

1. Stock/Cardboxes Shelving: ordered locations
2. Stock/Cardboxes Reserve: ordered locations

It will first try to put the goods in Bin 1, then Bin 2 and finally Bin
3 if the others are full.

This commit aims to support the strategies with a 'none' strategy has
valid locations in the sequences, such as:

1. Stock: None
2. Stock/Cardboxes Shelving: ordered locations
3. Stock/Cardboxes Reserve: ordered locations

In this example, if a move line with a cardbox has a destination Stock,
no strategy will be applied, if the move line has a destination Cardbox
Shelving, the ordered location strategy is applied.

It allows to use a sort of buffer: the default destination is Stock,
then the destination is updated to Stock/Cardbox Reserve (upon the
choice of a user!) and a new computation of the putaway is asked.
