### PR TITLE
[13.0] shopfloor: fix zone picking scan source

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -283,10 +283,8 @@ class MessageAction(Component):
         return {
             "message_type": "warning",
             "body": _(
-                _(
-                    "This product is part of a package with other products, "
-                    "please scan a package."
-                )
+                "This product is part of a package with other products, "
+                "please scan a package."
             ),
         }
 
@@ -306,10 +304,8 @@ class MessageAction(Component):
         return {
             "message_type": "warning",
             "body": _(
-                _(
-                    "This lot is part of a package with other products, "
-                    "please scan a package."
-                )
+                "This lot is part of a package with other products, "
+                "please scan a package."
             ),
         }
 
@@ -436,7 +432,7 @@ class MessageAction(Component):
         return {
             "message_type": "error",
             "body": _(
-                _("Package {} cannot be picked, already moved by transfer {}.")
+                "Package {} cannot be picked, already moved by transfer {}."
             ).format(package.name, picking.name),
         }
 

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -382,31 +382,25 @@ class ZonePicking(Component):
         )
         return self._response_for_select_line(zone_location, picking_type, move_lines)
 
-    def _scan_source_location(
-        self, zone_location, picking_type, location, order="priority"
-    ):
+    def _scan_source_location(self, zone_location, picking_type, location, **kw):
         """Return the move line related to the scanned `location`.
 
         The method tries to identify unambiguously a move line in the location
         if possible, otherwise return `False`.
         """
-        quants = self.env["stock.quant"].search([("location_id", "=", location.id)])
-        product = quants.product_id
-        lot = quants.lot_id
-        package = quants.package_id
-        if len(product) > 1 or len(lot) > 1 or len(package) > 1:
-            return False
         move_lines = self._find_location_move_lines(
-            location,
-            picking_type=picking_type,
-            product=product,
-            package=package,
-            lot=lot,
-            match_user=True,
+            location, picking_type=picking_type, match_user=True, **kw
         )
         if move_lines:
             return first(move_lines)
         return False
+
+    def _find_product_in_location(self, location):
+        quants = self.env["stock.quant"].search([("location_id", "=", location.id)])
+        product = quants.product_id
+        lot = quants.lot_id
+        package = quants.package_id
+        return product, lot, package
 
     def _scan_source_package(self, zone_location, picking_type, package, order):
         move_lines = self._find_location_move_lines(
@@ -461,8 +455,21 @@ class ZonePicking(Component):
                 return self._response_for_start(
                     message=self.msg_store.location_not_allowed()
                 )
+            product, lot, package = self._find_product_in_location(location)
+            if len(product) > 1 or len(lot) > 1 or len(package) > 1:
+                response = self.list_move_lines(location.id, picking_type.id)
+                return self._response(
+                    base_response=response,
+                    message=self.msg_store.several_products_in_location(location),
+                )
             move_line = self._scan_source_location(
-                zone_location, picking_type, location, order=order
+                zone_location,
+                picking_type,
+                location,
+                order=order,
+                product=product,
+                lot=lot,
+                package=package,
             )
             # if no move line, narrow the list of move lines on the scanned location
             if not move_line:

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -240,7 +240,9 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             zone_location=self.zone_sublocation2,
             picking_type=self.picking_type,
             move_lines=move_lines,
-            message=self.service.msg_store.location_empty(self.zone_sublocation2),
+            message=self.service.msg_store.several_products_in_location(
+                self.zone_sublocation2
+            ),
         )
 
     def test_scan_source_barcode_package(self):


### PR DESCRIPTION
When a location is scanned and several items are found
ask to scan a package instead of saying that the location is empty.

The fix is in the 1st commit. The second commit is a small fix on messages declaration and 3rd one is a small refactoring to reduce the complexity of `_scan_source` and avoid searching w/ the same barcode all kind of records.

ref: 1895