### PR TITLE
[13.0] stock_storage_type: Add package storage type on product

### DIFF
--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -19,6 +19,7 @@
     "data": [
         "security/ir.model.access.csv",
         "views/product_packaging.xml",
+        "views/product_template.xml",
         "views/stock_location.xml",
         "views/stock_location_package_storage_type_rel.xml",
         "views/stock_location_storage_type.xml",

--- a/stock_storage_type/models/__init__.py
+++ b/stock_storage_type/models/__init__.py
@@ -1,4 +1,5 @@
 from . import product_packaging
+from . import product_template
 from . import stock_location
 from . import stock_location_package_storage_type_rel
 from . import stock_location_storage_type

--- a/stock_storage_type/models/product_template.py
+++ b/stock_storage_type/models/product_template.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+
+    _inherit = "product.template"
+
+    product_package_storage_type_id = fields.Many2one(
+        "stock.package.storage.type",
+        string="Package storage type",
+        help="Defines a 'default' package storage type for this product to be "
+        "applied on packages without product packagings for put-away "
+        "computations.",
+    )

--- a/stock_storage_type/models/stock_quant_package.py
+++ b/stock_storage_type/models/stock_quant_package.py
@@ -20,8 +20,9 @@ class StockQuantPackage(models.Model):
     @api.depends(
         "product_packaging_id",
         "product_packaging_id.package_storage_type_id",
-        "single_product_id",
-        "single_product_id.product_package_storage_type_id",
+        "quant_ids",
+        "quant_ids.product_id",
+        "quant_ids.product_id.product_package_storage_type_id",
     )
     def _compute_package_storage_type_id(self):
         for pack in self:

--- a/stock_storage_type/models/stock_quant_package.py
+++ b/stock_storage_type/models/stock_quant_package.py
@@ -7,31 +7,39 @@ class StockQuantPackage(models.Model):
 
     _inherit = "stock.quant.package"
 
-    package_storage_type_id = fields.Many2one("stock.package.storage.type")
+    package_storage_type_id = fields.Many2one(
+        "stock.package.storage.type",
+        compute="_compute_package_storage_type_id",
+        store=True,
+        readonly=False,
+        help="Package storage type for put-away computation. Computed "
+        "automatically from the packaging if set, or from the product if"
+        "the package contains only a single product.",
+    )
 
-    @api.onchange("product_packaging_id")
-    def onchange_product_packaging_id(self):
-        res = super().onchange_product_packaging_id()
-        packaging = self.product_packaging_id
-        storage_type = packaging.package_storage_type_id
-        if storage_type:
-            self.package_storage_type_id = storage_type
-        return res
-
-    @api.model
-    def create(self, vals):
-        vals = self._vals_for_storage_type(vals)
-        return super().create(vals)
-
-    def write(self, vals):
-        vals = self._vals_for_storage_type(vals)
-        return super().write(vals)
-
-    def _vals_for_storage_type(self, vals):
-        packaging_id = vals.get("product_packaging_id")
-        if packaging_id:
-            packaging = self.env["product.packaging"].browse(packaging_id)
-            storage_type = packaging.package_storage_type_id
-            if storage_type:
-                vals = dict(vals, package_storage_type_id=storage_type.id)
-        return vals
+    @api.depends(
+        "product_packaging_id",
+        "product_packaging_id.package_storage_type_id",
+        "single_product_id",
+        "single_product_id.product_package_storage_type_id",
+    )
+    def _compute_package_storage_type_id(self):
+        for pack in self:
+            if pack.package_storage_type_id:
+                continue
+            elif (
+                pack.product_packaging_id
+                and pack.product_packaging_id.package_storage_type_id
+            ):
+                pack.package_storage_type_id = (
+                    pack.product_packaging_id.package_storage_type_id
+                )
+            elif (
+                pack.single_product_id
+                and pack.single_product_id.product_package_storage_type_id
+            ):
+                pack.package_storage_type_id = (
+                    pack.single_product_id.product_package_storage_type_id
+                )
+            else:
+                pack.package_storage_type_id = False

--- a/stock_storage_type/views/product_template.xml
+++ b/stock_storage_type/views/product_template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record
+        model="ir.ui.view"
+        id="product_template_form_view_procurement_button_inherit"
+    >
+        <field name="name">product.template_procurement.inherit</field>
+        <field name="model">product.template</field>
+        <field name="groups_id" eval="[(4, ref('stock.group_stock_user'))]" />
+        <field
+            name="inherit_id"
+            ref="stock.product_template_form_view_procurement_button"
+        />
+        <field name="arch" type="xml">
+            <field name="responsible_id" position="before">
+                <field name="product_package_storage_type_id" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Package storage type can be defined on products to compute automatically
a package storage type on packages if no packaging is defined and
the package only contains a single product.