### PR TITLE
[13.0] stock_reception_screen: open from move line

### DIFF
--- a/stock_reception_screen/models/stock_move_line.py
+++ b/stock_reception_screen/models/stock_move_line.py
@@ -20,3 +20,8 @@ class StockMoveLine(models.Model):
         self.picking_id.reception_screen_id.next_step()
         # FIXME: don't know how to close the pop-up and refresh the screen
         return self.picking_id.action_reception_screen_open()
+
+    def action_reception_screen_open(self):
+        """Open reception screen from specific move line."""
+        self.picking_id.action_reception_screen_open()
+        return self.action_select_move_line()

--- a/stock_reception_screen/views/stock_move_line.xml
+++ b/stock_reception_screen/views/stock_move_line.xml
@@ -17,4 +17,25 @@
             </field>
         </field>
     </record>
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">stock.move.line.tree.stock.reception.screen</field>
+        <field name="inherit_id" ref="stock.view_move_line_tree" />
+        <field name="model">stock.move.line</field>
+        <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field name="picking_code" invisible="1" />
+                <button
+                    name="action_reception_screen_open"
+                    type="object"
+                    string="Reception"
+                    class="oe_highlight"
+                    attrs="{'invisible': [
+                      '|',
+                      ('picking_code', '!=', 'incoming'),
+                      ('state', 'in', ('cancel', 'done')),
+                    ]}"
+                />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Add a reception button on the stock.move.line tree view to open the
reception screen.