### PR TITLE
Add printed flag on all released transfers

### DIFF
--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -337,6 +337,7 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
                     "state": "waiting",
                     "location_id": self.wh.wh_output_stock_loc_id.id,
                     "location_dest_id": self.loc_customer.id,
+                    "printed": False,
                 }
             ],
         )
@@ -358,9 +359,12 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
                     "state": "assigned",
                     "location_id": self.wh.lot_stock_id.id,
                     "location_dest_id": self.wh.wh_output_stock_loc_id.id,
+                    "printed": True,
                 }
             ],
         )
+        # the released customer picking is set to "printed"
+        self.assertRecordValues(cust_picking, [{"printed": True}])
         # the split once stays in the original location
         self.assertRecordValues(
             split_cust_picking,
@@ -369,6 +373,7 @@ class TestAvailableToPromiseRelease(common.SavepointCase):
                     "state": "waiting",
                     "location_id": self.wh.wh_output_stock_loc_id.id,
                     "location_dest_id": self.loc_customer.id,
+                    "printed": False,
                 }
             ],
         )


### PR DESCRIPTION
## Current behavior

When we release an OUT stock move, the OUT transfer is set to printed.
The origin transfers (e.g. Pick+Pack) are not.

## Expected behavior

When we release an OUT stock move, all the origin transfer (e.g.
Pick+Pack) are set to printed.

## Reason

The original reason for setting "printed" to True, is that when
"_assign_picking()" is called on a stock.move, the stock.move can be
added only in a stock.picking which is not printed yet. In other terms,
"printed" means the transfer has been started and shouldn't be modified.
When we "release" moves, we actually planify the work to be done, and if
we release again new moves, we don't expect transfers of the 2 waves of
releases to be merged together.

If we set the flag "printed" on the Out transfer only, we can end up
with one Packing transfer leading to 2 Out transfers, which generally
doesn't make sense.