### PR TITLE
Add shipping line on sale order confirmation

### DIFF
--- a/sale_delivery_carrier_preference/models/sale_order.py
+++ b/sale_delivery_carrier_preference/models/sale_order.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
-from odoo import api, fields, models
+from odoo import _, api, exceptions, fields, models
 
 
 class SaleOrder(models.Model):
@@ -9,18 +9,38 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     shipping_weight = fields.Float(
-        string="Shipping weight (kg)", compute="_compute_shipping_weight",
+        string="Shipping weight (kg)", compute="_compute_shipping_weight"
     )
 
     def action_confirm(self):
+        self._add_delivery_carrier_on_confirmation()
+        return super().action_confirm()
+
+    def _add_delivery_carrier_on_confirmation(self):
         """Automatically add delivery.carrier on sale order confirmation"""
         for order in self:
-            if (
-                any([line.product_id.type != "service" for line in order.order_line])
-                and not order.carrier_id
-            ):
-                order.carrier_id = order.get_preferred_carrier()
-        return super().action_confirm()
+            if order.carrier_id or any(line.is_delivery for line in order.order_line):
+                continue
+            carrier = order.get_preferred_carrier()
+            if not carrier:
+                continue
+            # rate_shipment returns None if the shipping method doesn't
+            # implement rate computation. If it returns a dict, we expect it to
+            # return if it was a success or not, however, to be defensive,
+            # consider that a dictionary without 'success' key was a success.
+            vals = carrier.rate_shipment(order) or {}
+            if not vals.get("success", True):
+                raise exceptions.UserError(
+                    _(
+                        "Error when adding shipping on {}. Try adding"
+                        " shipping manually. Message: {}"
+                    ).format(order.name, vals.get("error_message"))
+                )
+            delivery_price = vals.get("price", 0.0)
+            order.set_delivery_line(carrier, delivery_price)
+            order.recompute_delivery_price = False
+            if vals.get("warning_message"):
+                order.delivery_message = vals["warning_message"]
 
     @api.depends("order_line", "order_line.shipping_weight")
     def _compute_shipping_weight(self):
@@ -46,7 +66,7 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     shipping_weight = fields.Float(
-        string="Shipping weight (kg)", compute="_compute_shipping_weight",
+        string="Shipping weight (kg)", compute="_compute_shipping_weight"
     )
 
     @api.depends("product_id", "product_uom_qty", "product_uom")


### PR DESCRIPTION
The former implementation sets the preferred carrier, but it doesn't
completely reflects what is being done by the wizard.

This change adds the missing bits:

* When a carrier_id is set, it adds the shipping line with the computed
  price.
* If there is a warning message, it stores in on the sales order.
* If there is an error message, it prevents the confirmation of the
  sales order as no shipping could be added.
* Fix the check based on 'product_id.type != service', which would
  not add a shipping method as soon as we have a single service. There
  is a dedicated flag "is_delivery" to track the delivery line.
