### PR TITLE
Shopfloor: fix sorting of lines by scheduled date

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -324,6 +324,7 @@ class ClusterPicking(Component):
             line.location_id.shopfloor_picking_sequence or "",
             line.location_id.name,
             -int(line.move_id.priority or 1),
+            line.move_id.date_expected,
             line.move_id.sequence,
             line.move_id.id,
             line.id,


### PR DESCRIPTION
zone_picking and cluster_picking should order lines by scheduled date as well. Always.

ref: 1791