### PR TITLE
[FIX] shopfloor_mobile, delivery, rename button 'Mark as done' to 'Make partial delivery'

### DIFF
--- a/shopfloor_mobile/static/wms/src/scenario/delivery.js
+++ b/shopfloor_mobile/static/wms/src/scenario/delivery.js
@@ -33,7 +33,7 @@ const Delivery = {
             <div class="button-list button-vertical-list full">
                 <v-row align="center" v-if="state_is('deliver') && has_picking()">
                     <v-col class="text-center" cols="12">
-                        <btn-action @click="state.on_mark_as_done">Mark as done</btn-action>
+                        <btn-action @click="state.on_mark_as_done">Make partial delivery</btn-action>
                     </v-col>
                 </v-row>
                 <v-row align="center" v-if="state_in([initial_state_key, 'deliver'])">


### PR DESCRIPTION
Because as soon as all lines are processed (qty done filled), the related transfer is automatically validated. So the current button only serves one purpose: creating a partial delivery.

Ref. 1783.