### PR TITLE
[13.0] Improve performance of available to promise computation

### DIFF
--- a/delivery_carrier_preference/models/stock_move.py
+++ b/delivery_carrier_preference/models/stock_move.py
@@ -22,13 +22,13 @@ class StockMove(models.Model):
         "product_id.packaging_ids",
         "product_id.packaging_ids.max_weight",
         "product_id.weight",
-        "ordered_available_to_promise",
+        "ordered_available_to_promise_uom_qty",
     )
     def _compute_estimated_shipping_weight(self):
         for move in self:
             prod = move.product_id
             move.estimated_shipping_weight = prod.get_total_weight_from_packaging(
-                move.ordered_available_to_promise
+                move.ordered_available_to_promise_uom_qty
             )
 
     def _get_new_picking_values(self):
@@ -51,7 +51,7 @@ class StockMove(models.Model):
             move.need_release
             # do not change the carrier is nothing can be released on the stock move
             and not tools.float_is_zero(
-                move._ordered_available_to_promise(), precision_digits=precision
+                move.ordered_available_to_promise_uom_qty, precision_digits=precision
             )
             and move.rule_id.route_id.force_recompute_preferred_carrier_on_release
         )

--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -16,7 +16,12 @@
                 <field name="city" optional="show" />
             </field>
             <field name="product_uom_qty" position="after">
-                <field name="ordered_available_to_promise" />
+                <field name="ordered_available_to_promise_uom_qty" />
+                <field
+                    name="previous_promised_qty"
+                    optional="hide"
+                    groups="base.group_no_one"
+                />
                 <field name="date_priority" />
                 <field name="priority" />
             </field>
@@ -42,7 +47,7 @@
                 <attribute name="string">Shipment date</attribute>
             </field>
             <group name="main_grp_col2" position="inside">
-                <field name="ordered_available_to_promise" />
+                <field name="ordered_available_to_promise_uom_qty" />
                 <field name="date_priority" />
             </group>
         </field>


### PR DESCRIPTION
When we have thousands of moves, the screen becomes hardly usable.
Make the comptutation faster.

* Compute the available quantity directly from quants with a read group
  (the qty_available computed field is too slow as it computes other
  quantities, and even much slower because of "mrp" overrides)
* The computation of the quantity promised to previous moves is very
  slow because it runs one query per move. Use a SQL query with LATERAL
  JOIN in order to run a single query for *all* the moves.

As I changed the computation, I went through it and improved / fixed
some things:

* Show a "previous_promised_qty" field which contains the result of
  the new query that returns the promised qty of previous moves. It
  is shown only with debug mode.
* Do no longer filter on the "previous moves" of the same warehouse:
  moves do not always have a "warehouse_id" set. Instead, all the
  quantities are computed on the same basis: in the view locations of
  all the warehouses, assuming that if we have the quantity anywhere
  in the stock, we can release (then make internal transfers).
* Compute both uom and real "ordered available to promise" quantity in
  the same compute method, the uom one being displayed to the user,
  while the real one is used during the release
* When both the priority and the date_priority of previous moves were
  equal, the previous quantity could be indeterministic, in this case,
  order by id in last resort
* Add tests for search methods