### PR TITLE
[13.0] Search ordered available to promise

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -1,10 +1,10 @@
 # Copyright 2019 Camptocamp (https://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import date_utils, float_compare
-from odoo.exceptions import UserError
 
 
 class StockMove(models.Model):
@@ -35,19 +35,14 @@ class StockMove(models.Model):
     @api.model
     def _search_ordered_available_to_promise(self, operator, value):
         if operator not in (">", ">=", "="):
-            raise UserError(
-                _("Unsupported operator %s") % (operator,)
-            )
-        moves = self.search([('need_release', '=', True)])
+            raise UserError(_("Unsupported operator %s") % (operator,))
+        moves = self.search([("need_release", "=", True)])
         if operator == ">":
-            moves = moves.filtered(
-                lambda m: m._ordered_available_to_promise() > value)
+            moves = moves.filtered(lambda m: m._ordered_available_to_promise() > value)
         elif operator == ">=":
-            moves = moves.filtered(
-                lambda m: m._ordered_available_to_promise() >= value)
+            moves = moves.filtered(lambda m: m._ordered_available_to_promise() >= value)
         else:
-            moves = moves.filtered(
-                lambda m: m._ordered_available_to_promise() == value)
+            moves = moves.filtered(lambda m: m._ordered_available_to_promise() == value)
         return [("id", "in", moves.ids)]
 
     def _should_compute_ordered_available_to_promise(self):

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -1,9 +1,10 @@
 # Copyright 2019 Camptocamp (https://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.osv import expression
 from odoo.tools import date_utils, float_compare
+from odoo.exceptions import UserError
 
 
 class StockMove(models.Model):
@@ -29,6 +30,24 @@ class StockMove(models.Model):
     def _compute_ordered_available_to_promise(self):
         for move in self:
             move.ordered_available_to_promise = move._ordered_available_to_promise()
+
+    @api.model
+    def _search_ordered_available_to_promise(self, operator, value):
+        if operator not in (">", ">=", "="):
+            raise UserError(
+                _("Unsupported operator %s") % (operator,)
+            )
+        moves = self.search([('need_release', '=', True)])
+        if operator == ">":
+            moves = moves.filtered(
+                lambda m: m._ordered_available_to_promise() > value)
+        elif operator == ">=":
+            moves = moves.filtered(
+                lambda m: m._ordered_available_to_promise() >= value)
+        else:
+            moves = moves.filtered(
+                lambda m: m._ordered_available_to_promise() == value)
+        return [("id", "in", moves.ids)]
 
     def _should_compute_ordered_available_to_promise(self):
         return (

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -20,6 +20,7 @@ class StockMove(models.Model):
     ordered_available_to_promise = fields.Float(
         string="Ordered Available to Promise",
         compute="_compute_ordered_available_to_promise",
+        search="_search_ordered_available_to_promise",
         digits="Product Unit of Measure",
         help="Available to Promise quantity minus quantities promised "
         " to older promised operations.",

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -25,7 +25,31 @@ class StockMove(models.Model):
         help="Available to Promise quantity minus quantities promised "
         " to older promised operations.",
     )
+    release_ready = fields.Boolean(
+        compute="_compute_release_ready", search="_search_release_ready",
+    )
     need_release = fields.Boolean(index=True,)
+
+    @api.depends(
+        "ordered_available_to_promise", "picking_id.move_type", "picking_id.move_lines"
+    )
+    def _compute_release_ready(self):
+        for move in self:
+            if move.picking_id.move_type == "one":
+                move.release_ready = all(
+                    m.ordered_available_to_promise > 0
+                    for m in move.picking_id.move_lines
+                )
+            else:
+                move.release_ready = move.ordered_available_to_promise > 0
+
+    @api.model
+    def _search_release_ready(self, operator, value):
+        if operator != "=":
+            raise UserError(_("Unsupported operator %s") % (operator,))
+        moves = self.search([("ordered_available_to_promise", ">", 0)])
+        moves = moves.filtered(lambda m: m.release_ready)
+        return [("id", "in", moves.ids)]
 
     @api.depends()
     def _compute_ordered_available_to_promise(self):

--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -37,7 +37,7 @@
                     name="qty_available_to_release"
                     domain="[('ordered_available_to_promise', '>', 0.0)]"
                 />
-                <separator/>
+                <separator />
             </field>
         </field>
     </record>
@@ -55,7 +55,9 @@
                      (0, 0, {'view_mode': 'form', 'view_id': ref('view_move_release_form')}),
                      ]"
         />
-        <field name="context">{'search_default_groupby_picking_id': 1, 'search_default_qty_available_to_release': 1}</field>
+        <field
+            name="context"
+        >{'search_default_groupby_picking_id': 1, 'search_default_qty_available_to_release': 1}</field>
         <field name="domain">[('need_release', '=' , True)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -26,6 +26,21 @@
             </group>
         </field>
     </record>
+    <record id="view_move_release_search" model="ir.ui.view">
+        <field name="name">stock.move.release.search</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_search" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <filter
+                    string="Qty Available to Release"
+                    name="qty_available_to_release"
+                    domain="[('ordered_available_to_promise', '>', 0.0)]"
+                />
+                <separator/>
+            </field>
+        </field>
+    </record>
     <record id="stock_move_release_action" model="ir.actions.act_window">
         <field name="name">Stock Moves To Release</field>
         <field name="res_model">stock.move</field>
@@ -40,8 +55,8 @@
                      (0, 0, {'view_mode': 'form', 'view_id': ref('view_move_release_form')}),
                      ]"
         />
-        <field name="context">{'search_default_groupby_picking_id': 1}</field>
-        <field name="domain">[('need_release', '=' , True), ('ordered_available_to_promise', '>', 0.0)]</field>
+        <field name="context">{'search_default_groupby_picking_id': 1, 'search_default_qty_available_to_release': 1}</field>
+        <field name="domain">[('need_release', '=' , True)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new stock movement

--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -41,7 +41,7 @@
                      ]"
         />
         <field name="context">{'search_default_groupby_picking_id': 1}</field>
-        <field name="domain">[('need_release', '=' , True)]</field>
+        <field name="domain">[('need_release', '=' , True), ('ordered_available_to_promise', '>', 0.0)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new stock movement

--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -35,7 +35,7 @@
                 <filter
                     string="Qty Available to Release"
                     name="qty_available_to_release"
-                    domain="[('ordered_available_to_promise', '>', 0.0)]"
+                    domain="[('release_ready', '=', True)]"
                 />
                 <separator />
             </field>


### PR DESCRIPTION
We want to give the possibility to search stock moves by `Ordered Available to Promise`

Also in Stock Moves To Release tree view, we just want to show moves with quantities available to release.