### PR TITLE
Fix error when a picking has no move lines

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -108,7 +108,12 @@ class StockPicking(models.Model):
     @api.depends("move_lines.date_priority")
     def _compute_date_priority(self):
         for picking in self:
-            picking.date_priority = min(picking.move_lines.mapped("date_priority"))
+            dates = [
+                date_priority
+                for date_priority in picking.move_lines.mapped("date_priority")
+                if date_priority
+            ]
+            picking.date_priority = min(dates) if dates else False
 
     def release_available_to_promise(self):
         # When the stock.picking form view is opened through the "Deliveries"


### PR DESCRIPTION
When computing date_priority, if a picking has no move lines or some
move lines have no date_priority, we can have errors because min()
is called without sequence or compares bool and datetime.