### PR TITLE
[FIX] shopfloor, zone picking: do not process line processed by someone else

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -175,12 +175,6 @@ class MessageAction(Component):
             "body": _("Location %s doesn't contain any package.") % location.name,
         }
 
-    def several_lines_in_location(self, location):
-        return {
-            "message_type": "warning",
-            "body": _("Several lines found in %s, please scan one.") % location.name,
-        }
-
     def several_packs_in_location(self, location):
         return {
             "message_type": "warning",

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -434,7 +434,12 @@ class ZonePicking(Component):
         package = quants.package_id
         if len(product) > 1 or len(lot) > 1 or len(package) > 1:
             return False
-        domain = [("location_id", "=", location.id)]
+        domain = [
+            ("location_id", "=", location.id),
+            "|",
+            ("shopfloor_user_id", "=", False),
+            ("shopfloor_user_id", "=", self.env.uid),
+        ]
         if product:
             domain.append(("product_id", "=", product.id))
             if lot:
@@ -508,7 +513,7 @@ class ZonePicking(Component):
                 response = self.list_move_lines(location.id, picking_type.id)
                 return self._response(
                     base_response=response,
-                    message=self.msg_store.several_lines_in_location(location),
+                    message=self.msg_store.location_empty(location),
                 )
         package = search.package_from_scan(barcode)
         if package:

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -13,6 +13,20 @@ class ZonePickingCommonCase(CommonCase):
         cls.picking_type = cls.menu.picking_type_ids
 
     @classmethod
+    def setUpClassUsers(cls):
+        super().setUpClassUsers()
+        Users = cls.env["res.users"].sudo().with_context(no_reset_password=True)
+        cls.stock_user2 = Users.create(
+            {
+                "name": "Paul Posichon",
+                "login": "paulposichon",
+                "email": "paul.posichon@example.com",
+                "notification_type": "inbox",
+                "groups_id": [(6, 0, [cls.env.ref("stock.group_stock_user").id])],
+            }
+        )
+
+    @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):
         super().setUpClassBaseData(*args, **kwargs)
         cls.packing_location.sudo().active = True


### PR DESCRIPTION
First user scans the source location 'Zone sub-location 1' containing only one move line, then processes the next step 'set_line_destination'.

The second user scans the same source location, and should not find any line.

And since 9021c85c7085f883756ff64b797950a2192c3a5a has been merged, if no move line is found when scanning the source location, the message returned has to say that the location is empty.