### PR TITLE
[13.0] Create module delivery_carrier_warehouse

### DIFF
--- a/delivery_carrier_warehouse/__init__.py
+++ b/delivery_carrier_warehouse/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_carrier_warehouse/__manifest__.py
+++ b/delivery_carrier_warehouse/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Delivery Carrier Warehouse",
+    "summary": "Get delivery method used in sales orders from warehouse",
+    "version": "13.0.1.2.0",
+    "category": "Operations/Inventory/Delivery",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["delivery"],
+    "data": ["views/stock_warehouse.xml"],
+}

--- a/delivery_carrier_warehouse/models/__init__.py
+++ b/delivery_carrier_warehouse/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order
+from . import stock_warehouse

--- a/delivery_carrier_warehouse/models/sale_order.py
+++ b/delivery_carrier_warehouse/models/sale_order.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class SaleOrder(models.Model):
+
+    _inherit = "sale.order"
+
+    def action_open_delivery_wizard(self):
+        res = super().action_open_delivery_wizard()
+        wh_carrier = self.warehouse_id.delivery_carrier_id
+        if (
+            not self.env.context.get("carrier_recompute")
+            and not res["context"].get("default_carrier_id")
+            and wh_carrier
+        ):
+            res["context"]["default_carrier_id"] = wh_carrier.id
+        return res

--- a/delivery_carrier_warehouse/models/stock_warehouse.py
+++ b/delivery_carrier_warehouse/models/stock_warehouse.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class StockWarehouse(models.Model):
+
+    _inherit = "stock.warehouse"
+
+    delivery_carrier_id = fields.Many2one(
+        "delivery.carrier",
+        string="Delivery Method",
+        help="Default delivery method used in sales orders. Will be applied "
+        "only if the partner does not have a default delivery method.",
+    )

--- a/delivery_carrier_warehouse/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_warehouse/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/delivery_carrier_warehouse/readme/DESCRIPTION.rst
+++ b/delivery_carrier_warehouse/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module allows to define a delivery carrier on stock warehouse.
+
+If a partner does not have a default carrier defined, the 'Add shipping' wizard
+will use the carrier defined on the warehouse as default.

--- a/delivery_carrier_warehouse/tests/__init__.py
+++ b/delivery_carrier_warehouse/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_delivery_carrier_warehouse

--- a/delivery_carrier_warehouse/tests/test_delivery_carrier_warehouse.py
+++ b/delivery_carrier_warehouse/tests/test_delivery_carrier_warehouse.py
@@ -1,0 +1,39 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.tests.common import Form, SavepointCase
+
+
+class TestSaleDeliveryCarrierPreference(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        ref = cls.env.ref
+        cls.partner = ref("base.res_partner_12")
+        cls.product = ref("product.product_product_20")
+        cls.free_delivery_carrier = ref("delivery.free_delivery_carrier")
+        cls.normal_delivery_carrier = ref("delivery.normal_delivery_carrier")
+        cls.warehouse = ref("stock.warehouse0")
+        cls.warehouse.delivery_carrier_id = cls.free_delivery_carrier
+
+    @classmethod
+    def _create_sale_order(cls):
+        sale_form = Form(cls.env["sale.order"])
+        sale_form.partner_id = cls.partner
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = cls.product
+            line_form.product_uom_qty = 2
+        return sale_form.save()
+
+    def test_warehouse_carrier(self):
+        order = self._create_sale_order()
+        self.assertEqual(
+            self.partner.property_delivery_carrier_id, self.normal_delivery_carrier
+        )
+        action = order.action_open_delivery_wizard()
+        default_carrier_id = action["context"]["default_carrier_id"]
+        self.assertEqual(default_carrier_id, self.normal_delivery_carrier.id)
+        self.partner.property_delivery_carrier_id = False
+        action = order.action_open_delivery_wizard()
+        default_carrier_id = action["context"]["default_carrier_id"]
+        self.assertEqual(default_carrier_id, self.free_delivery_carrier.id)

--- a/delivery_carrier_warehouse/views/stock_warehouse.xml
+++ b/delivery_carrier_warehouse/views/stock_warehouse.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_warehouse_inherit" model="ir.ui.view">
+        <field name="name">stock.warehouse.inherit</field>
+        <field name="model">stock.warehouse</field>
+        <field name="inherit_id" ref="stock.view_warehouse" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field
+                    name="delivery_carrier_id"
+                    domain="['|', ('company_id', '=', False), ('company_id', '=', company_id.id)]"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/delivery_carrier_warehouse/odoo/addons/delivery_carrier_warehouse
+++ b/setup/delivery_carrier_warehouse/odoo/addons/delivery_carrier_warehouse
@@ -1,0 +1,1 @@
+../../../../delivery_carrier_warehouse

--- a/setup/delivery_carrier_warehouse/setup.py
+++ b/setup/delivery_carrier_warehouse/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This module allows to define a delivery on stock warehouse.

If a partner does not have a default carrier defined, the 'Add shipping' wizard
will use the carrier defined on the warehouse as default.
