### PR TITLE
[13.0] stock_available_to_promise_release: Fix release of operation containing canceled moves

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -155,7 +155,7 @@ class StockMove(models.Model):
         for move in self:
             if not move.need_release:
                 continue
-            if move.state not in ("confirmed", "waiting"):
+            if move.state not in ("confirmed", "waiting", "done", "cancel"):
                 continue
             # do not use the computed field, because it will keep
             # a value in cache that we cannot invalidate declaratively
@@ -193,6 +193,8 @@ class StockMove(models.Model):
         released_pickings = pulled_moves.picking_id
         unreleased_moves = released_pickings.move_lines - pulled_moves
         for unreleased_move in unreleased_moves:
+            if unreleased_move.state in ("done", "cancel"):
+                continue
             # no split will occur as we keep the same qty, but the move
             # will be assigned to a new stock.picking
             original_picking = unreleased_move.picking_id


### PR DESCRIPTION
If a delivery contains moves from multiple sales order and one of the SO
is canceled, the canceled moves should not be split not moved to a
separate operation.