### PR TITLE
shopfloor: fix zone_picking._scan_source_location

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.1.3.6",
+    "version": "13.0.1.3.7",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -282,7 +282,13 @@ class ZonePicking(Component):
         return res
 
     def _find_location_move_lines_domain(
-        self, locations, picking_type=None, package=None, product=None, lot=None
+        self,
+        locations,
+        picking_type=None,
+        package=None,
+        product=None,
+        lot=None,
+        match_user=False,
     ):
         domain = [
             ("location_id", "child_of", locations.ids),
@@ -300,6 +306,12 @@ class ZonePicking(Component):
             domain += [("product_id", "=", product.id)]
         if lot:
             domain += [("lot_id", "=", lot.id)]
+        if match_user:
+            domain += [
+                "|",
+                ("shopfloor_user_id", "=", False),
+                ("shopfloor_user_id", "=", self.env.uid),
+            ]
         return domain
 
     def _find_location_move_lines(
@@ -310,11 +322,12 @@ class ZonePicking(Component):
         product=None,
         lot=None,
         order="priority",
+        match_user=False,
     ):
         """Find lines that potentially need work in given locations."""
         move_lines = self.env["stock.move.line"].search(
             self._find_location_move_lines_domain(
-                locations, picking_type, package, product, lot
+                locations, picking_type, package, product, lot, match_user=match_user
             )
         )
         sort_keys_func = self._sort_key_move_lines(order)
@@ -437,21 +450,15 @@ class ZonePicking(Component):
         package = quants.package_id
         if len(product) > 1 or len(lot) > 1 or len(package) > 1:
             return False
-        domain = [
-            ("location_id", "=", location.id),
-            "|",
-            ("shopfloor_user_id", "=", False),
-            ("shopfloor_user_id", "=", self.env.uid),
-        ]
-        if product:
-            domain.append(("product_id", "=", product.id))
-            if lot:
-                domain.append(("lot_id", "=", lot.id))
-            if package:
-                domain.append(("package_id", "=", package.id))
-            move_lines = self.env["stock.move.line"].search(domain)
-            sort_keys_func = self._sort_key_move_lines(order)
-            move_lines = move_lines.sorted(sort_keys_func)
+        move_lines = self._find_location_move_lines(
+            location,
+            picking_type=picking_type,
+            product=product,
+            package=package,
+            lot=lot,
+            match_user=True,
+        )
+        if move_lines:
             return first(move_lines)
         return False
 

--- a/shopfloor/tests/common.py
+++ b/shopfloor/tests/common.py
@@ -302,7 +302,10 @@ class CommonCase(SavepointCase, ComponentMixin):
         product_locations = {}
         package = None
         if in_package:
-            package = cls.env["stock.quant.package"].create({})
+            if isinstance(in_package, models.BaseModel):
+                package = in_package
+            else:
+                package = cls.env["stock.quant.package"].create({})
         for move in moves:
             key = (move.product_id, location or move.location_id)
             product_locations.setdefault(key, 0)


### PR DESCRIPTION
Lines from source location should respect the same domain
as the one used to retrieve all available lines (eg: not done lines).

ref: 1811