### PR TITLE
[IMP] stock_reception_screen: scan several packages for the same product/lot

### DIFF
--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -42,21 +42,20 @@ class StockReceptionScreen(models.Model):
         },
         "set_location": {
             "label": _("Set Destination"),
-            "next_steps": [{"next": "set_package"}],
-            "focus_field": "current_move_line_location_dest_id",
-        },
-        "set_package": {
-            "label": _("Set Package"),
             "next_steps": [
                 {
-                    "before": "_before_set_package_to_select_packaging",
+                    "before": "_before_set_location_to_select_packaging",
                     "next": "select_packaging",
                 }
             ],
-            "focus_field": "current_move_line_package",
+            "focus_field": "current_move_line_location_dest_id",
         },
         "select_packaging": {
             "label": _("Select Packaging"),
+            "next_steps": [{"next": "set_package"}],
+        },
+        "set_package": {
+            "label": _("Set Package"),
             "next_steps": [
                 # TODO: Should add a before step
                 {
@@ -79,6 +78,7 @@ class StockReceptionScreen(models.Model):
                 },
                 {"next": "done", "after": "_after_step_done"},
             ],
+            "focus_field": "current_move_line_package",
         },
         "done": {"label": _("Done"), "next_steps": []},
     }
@@ -564,10 +564,10 @@ class StockReceptionScreen(models.Model):
             return
         self.next_step()
 
-    def process_set_package(self):
+    def process_select_packaging(self):
         self.next_step()
 
-    def _before_set_package_to_select_packaging(self):
+    def _before_set_location_to_select_packaging(self):
         """Auto-complete the package data matching the qty (if there is one)."""
         qty_done = self.current_move_line_qty_done
         if qty_done:
@@ -577,7 +577,7 @@ class StockReceptionScreen(models.Model):
             self._autocomplete_package_data(packaging)
         return True
 
-    def process_select_packaging(self):
+    def process_set_package(self):
         if self._check_package_data():
             self._set_package_data()
             self.next_step()

--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -85,7 +85,7 @@ class StockReceptionScreen(models.Model):
 
     picking_id = fields.Many2one(
         comodel_name="stock.picking",
-        string=u"Transfer",
+        string="Transfer",
         ondelete="cascade",
         required=True,
     )
@@ -581,6 +581,8 @@ class StockReceptionScreen(models.Model):
         if self._check_package_data():
             self._set_package_data()
             self.next_step()
+            return True
+        return False
 
     def _before_next_move_to_set_lot_number(self):
         """Receive next move for same product (with lot) directely."""
@@ -656,6 +658,55 @@ class StockReceptionScreen(models.Model):
             return
         method = "process_{}".format(self.current_step)
         getattr(self, method)()
+        return True
+
+    def button_next_pack(self):
+        """Process the current package and prepare the screen to scan another
+        one for the same product/lot/packaging data.
+
+        When calling this button we are supposed to be in the `set_package` step,
+        and once triggered the button will complete the first steps with the
+        same data than the previous package, and will stop again on the
+        `set_package` step.
+        """
+        self.ensure_one()
+        if not self.current_move_id and not self.current_move_line_id:
+            return
+        assert self.current_step == "set_package", f"step = {self.current_step}"
+        # Copy relevant data for the next package
+        qty_done = self.current_move_line_qty_done
+        location_dest = self.current_move_line_location_dest_id
+        product_packaging = self.product_packaging_id
+        package_storage_type = self.package_storage_type_id
+        package_height = self.package_height
+        # Validate the current package
+        if not self.process_set_package():
+            # Package data may be missing the first time, aborting operation
+            return
+        # Stop when the current product/lot has been fully processed
+        if self.current_step in ("select_product", "select_move"):
+            return
+        # Process the first steps of the next package
+        #   - process lot if required
+        if self.current_step == "set_lot_number":
+            self.process_set_lot_number()
+            self.process_set_expiry_date()
+        #   - set the quantity
+        assert self.current_step == "set_quantity", f"step = {self.current_step}"
+        self.current_move_line_qty_done = qty_done
+        self.process_set_quantity()
+        #   - set the destination
+        self.current_move_line_location_dest_id = location_dest
+        self.process_set_location()
+        #   - set packaging data
+        assert self.current_step == "select_packaging", f"step = {self.current_step}"
+        self.product_packaging_id = product_packaging
+        self.package_storage_type_id = package_storage_type
+        if self.package_storage_type_height_required:
+            self.package_height = package_height
+        self.process_select_packaging()
+        assert self.current_step == "set_package", f"step = {self.current_step}"
+        return True
 
     def button_reset(self):
         """Reset the current step.

--- a/stock_reception_screen/tests/test_reception_screen.py
+++ b/stock_reception_screen/tests/test_reception_screen.py
@@ -104,6 +104,12 @@ class TestReceptionScreen(SavepointCase):
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
         self.assertTrue(self.screen.current_move_line_location_dest_id)
+        # Check package data (automatically filled normally)
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "select_packaging")
+        self.assertEqual(self.screen.product_packaging_id, self.product_packaging)
+        self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
+        self.assertEqual(self.screen.package_height, self.product_packaging.height)
         # Set a package
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
@@ -111,12 +117,6 @@ class TestReceptionScreen(SavepointCase):
         self.assertEqual(
             self.screen.current_move_line_id.result_package_id.name, "PID-TEST-1"
         )
-        # Check package data (automatically filled normally)
-        self.screen.button_save_step()
-        self.assertEqual(self.screen.current_step, "select_packaging")
-        self.assertEqual(self.screen.product_packaging_id, self.product_packaging)
-        self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
-        self.assertEqual(self.screen.package_height, self.product_packaging.height)
         # The first 4 qties should be validated, creating a 2nd move to process
         self.assertEqual(len(self.picking.move_lines), 2)
         self.screen.button_save_step()
@@ -133,13 +133,6 @@ class TestReceptionScreen(SavepointCase):
         self.assertEqual(self.screen.current_move_line_qty_status, "eq")
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
-        # Set a package
-        self.screen.button_save_step()
-        self.assertEqual(self.screen.current_step, "set_package")
-        self.screen.current_move_line_package = "PID-TEST-2"
-        self.assertEqual(
-            self.screen.current_move_line_id.result_package_id.name, "PID-TEST-2"
-        )
         # Check package data (not automatically filled as no packaging match)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
@@ -149,6 +142,13 @@ class TestReceptionScreen(SavepointCase):
         # Set mandatory package data
         self.screen.package_storage_type_id = self.storage_type_pallet
         self.screen.package_height = 20
+        # Set a package
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_package")
+        self.screen.current_move_line_package = "PID-TEST-2"
+        self.assertEqual(
+            self.screen.current_move_line_id.result_package_id.name, "PID-TEST-2"
+        )
         # Reception done
         self.screen.button_save_step()
 
@@ -166,15 +166,15 @@ class TestReceptionScreen(SavepointCase):
         self.assertEqual(self.screen.current_step, "set_location")
         self.assertTrue(self.screen.current_move_line_location_dest_id)
         self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "select_packaging")
+        self.screen.package_storage_type_id = self.storage_type_pallet
+        self.screen.package_height = 20
+        self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
         self.screen.current_move_line_package = "PID-TEST-2.1"
         self.assertEqual(
             self.screen.current_move_line_id.result_package_id.name, "PID-TEST-2.1"
         )
-        self.screen.button_save_step()
-        self.assertEqual(self.screen.current_step, "select_packaging")
-        self.screen.package_storage_type_id = self.storage_type_pallet
-        self.screen.package_height = 20
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "done")
         move_states = self.picking.move_lines.mapped("state")

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -54,6 +54,15 @@
                             attrs="{'invisible': [('current_step', 'in', ('select_product', 'select_move', 'done'))]}"
                         />
                         <button
+                            name="button_next_pack"
+                            type="object"
+                            string="Next PACK"
+                            icon="fa-repeat"
+                            class="btn-secondary"
+                            style="background-color: #eef0f2;"
+                            attrs="{'invisible': [('current_step', '!=', 'set_package')]}"
+                        />
+                        <button
                             name="button_reset"
                             type="object"
                             string="Cancel"

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -169,6 +169,7 @@
                                         attrs="{'invisible': [('current_move_line_qty_status', '!=', 'gt')]}"
                                     />
                                 </div>
+                                <!-- set_location -->
                                 <label for="current_move_line_location_dest_id" />
                                 <div>
                                     <field
@@ -182,15 +183,7 @@
                                         domain="[('id', 'child_of', picking_location_dest_id)]"
                                     />
                                 </div>
-                                <label for="current_move_line_package" />
-                                <div>
-                                    <field
-                                        name="current_move_line_package"
-                                        class="mr8"
-                                        style="width: 15em;"
-                                        attrs="{'readonly': [('current_step', '!=', 'set_package')]}"
-                                    />
-                                </div>
+                                <!-- select_packaging -->
                                 <label for="product_packaging_id" />
                                 <div>
                                     <field
@@ -229,6 +222,16 @@
                                         attrs="{
                             'readonly': [('current_step', '!=', 'select_packaging')],
                           }"
+                                    />
+                                </div>
+                                <!-- set_package -->
+                                <label for="current_move_line_package" />
+                                <div>
+                                    <field
+                                        name="current_move_line_package"
+                                        class="mr8"
+                                        style="width: 15em;"
+                                        attrs="{'readonly': [('current_step', '!=', 'set_package')]}"
                                     />
                                 </div>
                             </group>


### PR DESCRIPTION
First the steps `set_package` and `select_packaging` are inverted (first commit), then we allow the operator to "loop" on `set_package`.

This feature allows to receive several packages for the same product/lot when the operator triggers the `Next PACK` button once the packaging info and the first package are filled. The screen will loop on the `set_package` step until all quantities are processed.

![image](https://user-images.githubusercontent.com/5315285/97722535-09cc4f80-1acb-11eb-961c-c9e30b57830b.png)
