### PR TITLE
[IMP] shopfloor: create backorder when validating moves

### DIFF
--- a/shopfloor/actions/__init__.py
+++ b/shopfloor/actions/__init__.py
@@ -27,3 +27,4 @@ from . import search
 from . import inventory
 from . import savepoint
 from . import move_line_search
+from . import stock

--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -1,0 +1,41 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.component.core import Component
+
+
+class StockAction(Component):
+    """Provide methods to work with stock operations."""
+
+    _name = "shopfloor.stock.action"
+    _inherit = "shopfloor.process.action"
+    _usage = "stock"
+
+    def validate_moves(self, moves):
+        """Validate moves in different ways depending on several criterias:
+
+        - moves to process are all the moves of the related transfer:
+            the current transfer is validated
+        - moves to process are a subset of available moves in the picking:
+            the moves are put in a new transfer which is validated, the current
+            transfer still have the remaining moves
+        - moves to process are exactly the assigned moves of the related transfer:
+            the transfer is validated as usual, creating a backorder.
+        """
+        moves.split_unavailable_qty()
+        for picking in moves.picking_id:
+            moves_todo = picking.move_lines & moves
+            if self._check_backorder(picking, moves_todo):
+                picking.action_done()
+            else:
+                moves_todo.extract_and_action_done()
+
+    def _check_backorder(self, picking, moves):
+        """Check if the `picking` has to be validated as usual to create a backorder.
+
+        If the moves are equal to all available moves of the current picking
+        - but there are still unavailable moves to process - then we want to
+        create a normal backorder (i.e. the current picking is validated and
+        the remaining moves are put in a backorder as usual)
+        """
+        assigned_moves = picking.move_lines.filtered(lambda m: m.state == "assigned")
+        return moves == assigned_moves

--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -37,6 +37,15 @@ class StockMove(models.Model):
             return backorder_move
         return False
 
+    def split_unavailable_qty(self):
+        """Put unavailable qty of a partially available move in their own
+        move (which will be 'confirmed').
+        """
+        partial_moves = self.filtered(lambda m: m.state == "partially_available")
+        for partial_move in partial_moves:
+            partial_move.split_other_move_lines(partial_move.move_line_ids)
+        return partial_moves
+
     def extract_and_action_done(self):
         """Extract the moves in a separate transfer and validate them.
 
@@ -44,20 +53,19 @@ class StockMove(models.Model):
         to first extract some move lines in a separate move, then validate it
         with this method.
         """
-        # Put remaining qty to process from partially available moves
-        # in their own move (which will be then 'confirmed')
-        partial_moves = self.filtered(lambda m: m.state == "partially_available")
-        for partial_move in partial_moves:
-            partial_move.split_other_move_lines(partial_move.move_line_ids)
         # Process assigned moves
         moves = self.filtered(lambda m: m.state == "assigned")
         if not moves:
             return False
         for picking in moves.picking_id:
             moves_todo = picking.move_lines & moves
+            # No need to create a new transfer if we are processing all moves
             if moves_todo == picking.move_lines:
-                # No need to create a new transfer if we are processing all moves
                 new_picking = picking
+            # We process some available moves of the picking, but there are still
+            # some other moves to process, then we put the moves to process in
+            # a new transfer to validate. All remaining moves stay in the
+            # current transfer.
             else:
                 new_picking = picking.copy(
                     {

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -656,7 +656,8 @@ class LocationContentTransfer(Component):
             # split the move to process only the lines related to the package.
             package_move.split_other_move_lines(package_move_lines)
         self._write_destination_on_lines(package_level.move_line_ids, scanned_location)
-        package_moves.extract_and_action_done()
+        stock = self.actions_for("stock")
+        stock.validate_moves(package_moves)
         move_lines = self._find_transfer_move_lines(location)
         message = self.msg_store.location_content_transfer_item_complete(
             scanned_location
@@ -730,7 +731,8 @@ class LocationContentTransfer(Component):
                 remaining_move_line.qty_done = remaining_move_line.product_uom_qty
         move_line.move_id.split_other_move_lines(move_line)
         self._write_destination_on_lines(move_line, scanned_location)
-        move_line.move_id.extract_and_action_done()
+        stock = self.actions_for("stock")
+        stock.validate_moves(move_line.move_id)
         move_lines = self._find_transfer_move_lines(location)
         message = self.msg_store.location_content_transfer_item_complete(
             scanned_location

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -259,7 +259,8 @@ class SinglePackTransfer(Component):
         # when writing the destination on the package level, it writes
         # on the move lines
         move.move_line_ids.package_level_id.location_dest_id = scanned_location
-        move.extract_and_action_done()
+        stock = self.actions_for("stock")
+        stock.validate_moves(move)
 
     def cancel(self, package_level_id):
         package_level = self.env["stock.package_level"].browse(package_level_id)

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -566,7 +566,8 @@ class ZonePicking(Component):
         # try to re-assign any split move (in case of partial qty)
         if "confirmed" in move_line.picking_id.move_lines.mapped("state"):
             move_line.picking_id.action_assign()
-        move_line.move_id.extract_and_action_done()
+        stock = self.actions_for("stock")
+        stock.validate_moves(move_line.move_id)
         location_changed = True
         # Zero check
         zero_check = picking_type.shopfloor_zero_check
@@ -1095,7 +1096,8 @@ class ZonePicking(Component):
             self._write_destination_on_lines(buffer_lines, location)
             # set lines to done + refresh buffer lines (should be empty)
             moves = buffer_lines.mapped("move_id")
-            moves.extract_and_action_done()
+            stock = self.actions_for("stock")
+            stock.validate_moves(moves)
             message = self.msg_store.buffer_complete()
             buffer_lines = self._find_buffer_move_lines(zone_location, picking_type)
         else:
@@ -1302,7 +1304,8 @@ class ZonePicking(Component):
             for move in moves:
                 move.split_other_move_lines(buffer_lines & move.move_line_ids)
 
-            moves.extract_and_action_done()
+            stock = self.actions_for("stock")
+            stock.validate_moves(moves)
             buffer_lines = self._find_buffer_move_lines(zone_location, picking_type)
 
             if buffer_lines:

--- a/shopfloor/tests/test_stock_split.py
+++ b/shopfloor/tests/test_stock_split.py
@@ -171,7 +171,7 @@ class TestStockSplit(SavepointCase):
             set(self.pack_move_a.move_line_ids.mapped("state")), {"assigned"}
         )
 
-    def test_extract_and_action_done_one_move(self):
+    def test_extract_and_action_done_one_assigned_move(self):
         self.assertFalse(self.picking.backorder_ids)
         self.assertEqual(self.picking.state, "assigned")
         for move_line in self.pick_move_b.move_line_ids:
@@ -187,7 +187,7 @@ class TestStockSplit(SavepointCase):
         self.assertEqual(self.pick_move_b.state, "done")
         self.assertEqual(new_picking.state, "done")
 
-    def test_extract_and_action_done_several_moves(self):
+    def test_extract_and_action_done_multiple_assigned_moves(self):
         self.assertFalse(self.picking.backorder_ids)
         self.assertEqual(self.picking.state, "assigned")
         for move_line in self.picking.move_line_ids:

--- a/shopfloor/tests/test_zone_picking_unload_all.py
+++ b/shopfloor/tests/test_zone_picking_unload_all.py
@@ -262,7 +262,7 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         )
         # check data
         #   picking validated
-        picking_validated = self.picking6.backorder_ids
+        picking_validated = self.picking6
         self.assertEqual(picking_validated.state, "done")
         self.assertEqual(picking_validated.move_line_ids, move_line_g | move_line_h)
         self.assertEqual(move_line_g.state, "done")
@@ -270,10 +270,11 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         self.assertEqual(move_line_h.state, "done")
         self.assertEqual(move_line_h.qty_done, 3)
         #   current picking (backorder)
-        self.assertEqual(self.picking6.state, "confirmed")
-        self.assertEqual(self.picking6.move_lines.product_id, self.product_h)
-        self.assertEqual(self.picking6.move_lines.product_uom_qty, 3)
-        self.assertFalse(self.picking6.move_line_ids)
+        backorder = self.picking6.backorder_ids
+        self.assertEqual(backorder.state, "confirmed")
+        self.assertEqual(backorder.move_lines.product_id, self.product_h)
+        self.assertEqual(backorder.move_lines.product_uom_qty, 3)
+        self.assertFalse(backorder.move_line_ids)
         # buffer should be empty
         buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
         self.assertFalse(buffer_lines)

--- a/shopfloor/tests/test_zone_picking_unload_set_destination.py
+++ b/shopfloor/tests/test_zone_picking_unload_set_destination.py
@@ -359,11 +359,13 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         )
         # check data
         # move line has been moved to a new picking
-        self.assertEqual(move_line.move_id.picking_id, self.picking_z.backorder_ids[0])
-        # the old picking contains a new line w/ the rest of the qty
+        # move line has been validated in the current picking
+        self.assertEqual(move_line.move_id.picking_id, self.picking_z)
+        # the new picking (backorder) contains a new line w/ the rest of the qty
         # that couldn't be processed
-        self.assertEqual(self.picking_z.move_lines[0].product_uom_qty, 8)
-        self.assertEqual(self.picking_z.state, "confirmed")
+        backorder = self.picking_z.backorder_ids[0]
+        self.assertEqual(backorder.move_lines[0].product_uom_qty, 8)
+        self.assertEqual(backorder.state, "confirmed")
         # the line has been processed
         self.assertEqual(move_line.location_dest_id, packing_sublocation)
         self.assertEqual(move_line.move_id.state, "done")


### PR DESCRIPTION
**Before**: when moves are processed, we were managing two cases:

- if the current moves to process are all the moves remaining in a
  transfer, we validate the transfer

- if the current moves to process are a subset of available moves of a
  transfer, then we put these moves to process in a new transfer which
  is validated. All remaining moves stay in the current transfer.

**After**: a third case is added:

- if the current moves to process are equal to all available moves of
  the current picking - but there are still unavailable moves to process -
  then we validate the current transfer as usual, which will create a
  backorder with remaining/unavailable moves.

As this third case is very specific to Shopfloor, it has been implemented in a new `StockAction` component (used by all related scenarios).
Now all scenarios use this new component to validate stock moves, and the `extract_and_action_done` method on `stock.move` can stay generic.
The opportunity was taken to create a new method `split_unavailable_qty` on `stock.move` to put unavailable qty to a new move and update the current move to `assigned` (it was done directly in `extract_and_action_done` before).