### PR TITLE
[FIX] shopfloor: cluster picking, remove unavailable picking from validated batch

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -957,6 +957,11 @@ class ClusterPicking(Component):
                 picking.action_done()
 
     def _unload_end(self, batch, completion_info_popup=None):
+        """Try to close the batch if all transfers are done.
+
+        Returns to `start_line` transition if some lines could still be processed,
+        otherwise try to validate all the transfers of the batch.
+        """
         if all(picking.state == "done" for picking in batch.picking_ids):
             # do not use the 'done()' method because it does many things we
             # don't care about
@@ -979,6 +984,12 @@ class ClusterPicking(Component):
             # produce backorders)
             batch.mapped("picking_ids").action_done()
             batch.state = "done"
+            # Unassign not validated pickings from the batch, they will be
+            # processed in another batch automatically later on
+            pickings_not_done = batch.mapped("picking_ids").filtered(
+                lambda p: p.state != "done"
+            )
+            pickings_not_done.batch_id = False
             return self._response_for_start(
                 message=self.msg_store.batch_transfer_complete(),
                 popup=completion_info_popup,

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -235,6 +235,45 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
             message={"body": "Batch Transfer line done", "message_type": "success"},
         )
 
+    def test_set_destination_all_picking_unassigned(self):
+        """Set destination on lines for some transfers of the batch.
+
+        The remaining transfers stay as unavailable (confirmed) and are removed
+        from the batch when this one is validated.
+        The remaining transfers will be processed later in a new batch.
+        """
+        self.batch.picking_ids.do_unreserve()
+        location = self.one_line_picking.location_id
+        product = self.one_line_picking.move_lines.product_id
+        qty = self.one_line_picking.move_lines.product_uom_qty
+        self._update_qty_in_location(location, product, qty)
+        self.one_line_picking.action_assign()
+        # Prepare lines to process
+        lines = self.one_line_picking.move_line_ids
+        self._set_dest_package_and_done(lines, self.bin1)
+        lines.write({"location_dest_id": self.packing_location.id})
+
+        response = self.service.dispatch(
+            "set_destination_all",
+            params={
+                "picking_batch_id": self.batch.id,
+                "barcode": self.packing_location.barcode,
+            },
+        )
+        # The batch should be done with only one picking.
+        # The remaining picking has been removed from the current batch
+        self.assertRecordValues(self.one_line_picking, [{"state": "done"}])
+        self.assertRecordValues(self.two_lines_picking, [{"state": "confirmed"}])
+        self.assertRecordValues(self.batch, [{"state": "done"}])
+        self.assertEqual(self.one_line_picking.batch_id, self.batch)
+        self.assertFalse(self.two_lines_picking.batch_id)
+
+        self.assert_response(
+            response,
+            next_state="start",
+            message=self.service.msg_store.batch_transfer_complete(),
+        )
+
     def test_set_destination_all_but_different_dest(self):
         """Endpoint was called but destinations are different"""
         move_lines = self.move_lines

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -827,6 +827,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         )
         self.assertEqual(ready_pickings, picking2)
 
+    @freeze_time("2020-12-16 00:00:00")
     def test_picking_type_count(self):
         self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
         out_type = self.wh.out_type_id


### PR DESCRIPTION
Unavailable transfers could be part of a batch (following a stock inventory happening at the same time for instance), as such we have to remove such transfers from the batch picking when this one is validated.
The transfers will be assigned to a new batch thereafter.

Ref. 1836