### PR TITLE
Fix error when location has no leaf locations

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -384,6 +384,8 @@ class StockLocation(models.Model):
         Locations are ordered by max height, knowing that a max height of 0
         means "no limit" and as such it should be among the last locations.
         """
+        if not self.leaf_location_ids:
+            return self.leaf_location_ids
         max_height = max(self.leaf_location_ids.mapped("max_height"))
         return self.leaf_location_ids.sorted(
             lambda l: l.max_height if l.max_height else (max_height + 1)


### PR DESCRIPTION
max() cannot be called on an empty iterable, as we have no locations
anyway, return the empty recordset