### PR TITLE
[13.0] Create module delivery_carrier_preference_dangerous_goods - alpha

### DIFF
--- a/delivery_carrier_preference_dangerous_goods/__init__.py
+++ b/delivery_carrier_preference_dangerous_goods/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/delivery_carrier_preference_dangerous_goods/__manifest__.py
+++ b/delivery_carrier_preference_dangerous_goods/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Delivery carrier preference dangerous goods",
+    "summary": "Consider dangerous goods in preferred carrier selection",
+    "version": "13.0.1.1.0",
+    "development_status": "Alpha",
+    "category": "Operations/Inventory/Delivery",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "delivery_carrier_preference",
+        "delivery_carrier_dangerous_goods_warning",
+    ],
+}

--- a/delivery_carrier_preference_dangerous_goods/models/__init__.py
+++ b/delivery_carrier_preference_dangerous_goods/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_picking

--- a/delivery_carrier_preference_dangerous_goods/models/stock_picking.py
+++ b/delivery_carrier_preference_dangerous_goods/models/stock_picking.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo import models
+
+
+class StockPicking(models.Model):
+
+    _inherit = "stock.picking"
+
+    def _carrier_valid(self, carrier):
+        """Hook to add extra validation between carrier and picking"""
+        res = super()._carrier_valid(carrier)
+        if carrier.dangerous_goods_warning and self.contains_dangerous_goods:
+            return False
+        return res

--- a/delivery_carrier_preference_dangerous_goods/readme/CONTRIBUTORS.rst
+++ b/delivery_carrier_preference_dangerous_goods/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Akim Juillerat <akim.juillerat@camptocamp.com>

--- a/delivery_carrier_preference_dangerous_goods/readme/DESCRIPTION.rst
+++ b/delivery_carrier_preference_dangerous_goods/readme/DESCRIPTION.rst
@@ -1,0 +1,6 @@
+This modules adds consideration of 'Dangerous goods' in the selection of preferred
+delivery carrier.
+
+In other words, if the delivery carrier is set to display a warning when the
+delivery order contains dangerous goods, this delivery carrier will not be
+selected in the computation of preferred delivery carrier.

--- a/delivery_carrier_preference_dangerous_goods/tests/__init__.py
+++ b/delivery_carrier_preference_dangerous_goods/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_delivery_carrier_preference_dangerous_goods

--- a/delivery_carrier_preference_dangerous_goods/tests/test_delivery_carrier_preference_dangerous_goods.py
+++ b/delivery_carrier_preference_dangerous_goods/tests/test_delivery_carrier_preference_dangerous_goods.py
@@ -1,0 +1,38 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from odoo.addons.delivery_carrier_preference.tests.test_delivery_carrier_preference import (  # noqa
+    TestSaleDeliveryCarrierPreference,
+)
+
+
+class TestSaleDeliveryCarrierPreferenceDangerousGoods(
+    TestSaleDeliveryCarrierPreference
+):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.normal_delivery_carrier.write({"dangerous_goods_warning": True})
+        cls.super_fast_carrier.write({"dangerous_goods_warning": True})
+        cls.env["delivery.carrier.preference"].create(
+            {"sequence": 15, "preference": "partner", "max_weight": 15.0}
+        )
+        cls.product.write({"is_dangerous_good": True})
+
+    def test_delivery_add_preferred_carrier_dangerous_goods(self):
+        """
+        With a qty of 1 in the sale order and 3 available to promise,
+        estimated_shipping_weight is 10, but as both of the first preferred
+        carriers (carrier-normal and partner-super fast) do not accept dangerous
+        goods, it must select 'the poste'
+        """
+        order = self._create_sale_order()
+        self._update_order_line_qty(order, 1)
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.loc_stock, 1
+        )
+        order.action_confirm()
+        delivery_pick = order.picking_ids
+        self.assertAlmostEqual(delivery_pick.estimated_shipping_weight, 10.0)
+        delivery_pick.add_preferred_carrier()
+        self.assertEqual(delivery_pick.carrier_id, self.the_poste_carrier)

--- a/setup/delivery_carrier_preference_dangerous_goods/odoo/addons/delivery_carrier_preference_dangerous_goods
+++ b/setup/delivery_carrier_preference_dangerous_goods/odoo/addons/delivery_carrier_preference_dangerous_goods
@@ -1,0 +1,1 @@
+../../../../delivery_carrier_preference_dangerous_goods

--- a/setup/delivery_carrier_preference_dangerous_goods/setup.py
+++ b/setup/delivery_carrier_preference_dangerous_goods/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Depends on:
 - [ ] #38 
 - [ ] #37 


This modules adds consideration of 'Dangerous goods' in the selection of preferred
delivery carrier.

In other words, if the delivery carrier is set to display a warning when the
delivery order contains dangerous goods, this delivery carrier will not be
selected in the computation of preferred delivery carrier.