### PR TITLE
[13.0] Add stock_storage_type_buffer 

### DIFF
--- a/setup/stock_storage_type_buffer/odoo/addons/stock_storage_type_buffer
+++ b/setup/stock_storage_type_buffer/odoo/addons/stock_storage_type_buffer
@@ -1,0 +1,1 @@
+../../../../stock_storage_type_buffer

--- a/setup/stock_storage_type_buffer/setup.py
+++ b/setup/stock_storage_type_buffer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -339,6 +339,12 @@ class StockLocation(models.Model):
     def select_allowed_locations(
         self, package_storage_type, quants, products, limit=None
     ):
+        """Filter allowed locations for a storage type
+
+        ``self`` contains locations already ordered according to the
+        putaway strategy, so beware of the return that must keep the
+        same order
+        """
         # We have package who may be placed in a stock.location
         #
         # 1. On the stock.location there are location_storage_type and on the

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -386,8 +386,10 @@ class StockLocation(models.Model):
 
         # NOTE: self.ids is ordered as expected, so we want to filter the valid
         # locations while preserving the initial order
-        valid_location_ids = [id_ for id_ in self.ids if id_ in valid_locations.ids]
-        valid_locations = self.browse(valid_location_ids)
+        valid_location_ids = set(valid_locations.ids)
+        valid_locations = self.browse(
+            id_ for id_ in self.ids if id_ in valid_location_ids
+        )
         valid_locations = valid_locations._select_final_valid_putaway_locations(
             limit=limit
         )

--- a/stock_storage_type_buffer/__init__.py
+++ b/stock_storage_type_buffer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_storage_type_buffer/__manifest__.py
+++ b/stock_storage_type_buffer/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock Storage Type Buffers",
+    "summary": "Exclude storage locations from put-away if their buffer is full",
+    "version": "13.0.1.1.0",
+    "development_status": "Alpha",
+    "category": "Warehouse Management",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "depends": ["stock_storage_type"],
+    "data": [
+        "views/stock_location_storage_buffer_views.xml",
+        "templates/stock_location_storage_buffer_templates.xml",
+        "security/ir.model.access.csv",
+    ],
+}

--- a/stock_storage_type_buffer/models/__init__.py
+++ b/stock_storage_type_buffer/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_location
+from . import stock_location_storage_buffer

--- a/stock_storage_type_buffer/models/stock_location.py
+++ b/stock_storage_type_buffer/models/stock_location.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo import models
+
+_logger = logging.getLogger(__name__)
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    def _select_final_valid_putaway_locations(self, limit=None):
+        """Return the valid locations using the provided limit
+
+        ``self`` contains locations already ordered and contains
+        only valid locations.
+        This method can be used as a hook to add or remove valid
+        locations based on other properties. Pay attention to
+        keep the order.
+        """
+        if self:  # short-circuit computation when already 0 valid
+            self = self._filter_locations_blocked_by_buffer()
+        return super()._select_final_valid_putaway_locations(limit=limit)
+
+    def _filter_locations_blocked_by_buffer(self):
+        valid_location_ids = set(self.ids)
+        for storage_buffer in self.env["stock.location.storage.buffer"].search([]):
+            # By looking first if the buffer is blocked, we may compute
+            # "location_is_empty" for nothing if no valid location was
+            # in the blocked locations.
+            # But if we first look if we have valid locations amongst the
+            # the potentially blocked locations, we have to compute all the
+            # leaf locations to find intersections with valid locations, which
+            # is costly too.
+            # If we have performance issues, it would be worth checking
+            # the costs of the two and pick the faster.
+            if storage_buffer.buffers_have_capacity():
+                # locations behind the buffer are not blocked
+                continue
+            # as the buffer is full, all the leaf locations behind the buffer
+            # are unreachable, remove them from the valid locations
+            blocked_locations = storage_buffer.location_ids.leaf_location_ids
+            current_valid_count = len(valid_location_ids)
+            valid_location_ids -= set(blocked_locations.ids)
+            new_valid_count = len(valid_location_ids)
+            _logger.debug(
+                "%d locations excluded, blocked by buffer locations %s",
+                current_valid_count - new_valid_count,
+                storage_buffer.buffer_location_ids.mapped("name"),
+            )
+        # keep the original order
+        return self.browse([id_ for id_ in self.ids if id_ in valid_location_ids])

--- a/stock_storage_type_buffer/models/stock_location_storage_buffer.py
+++ b/stock_storage_type_buffer/models/stock_location_storage_buffer.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import _, api, fields, models
+
+
+class StockLocationStorageBuffer(models.Model):
+    _name = "stock.location.storage.buffer"
+    _description = "Location Storage Buffer"
+
+    MAX_LOCATIONS_IN_NAME_GET = 3
+    MAX_LOCATIONS_IN_HELP = 10
+
+    buffer_location_ids = fields.Many2many(
+        comodel_name="stock.location",
+        relation="stock_location_storage_buffer_stock_location_buffer_rel",
+        required=True,
+        help="Buffers where goods are temporarily stored. When all these "
+        "locations contain goods or will receive goods,"
+        " the destination locations are not available for putaway.",
+    )
+    location_ids = fields.Many2many(
+        comodel_name="stock.location",
+        relation="stock_location_storage_buffer_stock_location_rel",
+        required=True,
+        help="Destination locations (including sublocations) that will be"
+        " unreachable for putaway if the buffers are full.",
+    )
+    help_message = fields.Html(compute="_compute_help_message")
+    active = fields.Boolean(default=True)
+
+    @api.depends("buffer_location_ids", "location_ids")
+    def _compute_help_message(self):
+        """Generate a description of the storage buffer for humans"""
+        for record in self:
+            if not (record.buffer_location_ids and record.location_ids):
+                record.help_message = _(
+                    "<p>Select buffer locations and locations "
+                    "blocked for putaways when the buffer locations "
+                    "already contain goods or have move lines "
+                    "reaching them.</p>"
+                )
+                continue
+
+            record.help_message = record._help_message()
+
+    def buffers_have_capacity(self):
+        self.ensure_one()
+        buffer_locations = self.buffer_location_ids.leaf_location_ids
+        return any(location.location_is_empty for location in buffer_locations)
+
+    def _help_message_location_items(self, records):
+        items = records[: self.MAX_LOCATIONS_IN_HELP].mapped("display_name")
+        return items, max(0, len(records) - self.MAX_LOCATIONS_IN_HELP)
+
+    def _prepare_values_for_help_message(self):
+        buffer_location_items, buffer_remaining = self._help_message_location_items(
+            self.buffer_location_ids.leaf_location_ids
+        )
+        location_items, loc_remaining = self._help_message_location_items(
+            self.location_ids.leaf_location_ids
+        )
+        return {
+            "buffers_have_capacity": self.buffers_have_capacity(),
+            "buffer_locations": buffer_location_items,
+            "buffer_locations_remaining": buffer_remaining,
+            "locations": location_items,
+            "locations_remaining": loc_remaining,
+        }
+
+    def _help_message(self):
+        return self.env["ir.qweb"].render(
+            "stock_storage_type_buffer.storage_buffer_help_message",
+            self._prepare_values_for_help_message(),
+        )
+
+    def name_get(self):
+        result = []
+        for record in self:
+            name = ", ".join(
+                record.buffer_location_ids[: self.MAX_LOCATIONS_IN_NAME_GET].mapped(
+                    "name"
+                )
+            )
+            if len(record.buffer_location_ids) > self.MAX_LOCATIONS_IN_NAME_GET:
+                name += ", ..."
+            result.append((record.id, name))
+        return result

--- a/stock_storage_type_buffer/readme/CONTRIBUTORS.rst
+++ b/stock_storage_type_buffer/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/stock_storage_type_buffer/readme/DESCRIPTION.rst
+++ b/stock_storage_type_buffer/readme/DESCRIPTION.rst
@@ -1,0 +1,18 @@
+This is an extensions for putaway with storage types (provided by
+``stock_storage_type``).
+
+In a warehouse, some areas where goods are put cannot be accessed directly and
+need to be moved to a buffer first (for instance, because they need a special
+machine to move from the buffer to the bins).
+
+In this situation, when we have several buffers each serving several bays, e.g.
+10 buffers in front of 10 alleys, we want to avoid putting everything in the
+alley 1 if anyway the buffer is full.
+
+This module allows to define buffers in front of a set of locations. When a
+buffer contains something or has move lines that reaches it, all the locations
+are removed from the put-away computation.
+
+This is specially useful when used with ``stock_dynamic_routing`` with a
+configuration that adds an additional move going through the buffer when
+we have to reach these areas.

--- a/stock_storage_type_buffer/security/ir.model.access.csv
+++ b/stock_storage_type_buffer/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_stock_location_storage_buffer_user,access_stock_location_storage_buffer_user,model_stock_location_storage_buffer,base.group_user,1,0,0,0
+access_stock_location_storage_buffer_manager,access_stock_location_storage_buffer_manager,model_stock_location_storage_buffer,stock.group_stock_manager,1,1,1,1

--- a/stock_storage_type_buffer/templates/stock_location_storage_buffer_templates.xml
+++ b/stock_storage_type_buffer/templates/stock_location_storage_buffer_templates.xml
@@ -1,0 +1,51 @@
+<odoo>
+    <template id="storage_buffer_help_message">
+        <p>The buffer locations
+            <ul class="mt8">
+                <t t-foreach="buffer_locations" t-as="loc_text">
+                    <li>
+                        <span itemprop="name" t-esc="loc_text" />
+                    </li>
+                </t>
+                <t t-if="buffer_locations_remaining">
+                    <t
+                        t-call="stock_storage_type_buffer.storage_buffer_help_message_other_locations"
+                    >
+                        <t t-set="remaining" t-value="buffer_locations_remaining" />
+                    </t>
+                </t>
+            </ul>
+            <span t-if="buffers_have_capacity">
+                currently <strong>have capacity</strong>,
+                so the following locations
+                <strong>can receive putaways</strong>:
+            </span>
+            <span t-if="not buffers_have_capacity">
+                currently <strong>have no capacity</strong>,
+                so the following locations
+                <strong>cannot receive putaways</strong>:
+            </span>
+            <ul class="mt8">
+                <t t-foreach="locations" t-as="loc_text">
+                    <li>
+                        <span itemprop="name" t-esc="loc_text" />
+                    </li>
+                </t>
+                <t t-if="locations_remaining">
+                    <t
+                        t-call="stock_storage_type_buffer.storage_buffer_help_message_other_locations"
+                    >
+                        <t t-set="remaining" t-value="locations_remaining" />
+                    </t>
+                </t>
+            </ul>
+        </p>
+        <p t-if="not buffers_have_capacity">
+            The buffers have no capacity because they all contain
+            goods or will contain goods due to move lines reaching them.
+        </p>
+    </template>
+    <template id="storage_buffer_help_message_other_locations">
+        <li>... and <span t-esc="remaining" /> other locations.</li>
+    </template>
+</odoo>

--- a/stock_storage_type_buffer/templates/stock_location_storage_buffer_templates.xml
+++ b/stock_storage_type_buffer/templates/stock_location_storage_buffer_templates.xml
@@ -1,45 +1,44 @@
 <odoo>
     <template id="storage_buffer_help_message">
-        <p>The buffer locations
-            <ul class="mt8">
-                <t t-foreach="buffer_locations" t-as="loc_text">
-                    <li>
-                        <span itemprop="name" t-esc="loc_text" />
-                    </li>
+        <span>The buffer locations</span>
+        <ul class="mt8">
+            <t t-foreach="buffer_locations" t-as="loc_text">
+                <li>
+                    <span itemprop="name" t-esc="loc_text" />
+                </li>
+            </t>
+            <t t-if="buffer_locations_remaining">
+                <t
+                    t-call="stock_storage_type_buffer.storage_buffer_help_message_other_locations"
+                >
+                    <t t-set="remaining" t-value="buffer_locations_remaining" />
                 </t>
-                <t t-if="buffer_locations_remaining">
-                    <t
-                        t-call="stock_storage_type_buffer.storage_buffer_help_message_other_locations"
-                    >
-                        <t t-set="remaining" t-value="buffer_locations_remaining" />
-                    </t>
+            </t>
+        </ul>
+        <span t-if="buffers_have_capacity">
+            currently <strong>have capacity</strong>,
+            so the following locations
+            <strong>can receive putaways</strong>:
+        </span>
+        <span t-if="not buffers_have_capacity">
+            currently <strong>have no capacity</strong>,
+            so the following locations
+            <strong>cannot receive putaways</strong>:
+        </span>
+        <ul class="mt8">
+            <t t-foreach="locations" t-as="loc_text">
+                <li>
+                    <span itemprop="name" t-esc="loc_text" />
+                </li>
+            </t>
+            <t t-if="locations_remaining">
+                <t
+                    t-call="stock_storage_type_buffer.storage_buffer_help_message_other_locations"
+                >
+                    <t t-set="remaining" t-value="locations_remaining" />
                 </t>
-            </ul>
-            <span t-if="buffers_have_capacity">
-                currently <strong>have capacity</strong>,
-                so the following locations
-                <strong>can receive putaways</strong>:
-            </span>
-            <span t-if="not buffers_have_capacity">
-                currently <strong>have no capacity</strong>,
-                so the following locations
-                <strong>cannot receive putaways</strong>:
-            </span>
-            <ul class="mt8">
-                <t t-foreach="locations" t-as="loc_text">
-                    <li>
-                        <span itemprop="name" t-esc="loc_text" />
-                    </li>
-                </t>
-                <t t-if="locations_remaining">
-                    <t
-                        t-call="stock_storage_type_buffer.storage_buffer_help_message_other_locations"
-                    >
-                        <t t-set="remaining" t-value="locations_remaining" />
-                    </t>
-                </t>
-            </ul>
-        </p>
+            </t>
+        </ul>
         <p t-if="not buffers_have_capacity">
             The buffers have no capacity because they all contain
             goods or will contain goods due to move lines reaching them.

--- a/stock_storage_type_buffer/tests/__init__.py
+++ b/stock_storage_type_buffer/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_storage_type_buffer

--- a/stock_storage_type_buffer/tests/test_storage_type_buffer.py
+++ b/stock_storage_type_buffer/tests/test_storage_type_buffer.py
@@ -1,0 +1,91 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo.addons.stock_storage_type.tests.common import TestStorageTypeCommon
+
+
+class TestStorageTypeBuffer(TestStorageTypeCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # when this buffer is not empty, it will block
+        # all the pallets locations
+        cls.buffer_location = cls.env["stock.location"].create(
+            {"name": "Pallet Buffer", "location_id": cls.warehouse.lot_stock_id.id}
+        )
+
+        cls.env["stock.location.storage.buffer"].create(
+            {
+                "buffer_location_ids": [(6, 0, cls.buffer_location.ids)],
+                "location_ids": [(6, 0, cls.pallets_location.ids)],
+            }
+        )
+
+    def _create_pallet_move_to_putaway(self):
+        move = self._create_single_move(self.product)
+        move._assign_picking()
+        package = self.env["stock.quant.package"].create(
+            {"product_packaging_id": self.product_pallet_product_packaging.id}
+        )
+        self._update_qty_in_location(
+            move.location_id, move.product_id, move.product_qty, package=package
+        )
+        return move
+
+    def test_buffer_with_capacity(self):
+        """The buffer is empty so we can move to the pallet locations"""
+        move = self._create_pallet_move_to_putaway()
+        move._action_assign()
+        move_line = move.move_line_ids
+        # the buffer is available, so we can move the pallet in the pallets locations
+        self.assertIn(
+            move_line.location_dest_id, self.pallets_location.leaf_location_ids
+        )
+
+    def test_buffer_without_capacity_quant(self):
+        """The buffer is occupied so we cannot move to the pallet locations
+
+        This test puts a quant in the buffer location.
+        """
+        move = self._create_pallet_move_to_putaway()
+
+        # put anything in the buffer
+        self._update_qty_in_location(self.buffer_location, self.product, 1)
+
+        move._action_assign()
+        move_line = move.move_line_ids
+        # as the buffer is occupied, the move line can't reach the pallets
+        # locations
+        self.assertNotIn(
+            move_line.location_dest_id, self.pallets_location.leaf_location_ids
+        )
+        self.assertIn(
+            move_line.location_dest_id, self.pallets_reserve_location.leaf_location_ids
+        )
+
+    def test_buffer_without_capacity_move_line_dest(self):
+        """The buffer is occupied so we cannot move to the pallet locations
+
+        There is no quant in the buffer location in this test, but another
+        move line has the buffer as destination.
+        """
+        other_move = self._create_single_move(self.product)
+        other_move._assign_picking()
+        self._update_qty_in_location(
+            other_move.location_id, other_move.product_id, other_move.product_qty
+        )
+        other_move._action_assign()
+        other_move.move_line_ids.location_dest_id = self.buffer_location
+
+        move = self._create_pallet_move_to_putaway()
+        move._action_assign()
+        move_line = move.move_line_ids
+        # as the buffer will be occupied, the move line can't reach the pallets
+        # locations
+        self.assertNotIn(
+            move_line.location_dest_id, self.pallets_location.leaf_location_ids
+        )
+        self.assertIn(
+            move_line.location_dest_id, self.pallets_reserve_location.leaf_location_ids
+        )

--- a/stock_storage_type_buffer/views/stock_location_storage_buffer_views.xml
+++ b/stock_storage_type_buffer/views/stock_location_storage_buffer_views.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="location_storage_buffer_tree_view" model="ir.ui.view">
+        <field name="name">stock.location.storage.buffer.tree.view</field>
+        <field name="model">stock.location.storage.buffer</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="buffer_location_ids" widget="many2many_tags" />
+                <field name="location_ids" widget="many2many_tags" />
+            </tree>
+        </field>
+    </record>
+    <record id="location_storage_buffer_form_view" model="ir.ui.view">
+        <field name="name">stock.location.storage.buffer.form.view</field>
+        <field name="model">stock.location.storage.buffer</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <div class="oe_button_box" name="button_box">
+                    </div>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
+                    <field name="active" invisible="1" />
+                    <group>
+                        <field name="help_message" nolabel="1" />
+                    </group>
+                    <group name="buffer_locations" string="Buffer Locations">
+                        <field name="buffer_location_ids" nolabel="1" />
+                    </group>
+                    <group name="locations" string="Locations">
+                        <field name="location_ids" nolabel="1" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="location_storage_buffer_search_view" model="ir.ui.view">
+        <field name="name">stock.location.storage.buffer.search.view</field>
+        <field name="model">stock.location.storage.buffer</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="buffer_location_ids" />
+                <field name="location_ids" />
+                <separator />
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active','=',False)]"
+                />
+            </search>
+        </field>
+    </record>
+    <record id="location_storage_buffer_action" model="ir.actions.act_window">
+        <field name="name">Storage Buffers</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.location.storage.buffer</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+    <menuitem
+        id="stock_location_storage_buffer_menu"
+        name="Storage Buffers"
+        action="location_storage_buffer_action"
+        parent="stock_storage_type.storage_type_menu"
+        sequence="15"
+    />
+</odoo>


### PR DESCRIPTION
This is an extensions for putaway with storage types (provided by
``stock_storage_type``).

In a warehouse, some areas where goods are put cannot be accessed
directly and need to be moved to a buffer first (for instance, because
they need a special machine to move from the buffer to the bins).

This module allows to define buffers in front of a set of locations.
When a buffer contains something or has move lines that reaches it, all
the locations are removed from the put-away computation.