### PR TITLE
[13.0] stock_storage_type & stock_storage_type_putaway_abc: handle max_height

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -101,6 +101,7 @@ class StockLocation(models.Model):
     max_height = fields.Float(
         string="Max height (mm)",
         compute="_compute_max_height",
+        store=True,
         help="The max height supported among allowed location storage types.",
     )
 

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -356,7 +356,7 @@ class StockLocation(models.Model):
                 compatible_locations, quants, products
             )
             _logger.debug("pertinent location domain: %s", location_domain)
-            locations = self.search(location_domain, limit=limit)
+            locations = self.search(location_domain)
             valid_location_ids |= set(locations.ids)
 
         # NOTE: self.ids is ordered as expected, so we want to filter the valid

--- a/stock_storage_type/tests/__init__.py
+++ b/stock_storage_type/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_storage_type
 from . import common
 from . import test_storage_type_move
 from . import test_storage_type_putaway_strategy
+from . import test_stock_location

--- a/stock_storage_type/tests/test_stock_location.py
+++ b/stock_storage_type/tests/test_stock_location.py
@@ -1,0 +1,74 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from .common import TestStorageTypeCommon
+
+
+class TestStockLocation(TestStorageTypeCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        ref = cls.env.ref
+        cls.areas.write({"pack_putaway_strategy": "ordered_locations"})
+        cls.pallets_reserve_bin_1_location = ref(
+            "stock_storage_type.stock_location_pallets_reserve_bin_1"
+        )
+        cls.pallets_reserve_bin_2_location = ref(
+            "stock_storage_type.stock_location_pallets_reserve_bin_2"
+        )
+        cls.pallets_reserve_bin_3_location = ref(
+            "stock_storage_type.stock_location_pallets_reserve_bin_3"
+        )
+
+    def test_get_ordered_leaf_locations(self):
+        # Test with the same max_height on all related storage types (0 here)
+        self.assertEqual(
+            self.areas._get_ordered_leaf_locations().ids,
+            (
+                self.cardboxes_bin_1_location
+                | self.cardboxes_bin_2_location
+                | self.cardboxes_bin_3_location
+                | self.cardboxes_bin_4_location
+                | self.pallets_bin_1_location
+                | self.pallets_bin_2_location
+                | self.pallets_bin_3_location
+                | self.pallets_reserve_bin_1_location
+                | self.pallets_reserve_bin_2_location
+                | self.pallets_reserve_bin_3_location
+            ).ids,
+        )
+        # Set the max_height on pallets storage type higher than the others
+        self.pallets_location_storage_type.max_height = 2
+        self.cardboxes_location_storage_type.max_height = 1
+        self.assertEqual(
+            self.areas._get_ordered_leaf_locations().ids,
+            (
+                self.cardboxes_bin_1_location
+                | self.cardboxes_bin_2_location
+                | self.cardboxes_bin_3_location
+                | self.cardboxes_bin_4_location
+                | self.pallets_bin_1_location
+                | self.pallets_bin_2_location
+                | self.pallets_bin_3_location
+                | self.pallets_reserve_bin_1_location
+                | self.pallets_reserve_bin_2_location
+                | self.pallets_reserve_bin_3_location
+            ).ids,
+        )
+        # Set the max_height on cardboxes storage type higher than the others
+        self.pallets_location_storage_type.max_height = 1
+        self.cardboxes_location_storage_type.max_height = 2
+        self.assertEqual(
+            self.areas._get_ordered_leaf_locations().ids,
+            (
+                self.pallets_bin_1_location
+                | self.pallets_bin_2_location
+                | self.pallets_bin_3_location
+                | self.pallets_reserve_bin_1_location
+                | self.pallets_reserve_bin_2_location
+                | self.pallets_reserve_bin_3_location
+                | self.cardboxes_bin_1_location
+                | self.cardboxes_bin_2_location
+                | self.cardboxes_bin_3_location
+                | self.cardboxes_bin_4_location
+            ).ids,
+        )

--- a/stock_storage_type/tests/test_storage_type.py
+++ b/stock_storage_type/tests/test_storage_type.py
@@ -14,6 +14,9 @@ class TestStorageType(SavepointCase):
         cls.pallets_location_storage_type = cls.env.ref(
             "stock_storage_type.location_storage_type_pallets"
         )
+        cls.pallets_uk_location_storage_type = cls.env.ref(
+            "stock_storage_type.location_storage_type_pallets_uk"
+        )
         cls.cardboxes_location_storage_type = cls.env.ref(
             "stock_storage_type.location_storage_type_cardboxes"
         )
@@ -107,3 +110,27 @@ class TestStorageType(SavepointCase):
 
     def test_location_leaf_locations_on_leaf(self):
         self.assertEqual(self.cardboxes_bin_3.leaf_location_ids, self.cardboxes_bin_3)
+
+    def test_location_max_height(self):
+        self.pallets_location_storage_type.max_height = 2
+        self.pallets_uk_location_storage_type.max_height = 3
+        self.cardboxes_location_storage_type.max_height = 0
+        test_location = self.env["stock.location"].create(
+            {
+                "name": "TEST",
+                "location_storage_type_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.pallets_location_storage_type.id,
+                            self.pallets_uk_location_storage_type.id,
+                            self.cardboxes_location_storage_type.id,
+                        ],
+                    ),
+                ],
+            }
+        )
+        self.assertEqual(test_location.max_height, 0)
+        self.cardboxes_location_storage_type.max_height = 1
+        self.assertEqual(test_location.max_height, 3)

--- a/stock_storage_type_putaway_abc/models/stock_location.py
+++ b/stock_storage_type_putaway_abc/models/stock_location.py
@@ -63,7 +63,7 @@ class StockLocation(models.Model):
         elif product_abc == "b":
             location_ids = b_location_ids + c_location_ids + a_location_ids
         elif product_abc == "c":
-            location_ids = c_location_ids + a_location_ids + b_location_ids
+            location_ids = c_location_ids + b_location_ids + a_location_ids
         else:
             raise ValueError("product_abc = %s" % product_abc)
         return self.env["stock.location"].browse(location_ids)

--- a/stock_storage_type_putaway_abc/models/stock_location.py
+++ b/stock_storage_type_putaway_abc/models/stock_location.py
@@ -14,8 +14,11 @@ def gather_location_ids(abc_sorted, max_heights_sorted, locations_grouped):
     """
     location_ids = []
     for abc_key in abc_sorted:
+        group_ids_per_height = locations_grouped.get(abc_key)
+        if not group_ids_per_height:
+            continue
         for max_height in max_heights_sorted:
-            location_ids.extend(locations_grouped[abc_key].get(max_height, []))
+            location_ids.extend(group_ids_per_height.get(max_height, []))
     return location_ids
 
 

--- a/stock_storage_type_putaway_abc/tests/test_abc_location.py
+++ b/stock_storage_type_putaway_abc/tests/test_abc_location.py
@@ -72,24 +72,30 @@ class TestAbcLocation(SavepointCase):
         self.product.write({"abc_storage": "a"})
         ordered_locations = self.cardboxes_location.get_storage_locations(self.product)
         self.assertEqual(
-            ordered_locations,
-            self.cardboxes_bin_2_location
-            | self.cardboxes_bin_1_location
-            | self.cardboxes_bin_3_location,
+            ordered_locations.ids,
+            (
+                self.cardboxes_bin_2_location
+                | self.cardboxes_bin_1_location
+                | self.cardboxes_bin_3_location
+            ).ids,
         )
         self.product.write({"abc_storage": "b"})
         ordered_locations = self.cardboxes_location.get_storage_locations(self.product)
         self.assertEqual(
-            ordered_locations,
-            self.cardboxes_bin_1_location
-            | self.cardboxes_bin_3_location
-            | self.cardboxes_bin_2_location,
+            ordered_locations.ids,
+            (
+                self.cardboxes_bin_1_location
+                | self.cardboxes_bin_3_location
+                | self.cardboxes_bin_2_location
+            ).ids,
         )
         self.product.write({"abc_storage": "c"})
         ordered_locations = self.cardboxes_location.get_storage_locations(self.product)
         self.assertEqual(
-            ordered_locations,
-            self.cardboxes_bin_3_location
-            | self.cardboxes_bin_2_location
-            | self.cardboxes_bin_1_location,
+            ordered_locations.ids,
+            (
+                self.cardboxes_bin_3_location
+                | self.cardboxes_bin_2_location
+                | self.cardboxes_bin_1_location
+            ).ids,
         )

--- a/stock_storage_type_putaway_abc/tests/test_abc_location.py
+++ b/stock_storage_type_putaway_abc/tests/test_abc_location.py
@@ -95,7 +95,7 @@ class TestAbcLocation(SavepointCase):
             ordered_locations.ids,
             (
                 self.cardboxes_bin_3_location
-                | self.cardboxes_bin_2_location
                 | self.cardboxes_bin_1_location
+                | self.cardboxes_bin_2_location
             ).ids,
         )

--- a/stock_storage_type_putaway_abc/tests/test_abc_location.py
+++ b/stock_storage_type_putaway_abc/tests/test_abc_location.py
@@ -216,3 +216,11 @@ class TestAbcLocation(SavepointCase):
                 | self.pallets_bin_2_location
             ).ids,
         )
+
+    def test_get_storage_locations_not_all_keys(self):
+        """Do not crash if we have no A or B or C locations"""
+        self.stock_location.write({"pack_putaway_strategy": "abc"})
+        self.env["stock.location"].search(
+            [("abc_storage", "in", ("a", "b"))]
+        ).abc_storage = "b"
+        self.assertTrue(self.stock_location.get_storage_locations())


### PR DESCRIPTION
**1.  Module `stock_storage_type`:**

New `max_height` field on the the location storage type to indicate the max height supported by a location among all its storage type.

We want to propose the first location corresponding to the height of a package by losing a minimum of space, so we sort leaf locations on their supported max height.

**2. Module `stock_storage_type_putaway_abc`:**

For ABC strategy we apply the same sort among on each chunk of locations "A", "B" and "C".

If we have the following locations:

- `LOC_A_MAXHEIGHT_200`
- `LOC_A_MAXHEIGHT_100`
- `LOC_B_MAXHEIGHT_400`
- `LOC_B_MAXHEIGHT_300`
- `LOC_C_MAXHEIGHT_600`
- `LOC_C_MAXHEIGHT_500`

If the ABC storage of a product is flagged `B`, then the proposed locations will be ordered as:
- `LOC_B_MAXHEIGHT_300`
- `LOC_B_MAXHEIGHT_400`
- `LOC_C_MAXHEIGHT_500`
- `LOC_C_MAXHEIGHT_600`
- `LOC_A_MAXHEIGHT_100`
- `LOC_A_MAXHEIGHT_200`

(ordered at first with `BCA` as usual, then by `max_height`)