### PR TITLE
Ensure compatibility between release and dynamic routing

### DIFF
--- a/setup/stock_available_to_promise_release_dynamic_routing/odoo/addons/stock_available_to_promise_release_dynamic_routing
+++ b/setup/stock_available_to_promise_release_dynamic_routing/odoo/addons/stock_available_to_promise_release_dynamic_routing
@@ -1,0 +1,1 @@
+../../../../stock_available_to_promise_release_dynamic_routing

--- a/setup/stock_available_to_promise_release_dynamic_routing/setup.py
+++ b/setup/stock_available_to_promise_release_dynamic_routing/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -199,20 +199,22 @@ class StockMove(models.Model):
         # Set all transfers released to "printed", consider the work has
         # been planned and started and another "release" of moves should
         # (for instance) merge new pickings with this "round of release".
-        self._release_set_printed(pulled_moves)
-        self._release_assign_moves(pulled_moves)
+        pulled_moves._release_assign_moves()
+        pulled_moves._release_set_printed()
 
         return True
 
-    def _release_set_printed(self, moves):
+    def _release_set_printed(self):
         picking_ids = set()
+        moves = self
         while moves:
             picking_ids.update(moves.mapped("picking_id").ids)
             moves = moves.mapped("move_orig_ids")
         pickings = self.env["stock.picking"].browse(picking_ids)
         pickings.filtered(lambda p: not p.printed).printed = True
 
-    def _release_assign_moves(self, moves):
+    def _release_assign_moves(self):
+        moves = self
         while moves:
             moves._action_assign()
             moves = moves.mapped("move_orig_ids")

--- a/stock_available_to_promise_release_dynamic_routing/__manifest__.py
+++ b/stock_available_to_promise_release_dynamic_routing/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Available to Promise Release - Dynamic Routing",
+    "summary": "Glue between moves release and dynamic routing",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/wms",
+    "category": "Warehouse Management",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": ["stock_available_to_promise_release", "stock_dynamic_routing"],
+    "demo": [],
+    "data": [],
+    "auto_install": True,
+    "installable": True,
+    "development_status": "Alpha",
+}

--- a/stock_available_to_promise_release_dynamic_routing/readme/CONTRIBUTORS.rst
+++ b/stock_available_to_promise_release_dynamic_routing/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/stock_available_to_promise_release_dynamic_routing/readme/DESCRIPTION.rst
+++ b/stock_available_to_promise_release_dynamic_routing/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+Glue module between ``stock_available_to_promise_release`` and
+``stock_dynamic_routing``.
+
+Currently, the module only contains tests to verify the compatibility
+between these two modules, but compatibility code may be needed later.

--- a/stock_available_to_promise_release_dynamic_routing/tests/__init__.py
+++ b/stock_available_to_promise_release_dynamic_routing/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_release_dynamic_routing

--- a/stock_available_to_promise_release_dynamic_routing/tests/test_release_dynamic_routing.py
+++ b/stock_available_to_promise_release_dynamic_routing/tests/test_release_dynamic_routing.py
@@ -1,0 +1,223 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+"""
+When we "release" moves, we set the "printed" flag on the transfers,
+because after a release, we shouldn't have any new move merged in a
+"wave" of release.
+
+The stock_available_to_promise_release module adds the flag on all
+the transfer chain (pick, pack, ship, ...), but as transfers created
+for dynamic routing are created later, we have to ensure that transfers
+for these new moves have the flag. These tests check this.
+"""
+
+from odoo.addons.stock_available_to_promise_release.tests.common import (
+    PromiseReleaseCommonCase,
+)
+
+
+class TestAvailableToPromiseReleaseDynamicRouting(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.location_hb = cls.env["stock.location"].create(
+            {"name": "Highbay", "location_id": cls.wh.lot_stock_id.id}
+        )
+        cls.location_hb_1 = cls.env["stock.location"].create(
+            {"name": "Highbay Shelf 1", "location_id": cls.location_hb.id}
+        )
+        cls.location_handover = cls.env["stock.location"].create(
+            {"name": "Handover", "location_id": cls.wh.lot_stock_id.id}
+        )
+
+    def test_dynamic_routing_pull_printed(self):
+        """Pull Dynamic routing applied after release get "printed" flag"""
+        pick_type_routing_op = self.env["stock.picking.type"].create(
+            {
+                "name": "Dynamic Routing",
+                "code": "internal",
+                "sequence_code": "WH/HO",
+                "warehouse_id": self.wh.id,
+                "use_create_lots": False,
+                "use_existing_lots": True,
+                "default_location_src_id": self.location_hb.id,
+                "default_location_dest_id": self.location_handover.id,
+            }
+        )
+        self.env["stock.routing"].create(
+            {
+                "location_id": self.location_hb.id,
+                "picking_type_id": self.wh.pick_type_id.id,
+                "rule_ids": [
+                    (
+                        0,
+                        0,
+                        {"method": "pull", "picking_type_id": pick_type_routing_op.id},
+                    )
+                ],
+            }
+        )
+        self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
+
+        self._update_qty_in_location(self.location_hb_1, self.product1, 20.0)
+        self._update_qty_in_location(self.location_hb_1, self.product2, 10.0)
+
+        pickings = self._create_picking_chain(
+            self.wh, [(self.product1, 20), (self.product2, 10)],
+        )
+        self.assertEqual(len(pickings), 1, "expect only the last out->customer")
+        cust_picking = pickings
+        self.assertRecordValues(
+            cust_picking,
+            [
+                {
+                    "state": "waiting",
+                    "location_id": self.wh.wh_output_stock_loc_id.id,
+                    "location_dest_id": self.loc_customer.id,
+                }
+            ],
+        )
+        cust_picking.release_available_to_promise()
+
+        pick_moves = cust_picking.move_lines.move_orig_ids
+        self.assertEqual(len(pick_moves), 2)
+        # this picking is created by standard 2-step rules
+        pick_picking = pick_moves.picking_id
+        # this flag is set by stock_available_to_promise_release
+        self.assertTrue(pick_picking.printed)
+
+        routing_moves = pick_moves.move_orig_ids
+        # if we put "printed" after we assign the 1st move only, the 2nd
+        # move will not be grouped in the same picking
+        self.assertEqual(len(routing_moves), 2)
+        routing_picking = routing_moves.picking_id
+        self.assertEqual(routing_picking.picking_type_id, pick_type_routing_op)
+
+        self.assertTrue(routing_picking.printed)
+
+    def test_dynamic_routing_change_picking_type_printed(self):
+        """Type Dynamic routing applied after release get "printed" flag"""
+        self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
+
+        area1 = self.env["stock.location"].create(
+            {"location_id": self.wh.wh_output_stock_loc_id.id, "name": "Area1"}
+        )
+        pick_loc = self.wh.pick_type_id.default_location_src_id
+        pick_type_routing_op = self.env["stock.picking.type"].create(
+            {
+                "name": "Dynamic Routing",
+                "code": "internal",
+                "sequence_code": "WH/PICK2",
+                "warehouse_id": self.wh.id,
+                "use_create_lots": False,
+                "use_existing_lots": True,
+                "default_location_src_id": pick_loc.id,
+                "default_location_dest_id": area1.id,
+            }
+        )
+        self.env["stock.routing"].create(
+            {
+                "location_id": pick_loc.id,
+                "picking_type_id": self.wh.pick_type_id.id,
+                "rule_ids": [
+                    (
+                        0,
+                        0,
+                        {"method": "pull", "picking_type_id": pick_type_routing_op.id},
+                    )
+                ],
+            }
+        )
+
+        self._update_qty_in_location(self.loc_bin1, self.product1, 20.0)
+        self._update_qty_in_location(self.loc_bin1, self.product2, 10.0)
+
+        pickings = self._create_picking_chain(
+            self.wh, [(self.product1, 20), (self.product2, 10)],
+        )
+        self.assertEqual(len(pickings), 1, "expect only the last out->customer")
+        cust_picking = pickings
+        self.assertRecordValues(
+            cust_picking,
+            [
+                {
+                    "state": "waiting",
+                    "location_id": self.wh.wh_output_stock_loc_id.id,
+                    "location_dest_id": self.loc_customer.id,
+                }
+            ],
+        )
+        cust_picking.release_available_to_promise()
+
+        pick_moves = cust_picking.move_lines.move_orig_ids
+        self.assertEqual(len(pick_moves), 2)
+        # this picking has been created to change the picking type
+        pick_picking = pick_moves.picking_id
+        self.assertEqual(pick_picking.picking_type_id, pick_type_routing_op)
+        # this flag is set by stock_available_to_promise_release
+        self.assertTrue(pick_picking.printed)
+
+    def test_dynamic_routing_change_picking_type_out_printed(self):
+        """Type Dynamic routing (on OUT) applied after release get "printed" flag
+
+        Ensure the "printed" flag is set even when we have no "move_dest_ids"
+        moves.
+        """
+        self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
+        pick_type_routing = self.wh.pick_type_id.copy(
+            {"name": "PICKP Routing", "sequence_code": "WH/PICKP"}
+        )
+        self.env["stock.routing"].create(
+            {
+                "location_id": pick_type_routing.default_location_src_id.id,
+                "picking_type_id": self.wh.pick_type_id.id,
+                "rule_ids": [
+                    (0, 0, {"method": "pull", "picking_type_id": pick_type_routing.id},)
+                ],
+            }
+        )
+        out_type_routing = self.wh.out_type_id.copy(
+            {"name": "OUTP Routing", "sequence_code": "WH/OUTP"}
+        )
+        self.env["stock.routing"].create(
+            {
+                "location_id": out_type_routing.default_location_src_id.id,
+                "picking_type_id": self.wh.out_type_id.id,
+                "rule_ids": [
+                    (0, 0, {"method": "pull", "picking_type_id": out_type_routing.id})
+                ],
+            }
+        )
+
+        self._update_qty_in_location(self.loc_bin1, self.product1, 20.0)
+        self._update_qty_in_location(self.loc_bin1, self.product2, 10.0)
+
+        pickings = self._create_picking_chain(
+            self.wh, [(self.product1, 20), (self.product2, 10)],
+        )
+        self.assertEqual(len(pickings), 1, "expect only the last out->customer")
+        cust_picking = pickings
+        cust_picking.release_available_to_promise()
+
+        # the original cust_picking has been canceled, because it is replaced
+        # by picking with the "OUTP" picking type
+        self.assertRecordValues(cust_picking, [{"state": "cancel"}])
+
+        new_cust_picking = self.env["stock.picking"].search(
+            [("picking_type_id", "=", out_type_routing.id)]
+        )
+
+        self.assertEqual(len(new_cust_picking.move_lines), 2)
+        self.assertRecordValues(
+            new_cust_picking,
+            [
+                {
+                    "state": "waiting",
+                    "location_id": self.wh.wh_output_stock_loc_id.id,
+                    "location_dest_id": self.loc_customer.id,
+                    "picking_type_id": out_type_routing.id,
+                    "printed": True,
+                }
+            ],
+        )


### PR DESCRIPTION
Add a module with tests to check a release of moves with dynamic routing
correctly sets the "printed" flag on all the chain.

When we release moves, we set the "printed" flag on the released
transfers, so we do not include any new moves (like a "wave" of
release).

As the dynamic routing is applied when we assign the moves, new moves
and transfers may be created after the "assign". We therefore have
to set the printed flag after it.