### PR TITLE
stock_available_to_promise_release: fix handling of unreleased moves

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -169,9 +169,7 @@ class StockMove(models.Model):
                     # we don't want to deliver unless we can deliver all at
                     # once
                     continue
-                new_move = move.with_context(
-                    release_available_to_promise=True
-                )._release_split(remaining)
+                new_move = move._release_split(remaining)
                 backorder_links[new_move.picking_id] = move.picking_id
 
             values = move._prepare_procurement_values()
@@ -188,6 +186,16 @@ class StockMove(models.Model):
                 )
             )
             pulled_moves |= move
+
+        # move the unreleased moves to a backorder
+        released_pickings = pulled_moves.picking_id
+        unreleased_moves = released_pickings.move_lines - pulled_moves
+        for unreleased_move in unreleased_moves:
+            # no split will occur as we keep the same qty, but the move
+            # will be assigned to a new stock.picking
+            original_picking = unreleased_move.picking_id
+            unreleased_move._release_split(unreleased_move.product_qty)
+            backorder_links[unreleased_move.picking_id] = original_picking
 
         for backorder, origin in backorder_links.items():
             backorder._release_link_backorder(origin)
@@ -222,6 +230,8 @@ class StockMove(models.Model):
         we move it to a new one so that we can release it later as soon as
         the qty is available.
         """
+        context = self.env.context
+        self = self.with_context(release_available_to_promise=True)
         # Rely on `printed` flag to make _assign_picking create a new picking.
         # See `stock.move._assign_picking` and
         # `stock.move._search_picking_for_assignation`.
@@ -232,4 +242,4 @@ class StockMove(models.Model):
         # thus the `_should_be_assigned` condition is not satisfied
         # and the move is not assigned.
         new_move._assign_picking()
-        return new_move
+        return new_move.with_context(context)

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -26,6 +26,12 @@ class PromiseReleaseCommonCase(common.SavepointCase):
         cls.product2 = cls.env["product.product"].create(
             {"name": "Product 2", "type": "product"}
         )
+        cls.product3 = cls.env["product.product"].create(
+            {"name": "Product 3", "type": "product"}
+        )
+        cls.product4 = cls.env["product.product"].create(
+            {"name": "Product 4", "type": "product"}
+        )
         cls.uom_unit = cls.env.ref("uom.product_uom_unit")
         cls.partner_delta = cls.env.ref("base.res_partner_4")
         cls.loc_bin1 = cls.env["stock.location"].create(


### PR DESCRIPTION
Previous behavior:

* If we use the "release" action on a move partially available, the
  remaining will be moved to a backorder picking
* When we "release" a move, it stays in the same transfer as the
  "unreleased" ones (wether they are available or not), so the
  "unreleased" ones are now in a picking with the "printed flag"

Examples of OUT transfer:

* 20 product A, 20 allocated
* 10 product B, 0 allocated

1. If I use the "release" on the 20 product A: both lines stays in the
   same transfer, which has the "printed" flag
2. If I use the "release" on both lines: a backorder is created for 10
   products B, the backorder has no "printed" flag

* 20 product A, 18 allocated
* 10 product B, 0 allocated

1. If I use the "release" on the 18 product A: both lines stays in the
   same transfer, which has the "printed" flag, a backorder is created for
   2 product A (without print flag)
2. If I use the "release" on both lines: a backorder is created for 10
   products B, the backorder has no "printed" flag

Expected behavior:

* If we use the "release" action on a move partially available, the
  remaining will be moved to a backorder picking
* When we "release" a move, the unreleased moves are put in a backorder
  (with the unavailable part of the released move if any) (and they are
  not "printed")