### PR TITLE
Make stock_storage_type depend on stock_putaway_hook

### DIFF
--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -12,6 +12,7 @@
     "application": False,
     "installable": True,
     "depends": [
+        "stock_putaway_hook",
         "base_m2m_custom_field",
         "stock_quant_package_dimension",
         "web_domain_field",

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -173,8 +173,11 @@ class StockLocation(models.Model):
                     (6, 0, parent.allowed_location_storage_type_ids.ids)
                 ]
 
-    def _get_putaway_strategy(self, product):
-        putaway_location = super()._get_putaway_strategy(product)
+    # method provided by "stock_putaway_hook"
+    def _putaway_strategy_finalizer(self, putaway_location, product):
+        putaway_location = super()._putaway_strategy_finalizer(
+            putaway_location, product
+        )
         quant = self.env.context.get("storage_quant")
         return self._get_pack_putaway_strategy(putaway_location, quant, product)
 


### PR DESCRIPTION
The putaway based on storage type *must* be applied at the very end
of the putaway rules, because it depends on the putaway location found.

If we execute it by calling super() and we added different putaway
strategies in StockLocation, we have no way to be sure it is the last
called.

That's why now it depends on stock_putaway_hook, which allow to search
for alternative put-away hooks, and call _putaway_strategy_finalizer at
the very end, where we can plug the storage type rules.

Stock Putaway Hook is added by https://github.com/OCA/stock-logistics-workflow/pull/687