### PR TITLE
[13.0] Add stock_dynamic_routing_reserve_rule

### DIFF
--- a/setup/stock_dynamic_routing_reserve_rule/odoo/addons/stock_dynamic_routing_reserve_rule
+++ b/setup/stock_dynamic_routing_reserve_rule/odoo/addons/stock_dynamic_routing_reserve_rule
@@ -1,0 +1,1 @@
+../../../../stock_dynamic_routing_reserve_rule

--- a/setup/stock_dynamic_routing_reserve_rule/setup.py
+++ b/setup/stock_dynamic_routing_reserve_rule/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_dynamic_routing/views/stock_routing_views.xml
+++ b/stock_dynamic_routing/views/stock_routing_views.xml
@@ -18,11 +18,11 @@
                     <h1>
                         <field name="location_id" />
                     </h1>
-                    <group>
-                        <group>
+                    <group name="options">
+                        <group name="picking_type">
                             <field name="picking_type_id" />
                         </group>
-                        <group>
+                        <group name="routing_message">
                             <field name="routing_message" nolabel="1" />
                         </group>
                     </group>
@@ -66,6 +66,7 @@
         <field name="arch" type="xml">
             <search string="Dynamic Routing">
                 <field name="location_id" />
+                <field name="picking_type_id" />
                 <separator />
                 <filter
                     string="Archived"

--- a/stock_dynamic_routing_reserve_rule/__init__.py
+++ b/stock_dynamic_routing_reserve_rule/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_dynamic_routing_reserve_rule/__manifest__.py
+++ b/stock_dynamic_routing_reserve_rule/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+{
+    "name": "Stock Dynamic Routing - Reservation Rules",
+    "summary": "Glue module between dynamic routing and reservation rules",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/wms",
+    "category": "Warehouse Management",
+    "version": "13.0.1.0.0",
+    "license": "AGPL-3",
+    "depends": [
+        "stock_dynamic_routing",  # OCA/wms
+        "stock_reserve_rule",  # OCA/stock-logistics-warehouse
+    ],
+    "data": ["templates/stock_routing_templates.xml", "views/stock_routing_views.xml"],
+    "installable": True,
+    "auto_install": True,
+    "development_status": "Beta",
+}

--- a/stock_dynamic_routing_reserve_rule/models/__init__.py
+++ b/stock_dynamic_routing_reserve_rule/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_routing

--- a/stock_dynamic_routing_reserve_rule/models/stock_routing.py
+++ b/stock_dynamic_routing_reserve_rule/models/stock_routing.py
@@ -1,0 +1,94 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from os.path import commonpath
+
+from odoo import _, api, fields, models
+
+
+class StockRouting(models.Model):
+    _inherit = "stock.routing"
+
+    reserve_rule_warning = fields.Html(compute="_compute_reserve_rule_warning")
+
+    def _removal_rules_common_locations(self, reserve_rules):
+        dest_removal_locations = reserve_rules.rule_removal_ids.location_id
+        location_names = dest_removal_locations.mapped("complete_name")
+        locations_common_path = commonpath(location_names)
+        location_names = [
+            name[len(locations_common_path) :].lstrip("/") for name in location_names
+        ]
+        return locations_common_path, location_names
+
+    def _render_reserve_rule_warning(self):
+        messages = []
+        src_picking_type = self.picking_type_id
+        src_reserve_rule = src_picking_type.reserve_rule_ids
+        for routing_rule in self.rule_ids:
+            dest_picking_type = routing_rule.picking_type_id
+
+            if src_reserve_rule and not dest_picking_type.reserve_rule_ids:
+                (
+                    location_common_path,
+                    location_names,
+                ) = self._removal_rules_common_locations(src_reserve_rule)
+                messages.append(
+                    self.env["ir.qweb"].render(
+                        "stock_dynamic_routing_reserve_rule."
+                        "routing_rule_reserve_rule_warning_src",
+                        values={
+                            "src_picking_type": src_picking_type,
+                            "location_common_path": location_common_path,
+                            "location_names": ", ".join(location_names),
+                            "dest_picking_type": dest_picking_type,
+                        },
+                    )
+                )
+            elif dest_picking_type.reserve_rule_ids and not src_reserve_rule:
+                (
+                    location_common_path,
+                    location_names,
+                ) = self._removal_rules_common_locations(
+                    dest_picking_type.reserve_rule_ids
+                )
+                messages.append(
+                    self.env["ir.qweb"].render(
+                        "stock_dynamic_routing_reserve_rule."
+                        "routing_rule_reserve_rule_warning_dest",
+                        values={
+                            "dest_picking_type": dest_picking_type,
+                            "location_common_path": location_common_path,
+                            "location_names": ", ".join(location_names),
+                            "src_picking_type": src_picking_type,
+                        },
+                    )
+                )
+        return messages
+
+    @api.depends(
+        "picking_type_id.reserve_rule_ids.rule_removal_ids.location_id",
+        "rule_ids.picking_type_id.reserve_rule_ids.rule_removal_ids.location_id",
+    )
+    def _compute_reserve_rule_warning(self):
+        for routing in self:
+            routing.reserve_rule_warning = b"".join(
+                routing._render_reserve_rule_warning()
+            )
+
+    def action_view_reserve_rule(self):
+        picking_types = self.picking_type_id | self.rule_ids.picking_type_id
+        reserve_rules = self.env["stock.reserve.rule"].search(
+            [("picking_type_id", "in", picking_types.ids)]
+        )
+        context = self.env.context
+        if len(picking_types) == 1:
+            context = dict(context, default_picking_type_id=picking_types.id)
+        return {
+            "name": _("Reservation Rules"),
+            "domain": [("id", "in", reserve_rules.ids)],
+            "res_model": "stock.reserve.rule",
+            "type": "ir.actions.act_window",
+            "view_id": False,
+            "view_mode": "tree,form",
+            "context": context,
+        }

--- a/stock_dynamic_routing_reserve_rule/templates/stock_routing_templates.xml
+++ b/stock_dynamic_routing_reserve_rule/templates/stock_routing_templates.xml
@@ -1,0 +1,40 @@
+<odoo>
+    <template id="routing_rule_reserve_rule_warning_src">
+        <p class="alert alert-warning">
+            Warning: the origin operation type
+            <span t-esc="src_picking_type.display_name" />
+            has reservation rules in
+            <span t-esc="location_common_path" />
+            <t t-if="location_names">
+                , for locations: <span t-esc="location_names" />
+            </t>.
+            <br />
+            This dynamic routing may change moves' operation types to
+            <strong>
+                <span t-esc="dest_picking_type.display_name" />
+            </strong>
+            which does not have a reservation rule. It may lead
+            to inconsistencies in the routing.
+        </p>
+    </template>
+    <template id="routing_rule_reserve_rule_warning_dest">
+        <p class="alert alert-warning">
+            Warning: this dynamic routing may change moves' operation
+            type to
+            <strong>
+                <span t-esc="dest_picking_type.display_name" />
+            </strong>.
+            This new operation type has reservation rules in
+            <span t-esc="location_common_path" />
+            <t t-if="location_names">
+                , for locations: <span t-esc="location_names" />
+            </t>.
+            <br />
+            The origin operation type
+            <span t-esc="src_picking_type.display_name" />
+            , however, has no
+            reservation rule, which
+            may lead to inconsistencies in the routing.
+        </p>
+    </template>
+</odoo>

--- a/stock_dynamic_routing_reserve_rule/views/stock_routing_views.xml
+++ b/stock_dynamic_routing_reserve_rule/views/stock_routing_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_routing_form" model="ir.ui.view">
+        <field name="name">stock.routing.form</field>
+        <field name="model">stock.routing</field>
+        <field name="inherit_id" ref="stock_dynamic_routing.view_stock_routing_form" />
+        <field name="arch" type="xml">
+            <group name="options" position="after">
+                <div class="col-12 d-inline-block text-left">
+                    <field name="reserve_rule_warning" />
+                </div>
+            </group>
+            <div name="button_box" position="inside">
+                <button
+                    name="action_view_reserve_rule"
+                    string="Reservation Rules"
+                    icon="fa-random"
+                    class="oe_stat_button"
+                    type="object"
+                />
+            </div>
+        </field>
+    </record>
+</odoo>

--- a/stock_move_source_relocate_dynamic_routing/__manifest__.py
+++ b/stock_move_source_relocate_dynamic_routing/__manifest__.py
@@ -5,7 +5,7 @@
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",
     "category": "Warehouse Management",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.1.1",
     "license": "AGPL-3",
     "depends": ["stock_dynamic_routing", "stock_move_source_relocate"],
     "demo": [],

--- a/stock_move_source_relocate_dynamic_routing/models/stock_routing.py
+++ b/stock_move_source_relocate_dynamic_routing/models/stock_routing.py
@@ -10,7 +10,7 @@ class StockRouting(models.Model):
 
     def action_view_source_relocate(self):
         picking_types = self.mapped("picking_type_id")
-        routing = self.env["stock.routing"].search(
+        relocate = self.env["stock.source.relocate"].search(
             [("picking_type_id", "in", picking_types.ids)]
         )
         context = self.env.context
@@ -18,7 +18,7 @@ class StockRouting(models.Model):
             context = dict(context, default_picking_type_id=picking_types.id)
         return {
             "name": _("Source Relocation"),
-            "domain": [("id", "in", routing.ids)],
+            "domain": [("id", "in", relocate.ids)],
             "res_model": "stock.source.relocate",
             "type": "ir.actions.act_window",
             "view_id": False,


### PR DESCRIPTION
Glue module between stock_dynamic_routing and stock_reserve_rule.
It adds a link to open reserve rules from dynamic routings, and
displays warning on dynamic routings when there are risks of
inconsistencies because of discrepancies between dynamic routing
and reservation rules.

For the record, these issues are:

How the application of the dynamic routing works:

1. StockMove._action_assign() is executed in a savepoint, to see what move
   lines are created and what are their source and destinations
2. If no dynamic routing matches the picking type and one of the lines:
   source / location (+ domain), the savepoint is released (we keep the
   initial _action_assign)
3. If we have a dynamic routing, the savepoint is rollbacked, we apply
   the dynamic routing (split moves if required, change picking type, add
   chained move), and call again StockMove._action_assign()

As in step 3, the picking type can be changed, and the reservation rules
are dependent of the picking type, if we have a reservation rule for the
initial picking type and no reservation rule for the new one, we may
get a different reservation which does no longer takes the good at the
place expected initially.

Depends on https://github.com/OCA/stock-logistics-warehouse/pull/1013