### PR TITLE
Fix prefered delivery on backorder creation

### DIFF
--- a/delivery_carrier_preference/models/stock_move.py
+++ b/delivery_carrier_preference/models/stock_move.py
@@ -93,6 +93,12 @@ class StockMove(models.Model):
             # these are backorders created for unavailable qties,
             # reassign them the original group and carrier
             need_release_pickings = new_group.picking_ids.filtered("need_release")
+
+            # need_release_pickings is empty from the UI
+            # but is not in the unit test
+            # Why ?
+            # This cause the bug in the UI
+
             # reassign the original group and carriers on the backorders
             need_release_pickings.move_lines.group_id = original_group
             need_release_pickings.carrier_id = original_group.carrier_id

--- a/delivery_carrier_preference/models/stock_picking.py
+++ b/delivery_carrier_preference/models/stock_picking.py
@@ -26,6 +26,7 @@ class StockPicking(models.Model):
 
     def add_preferred_carrier(self):
         self.ensure_one()
+        # There is no order, if there is multiple, is it random ?
         carrier = fields.first(self.get_preferred_carriers())
         if not carrier:
             return {


### PR DESCRIPTION
This is PR has only a unit test, trying to reproduce an issue encountered.
WIP