### PR TITLE
[13.0] Shopfloor: fix zone picking wide screen mode

### DIFF
--- a/shopfloor_mobile/__manifest__.py
+++ b/shopfloor_mobile/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Shopfloor mobile",
     "summary": "Mobile frontend for WMS Shopfloor app",
-    "version": "13.0.1.6.1",
+    "version": "13.0.1.6.2",
     "development_status": "Alpha",
     "depends": ["shopfloor"],
     "author": "Camptocamp, BCIM, Akretion, Odoo Community Association (OCA)",

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -60,14 +60,19 @@ const template_mobile = `
 
                 <template v-slot:item.quantity="{ item }">
                     <packaging-qty-picker-display
+                        :key="make_state_component_key(['qty-picker-widget', item['_origin'].id])"
                         :options="utils.misc.move_line_qty_picker_options(item['_origin'])"
                         />
                 </template>
                 <template v-slot:item.priority="{ item }">
-                    <priority-widget :options="{priority: parseInt(item.priority || '0', 10)}" />
+                    <priority-widget
+                        :key="make_state_component_key(['priority-widget', item['_origin'].id])"
+                        :options="{priority: parseInt(item.priority || '0', 10)}" />
                 </template>
                 <template v-slot:item.location_will_be_empty="{ item }">
-                    <empty-location-icon :record="item" />
+                    <empty-location-icon :record="item"
+                        :key="make_state_component_key(['empty-location-icon', item['_origin'].id])"
+                        />
                 </template>
             </v-data-table>
 


### PR DESCRIPTION
Compute a unique key for custom table widgets
otherwise when changing ordering by location/priority
the widgets are not updated (eg: wrong qty displayed)