### PR TITLE
[13.0] Shopfloor: zone picking refactor shared vars handling

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.2.1.2",
+    "version": "13.0.2.2.0",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",

--- a/shopfloor/tests/test_location_content_transfer_mix.py
+++ b/shopfloor/tests/test_location_content_transfer_mix.py
@@ -96,6 +96,8 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
         picking = move_line.picking_id
         zone_location = picking.location_id
         picking_type = picking.picking_type_id
+        self.zp_service.work.current_zone_location = zone_location
+        self.zp_service.work.current_picking_type = picking_type
         move_lines = picking.move_line_ids.filtered(
             lambda m: m.state not in ("cancel", "done")
         )
@@ -107,11 +109,7 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
         assert picking_type.id in available_picking_type_ids
         assert "message" not in response
         # Check the move lines related to the picking type
-        response = self.zp_service.list_move_lines(
-            zone_location_id=zone_location.id,
-            picking_type_id=picking_type.id,
-            order="priority",
-        )
+        response = self.zp_service.list_move_lines()
         available_move_line_ids = [
             r["id"] for r in response["data"]["select_line"]["move_lines"]
         ]
@@ -122,12 +120,7 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
             dest_location = move_line.location_dest_id
         qty = move_line.product_uom_qty
         response = self.zp_service.set_destination(
-            zone_location.id,
-            picking_type.id,
-            move_line.id,
-            dest_location.barcode,
-            qty,
-            confirmation=True,
+            move_line.id, dest_location.barcode, qty, confirmation=True,
         )
         assert response["message"]["message_type"] == "success"
         self.assertEqual(move_line.state, "done")

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -249,7 +249,12 @@ class ZonePickingCommonCase(CommonCase):
 
     def setUp(self):
         super().setUp()
-        with self.work_on_services(menu=self.menu, profile=self.profile) as work:
+        with self.work_on_services(
+            menu=self.menu,
+            profile=self.profile,
+            current_zone_location=self.zone_location,
+            current_picking_type=self.picking_type,
+        ) as work:
             self.service = work.component(usage="zone_picking")
 
     def _assert_response_select_zone(self, response, zone_locations, message=None):

--- a/shopfloor/tests/test_zone_picking_change_pack_lot.py
+++ b/shopfloor/tests/test_zone_picking_change_pack_lot.py
@@ -12,47 +12,6 @@ class ZonePickingChangePackLotCase(ZonePickingCommonCase):
     error, the "change.package.lot" component is tested in its own tests.
     """
 
-    def test_change_pack_lot_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        move_line = self.picking1.move_line_ids[0]
-        response = self.service.dispatch(
-            "change_pack_lot",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-                "barcode": self.free_lot.name,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "change_pack_lot",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "move_line_id": move_line.id,
-                "barcode": self.free_lot.name,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "change_pack_lot",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": 1234567890,
-                "barcode": self.free_lot.name,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-
     def test_change_pack_lot_no_package_or_lot_for_barcode(self):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -14,9 +14,11 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
 
     """
 
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
     def test_list_move_lines_order(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         self.zone_sublocation2.name = "AAA " + self.zone_sublocation2.name
 
         # Test by location
@@ -32,27 +34,24 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         move2.write({"date_expected": future})
         move2_line = move2.move_line_ids[0]
 
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, order="location"
-        )
+        self.service.work.current_lines_order = "location"
+        move_lines = self.service._find_location_move_lines()
         order_mapping = {line: i for i, line in enumerate(move_lines)}
         self.assertTrue(order_mapping[move1_line] < order_mapping[move2_line])
 
         # swap dates
         move2.write({"date_expected": today})
         move1.write({"date_expected": future})
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, order="location"
-        )
+        move_lines = self.service._find_location_move_lines()
         order_mapping = {line: i for i, line in enumerate(move_lines)}
         self.assertTrue(order_mapping[move1_line] > order_mapping[move2_line])
 
         # Test by priority
         self.picking2.move_lines.write({"priority": "0"})
         (self.pickings - self.picking2).move_lines.write({"priority": "2"})
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, order="priority"
-        )
+
+        self.service.work.current_lines_order = "priority"
+        move_lines = self.service._find_location_move_lines()
         order_mapping = {line: i for i, line in enumerate(move_lines)}
         # picking2 lines stay at the end as they are low priority
         # but move1_line comes before the other
@@ -63,86 +62,36 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         move1.write({"date_expected": today})
         # and increase priority
         self.picking2.move_lines.write({"priority": "3"})
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, order="priority"
-        )
+        move_lines = self.service._find_location_move_lines()
         order_mapping = {line: i for i, line in enumerate(move_lines)}
         self.assertEqual(order_mapping[move1_line], 0)
         self.assertEqual(order_mapping[move2_line], 1)
 
     def test_list_move_lines_order_by_location(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        response = self.service.dispatch(
-            "list_move_lines",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "order": "location",
-            },
-        )
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, order="location"
-        )
+        self.service.work.current_lines_order = "location"
+        response = self.service.dispatch("list_move_lines", params={})
+        move_lines = self.service._find_location_move_lines()
+        res = [
+            x["location_src"]["name"]
+            for x in response["data"]["select_line"]["move_lines"]
+        ]
+        self.assertEqual(res, [x.location_id.name for x in move_lines])
+        self.maxDiff = None
         self.assert_response_select_line(
-            response, zone_location, picking_type, move_lines,
+            response, self.zone_location, self.picking1.picking_type_id, move_lines,
         )
 
     def test_list_move_lines_order_by_priority(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        response = self.service.dispatch(
-            "list_move_lines",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "order": "priority",
-            },
-        )
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, order="priority"
-        )
+        response = self.service.dispatch("list_move_lines", params={})
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
-            response, zone_location, picking_type, move_lines,
-        )
-
-    def test_scan_source_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "barcode": self.zone_sublocation1.barcode,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "barcode": self.zone_sublocation1.barcode,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
+            response, self.zone_location, self.picking_type, move_lines,
         )
 
     def test_scan_source_barcode_location_not_allowed(self):
         """Scan source: scanned location not allowed."""
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.customer_location.barcode,
-            },
+            "scan_source", params={"barcode": self.customer_location.barcode},
         )
         self.assert_response_start(
             response, message=self.service.msg_store.location_not_allowed(),
@@ -152,15 +101,8 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned location 'Zone sub-location 1' contains only
         one move line, next step 'set_line_destination' expected.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.zone_sublocation1.barcode,
-            },
+            "scan_source", params={"barcode": self.zone_sublocation1.barcode},
         )
         move_line = self.picking1.move_line_ids
         self.assert_response_set_line_destination(
@@ -183,15 +125,8 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             new_picking.move_lines, in_package=package, location=self.zone_sublocation1
         )
         new_picking.action_assign()
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.zone_sublocation1.barcode,
-            },
+            "scan_source", params={"barcode": self.zone_sublocation1.barcode},
         )
         move_line = self.picking1.move_line_ids
         self.assert_response_set_line_destination(
@@ -204,12 +139,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         move_line.qty_done = move_line.product_uom_qty
         # get the next one
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.zone_sublocation1.barcode,
-            },
+            "scan_source", params={"barcode": self.zone_sublocation1.barcode},
         )
         move_line = new_picking.move_line_ids
         self.assert_response_set_line_destination(
@@ -224,20 +154,13 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         move lines, next step 'select_line' expected with the list of these
         move lines.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.zone_sublocation2.barcode,
-            },
+            "scan_source", params={"barcode": self.zone_sublocation2.barcode},
         )
         move_lines = self.picking2.move_line_ids
         self.assert_response_select_line(
             response,
-            zone_location=self.zone_sublocation2,
+            zone_location=self.zone_location,
             picking_type=self.picking_type,
             move_lines=move_lines,
             message=self.service.msg_store.several_products_in_location(
@@ -249,20 +172,11 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned package has one related move line,
         next step 'set_line_destination' expected on it.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         package = self.picking1.package_level_ids[0].package_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": package.name,
-            },
+            "scan_source", params={"barcode": package.name},
         )
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, package=package,
-        )
+        move_lines = self.service._find_location_move_lines(package=package,)
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         move_line = move_lines[0]
         self.assert_response_set_line_destination(
@@ -276,17 +190,10 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned package has no related move line,
         next step 'select_line' expected.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.free_package.name,
-            },
+            "scan_source", params={"barcode": self.free_package.name},
         )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -300,19 +207,10 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned product has one related move line,
         next step 'set_line_destination' expected on it.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.product_a.barcode,
-            },
+            "scan_source", params={"barcode": self.product_a.barcode},
         )
-        move_line = self.service._find_location_move_lines(
-            zone_location, picking_type, product=self.product_a,
-        )
+        move_line = self.service._find_location_move_lines(product=self.product_a,)
         self.assert_response_set_line_destination(
             response,
             zone_location=self.zone_location,
@@ -324,17 +222,10 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned product has no related move line,
         next step 'select_line' expected.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.free_product.barcode,
-            },
+            "scan_source", params={"barcode": self.free_product.barcode},
         )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -348,20 +239,9 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned lot has one related move line,
         next step 'set_line_destination' expected on it.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         lot = self.picking2.move_line_ids.lot_id[0]
-        response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": lot.name,
-            },
-        )
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, lot=lot,
-        )
+        response = self.service.dispatch("scan_source", params={"barcode": lot.name},)
+        move_lines = self.service._find_location_move_lines(lot=lot)
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         move_line = move_lines[0]
         self.assert_response_set_line_destination(
@@ -375,17 +255,10 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned lot has no related move line,
         next step 'select_line' expected.
         """
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "scan_source",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.free_lot.name,
-            },
+            "scan_source", params={"barcode": self.free_lot.name},
         )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -396,17 +269,15 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         )
 
     def test_scan_source_barcode_not_found(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
             "scan_source",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
+                "zone_location_id": self.zone_location.id,
+                "picking_type_id": self.picking_type.id,
                 "barcode": "UNKNOWN",
             },
         )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location=self.zone_location,
@@ -422,110 +293,60 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         The second user scans the same source location, and should not find any line.
         """
         # The first user starts to process the only line available
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         #   - scan source
-        response = self.service.scan_source(
-            zone_location.id, picking_type.id, self.zone_sublocation1.barcode,
-        )
+        response = self.service.scan_source(self.zone_sublocation1.barcode,)
         move_line = self.picking1.move_line_ids
         self.assertEqual(response["next_state"], "set_line_destination")
         #   - set destination
         self.service.set_destination(
-            zone_location.id,
-            picking_type.id,
-            move_line.id,
-            self.free_package.name,
-            move_line.product_uom_qty,
+            move_line.id, self.free_package.name, move_line.product_uom_qty,
         )
         self.assertEqual(move_line.shopfloor_user_id, self.env.user)
         # The second user scans the same source location
         env = self.env(user=self.stock_user2)
         with self.work_on_services(
-            env=env, menu=self.menu, profile=self.profile
+            env=env,
+            menu=self.menu,
+            profile=self.profile,
+            current_zone_location=self.zone_location,
+            current_picking_type=self.picking_type,
         ) as work:
             service = work.component(usage="zone_picking")
-            response = service.scan_source(
-                zone_location.id, picking_type.id, self.zone_sublocation1.barcode,
-            )
+            response = service.scan_source(self.zone_sublocation1.barcode,)
             self.assertEqual(response["next_state"], "select_line")
             self.assertEqual(
                 response["message"],
                 self.service.msg_store.location_empty(self.zone_sublocation1),
             )
 
-    def test_prepare_unload_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        response = self.service.dispatch(
-            "prepare_unload",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "prepare_unload",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-
     def test_prepare_unload_buffer_empty(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         # unload goods
-        response = self.service.dispatch(
-            "prepare_unload",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-            },
-        )
+        response = self.service.dispatch("prepare_unload", params={},)
         # check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
-            response, zone_location, picking_type, move_lines,
+            response, self.zone_location, self.picking_type, move_lines,
         )
 
     def test_prepare_unload_buffer_one_line(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         # scan a destination package to get something in the buffer
         move_line = self.picking1.move_line_ids
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.free_package.name,
                 "quantity": move_line.product_uom_qty,
             },
         )
         # unload goods
-        response = self.service.dispatch(
-            "prepare_unload",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-            },
-        )
+        response = self.service.dispatch("prepare_unload", params={},)
         # check response
         self.assert_response_unload_set_destination(
-            response, zone_location, picking_type, move_line,
+            response, self.zone_location, self.picking_type, move_line,
         )
 
     def test_prepare_unload_buffer_multi_line_same_destination(self):
-        zone_location = self.zone_location
-        picking_type = self.picking5.picking_type_id
         # scan a destination package for some move lines
         # to get several lines in the buffer (which have the same destination)
         self.another_package = self.env["stock.quant.package"].create(
@@ -540,42 +361,29 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             self.service.dispatch(
                 "set_destination",
                 params={
-                    "zone_location_id": zone_location.id,
-                    "picking_type_id": picking_type.id,
                     "move_line_id": move_line.id,
                     "barcode": package_dest.name,
                     "quantity": move_line.product_uom_qty,
                 },
             )
         # unload goods
-        response = self.service.dispatch(
-            "prepare_unload",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-            },
-        )
+        response = self.service.dispatch("prepare_unload", params={},)
         # check response
         self.assert_response_unload_all(
-            response, zone_location, picking_type, self.picking5.move_line_ids,
+            response,
+            self.zone_location,
+            self.picking_type,
+            self.picking5.move_line_ids,
         )
 
     def test_list_move_lines_empty_location(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         response = self.service.dispatch(
-            "list_move_lines",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "order": "location",
-            },
+            "list_move_lines", params={"order": "location"},
         )
-        move_lines = self.service._find_location_move_lines(
-            zone_location, picking_type, order="location"
-        )
+        # TODO: order by location?
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
-            response, zone_location, picking_type, move_lines,
+            response, self.zone_location, self.picking_type, move_lines,
         )
         data_move_lines = response["data"]["select_line"]["move_lines"]
         # Check that the move line in "Zone sub-location 1" is about to empty

--- a/shopfloor/tests/test_zone_picking_select_picking_type.py
+++ b/shopfloor/tests/test_zone_picking_select_picking_type.py
@@ -10,30 +10,6 @@ class ZonePickingSelectPickingTypeCase(ZonePickingCommonCase):
 
     """
 
-    def test_list_move_lines_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        response = self.service.dispatch(
-            "list_move_lines",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "list_move_lines",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-
     def test_list_move_lines_ok(self):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -10,43 +10,15 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
 
     """
 
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
     def test_set_destination_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids[0]
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-                "barcode": self.packing_location.barcode,
-                "quantity": move_line.product_uom_qty,
-                "confirmation": False,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "set_destination",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "move_line_id": move_line.id,
-                "barcode": self.packing_location.barcode,
-                "quantity": move_line.product_uom_qty,
-                "confirmation": False,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "set_destination",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": 1234567890,
                 "barcode": self.packing_location.barcode,
                 "quantity": move_line.product_uom_qty,
@@ -69,8 +41,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.packing_location.barcode,
                 "quantity": move_line.product_uom_qty,
@@ -92,8 +62,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.customer_location.barcode,
                 "quantity": move_line.product_uom_qty,
@@ -112,8 +80,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.packing_location.barcode,
                 "quantity": move_line.product_uom_qty,
@@ -121,7 +87,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
             },
         )
         # Check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -142,8 +108,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.packing_sublocation_b.barcode,
                 "quantity": move_line.product_uom_qty,
@@ -183,8 +147,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.packing_location.barcode,
                 "quantity": move_line.product_uom_qty,
@@ -197,7 +159,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         self.assertEqual(moves_before, moves_after)
         self.assertEqual(move_line.qty_done, 10)
         # Check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -234,8 +196,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": barcode,
                 "quantity": 6,
@@ -281,8 +241,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.packing_location.barcode,
                 "quantity": move_line.product_uom_qty,  # 6 qty
@@ -306,7 +264,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         self.assertEqual(move_line.qty_done, 6)
         self.assertNotEqual(move_line.move_id, other_move_line.move_id)
         # Check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -345,8 +303,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": barcode,
                 "quantity": 4,  # 4/6 qty
@@ -377,8 +333,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.packing_location.barcode,
                 "quantity": move_line.product_uom_qty,
@@ -413,8 +367,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.free_package.name,
                 "quantity": move_line.product_uom_qty,
@@ -436,7 +388,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
             ],
         )
         # Check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -469,8 +421,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.free_package.name,
                 "quantity": 6,
@@ -507,7 +457,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
             ],
         )
         # Check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
@@ -533,8 +483,6 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "move_line_id": move_line.id,
                 "barcode": self.free_package.name,
                 "quantity": move_line.product_uom_qty,

--- a/shopfloor/tests/test_zone_picking_stock_issue.py
+++ b/shopfloor/tests/test_zone_picking_stock_issue.py
@@ -10,39 +10,13 @@ class ZonePickingStockIssueCase(ZonePickingCommonCase):
 
     """
 
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
     def test_stock_issue_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        move_line = self.picking1.move_line_ids[0]
         response = self.service.dispatch(
-            "stock_issue",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "stock_issue",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "move_line_id": move_line.id,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "stock_issue",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": 1234567890,
-            },
+            "stock_issue", params={"move_line_id": 1234567890},
         )
         self.assert_response_start(
             response, message=self.service.msg_store.record_not_found(),
@@ -54,16 +28,11 @@ class ZonePickingStockIssueCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids[0]
         move = move_line.move_id
         response = self.service.dispatch(
-            "stock_issue",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-            },
+            "stock_issue", params={"move_line_id": move_line.id},
         )
         self.assertFalse(move_line.exists())
         self.assertFalse(move.move_line_ids)
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response, zone_location, picking_type, move_lines,
         )
@@ -76,16 +45,11 @@ class ZonePickingStockIssueCase(ZonePickingCommonCase):
         location = move_line.location_id
         move = move_line.move_id
         response = self.service.dispatch(
-            "stock_issue",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-            },
+            "stock_issue", params={"move_line_id": move_line.id},
         )
         self.assertFalse(move_line.exists())
         self.assertFalse(move.move_line_ids)
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response, zone_location, picking_type, move_lines,
         )
@@ -118,12 +82,7 @@ class ZonePickingStockIssueCase(ZonePickingCommonCase):
         # Increase the quantity in the current location
         self._update_qty_in_location(location, move.product_id, 100)
         response = self.service.dispatch(
-            "stock_issue",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-            },
+            "stock_issue", params={"move_line_id": move_line.id},
         )
         self.assertFalse(move_line.exists())
         self.assertTrue(move.move_line_ids)
@@ -162,12 +121,7 @@ class ZonePickingStockIssueCase(ZonePickingCommonCase):
         # Put some quantity in another location to get a new reservations from there
         self._update_qty_in_location(self.zone_sublocation2, move.product_id, 10)
         response = self.service.dispatch(
-            "stock_issue",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-            },
+            "stock_issue", params={"move_line_id": move_line.id},
         )
         self.assertFalse(move_line.exists())
         self.assertTrue(move.move_line_ids)

--- a/shopfloor/tests/test_zone_picking_unload_all.py
+++ b/shopfloor/tests/test_zone_picking_unload_all.py
@@ -11,31 +11,9 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
 
     """
 
-    def test_set_destination_all_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "barcode": "UNKNOWN",
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "barcode": "UNKNOWN",
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
 
     def test_set_destination_all_different_destination(self):
         zone_location = self.zone_location
@@ -49,18 +27,10 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         move_line2.location_dest_id = self.zone_sublocation3
         # set the destination package on lines
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line1,
-            move_line1.product_uom_qty,
-            self.free_package,
+            move_line1, move_line1.product_uom_qty, self.free_package,
         )
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line2,
-            move_line2.product_uom_qty,
-            another_package,
+            move_line2, move_line2.product_uom_qty, another_package,
         )
         # set destination location for all lines in the buffer
         response = self.service.dispatch(
@@ -72,7 +42,7 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
             },
         )
         # check response
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         self.assert_response_unload_all(
             response,
             zone_location,
@@ -113,18 +83,10 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         )
         # set the destination package on lines
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line1,
-            move_line1.product_uom_qty,
-            self.free_package,
+            move_line1, move_line1.product_uom_qty, self.free_package,
         )
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line2,
-            move_line2.product_uom_qty,
-            another_package,
+            move_line2, move_line2.product_uom_qty, another_package,
         )
         # set an allowed destination location (inside the picking type default
         # destination location) for all lines in the buffer with a non-expected
@@ -132,15 +94,10 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         # lines destination
         (move_line1 | move_line2).location_dest_id = packing_sublocation1
         response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": packing_sublocation2.barcode,
-            },
+            "set_destination_all", params={"barcode": packing_sublocation2.barcode},
         )
         # check response: this destination needs the user confirmation
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         self.assert_response_unload_all(
             response,
             zone_location,
@@ -156,15 +113,10 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         # meaning a destination which is a child of the current buffer lines
         # destination
         response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": packing_sublocation1.barcode,
-            },
+            "set_destination_all", params={"barcode": packing_sublocation1.barcode},
         )
         # check response: OK
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,
@@ -183,35 +135,22 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         )
         # set the destination package on lines
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line1,
-            move_line1.product_uom_qty,
-            self.free_package,
+            move_line1, move_line1.product_uom_qty, self.free_package,
         )
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line2,
-            move_line2.product_uom_qty,
-            another_package,
+            move_line2, move_line2.product_uom_qty, another_package,
         )
         # set destination location for all lines in the buffer
         response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.packing_location.barcode,
-            },
+            "set_destination_all", params={"barcode": self.packing_location.barcode},
         )
         # check data
         self.assertEqual(self.picking5.state, "done")
         # buffer should be empty
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         self.assertFalse(buffer_lines)
         # check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,
@@ -238,27 +177,14 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         )
         # set the destination package on lines
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line_g,
-            move_line_g.product_uom_qty,
-            self.free_package,
+            move_line_g, move_line_g.product_uom_qty, self.free_package,
         )
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line_h,
-            move_line_h.product_uom_qty,  # partial qty
-            another_package,
+            move_line_h, move_line_h.product_uom_qty, another_package,  # partial qty
         )
         # set destination location for all lines in the buffer
         response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.packing_location.barcode,
-            },
+            "set_destination_all", params={"barcode": self.packing_location.barcode},
         )
         # check data
         #   picking validated
@@ -276,10 +202,10 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         self.assertEqual(backorder.move_lines.product_uom_qty, 3)
         self.assertFalse(backorder.move_line_ids)
         # buffer should be empty
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         self.assertFalse(buffer_lines)
         # check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,
@@ -294,22 +220,13 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids
         # set the destination package on lines
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": self.customer_location.barcode,
-            },
+            "set_destination_all", params={"barcode": self.customer_location.barcode},
         )
         # check response
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         self.assert_response_unload_all(
             response,
             zone_location,
@@ -324,22 +241,13 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids
         # set the destination package on lines
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
-            "set_destination_all",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "barcode": "UNKNOWN",
-            },
+            "set_destination_all", params={"barcode": "UNKNOWN"},
         )
         # check response
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         self.assert_response_unload_all(
             response,
             zone_location,
@@ -351,15 +259,9 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
     def test_unload_split_buffer_empty(self):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id
-        response = self.service.dispatch(
-            "unload_split",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-            },
-        )
+        response = self.service.dispatch("unload_split", params={},)
         # check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,
@@ -374,21 +276,11 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids
         # put one line in the buffer
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
-        response = self.service.dispatch(
-            "unload_split",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-            },
-        )
+        response = self.service.dispatch("unload_split", params={},)
         # check response
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         self.assert_response_unload_set_destination(
             response, zone_location, picking_type, buffer_lines,
         )
@@ -405,21 +297,11 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
             self.picking5.move_line_ids, self.free_package | self.another_package
         ):
             self.service._set_destination_package(
-                zone_location,
-                picking_type,
-                move_line,
-                move_line.product_uom_qty,
-                package_dest,
+                move_line, move_line.product_uom_qty, package_dest,
             )
-        response = self.service.dispatch(
-            "unload_split",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-            },
-        )
+        response = self.service.dispatch("unload_split", params={},)
         # check response
-        buffer_lines = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_lines = self.service._find_buffer_move_lines()
         completion_info = self.service.actions_for("completion.info")
         completion_info_popup = completion_info.popup(buffer_lines)
         self.assert_response_unload_single(

--- a/shopfloor/tests/test_zone_picking_unload_set_destination.py
+++ b/shopfloor/tests/test_zone_picking_unload_set_destination.py
@@ -29,45 +29,18 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         cls.picking_z = cls._create_picking(lines=[(cls.product_z, 40)])
         cls._update_qty_in_location(cls.zone_sublocation1, cls.product_z, 32)
 
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
     def test_unload_set_destination_wrong_parameters(self):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id
-        move_line = self.picking1.move_line_ids
-        package = move_line.package_id
         response = self.service.dispatch(
             "unload_set_destination",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "package_id": package.id,
-                "barcode": "BARCODE",
-            },
+            params={"package_id": 1234567890, "barcode": "BARCODE"},
         )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "unload_set_destination",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "package_id": package.id,
-                "barcode": "BARCODE",
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "unload_set_destination",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "package_id": 1234567890,
-                "barcode": "BARCODE",
-            },
-        )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,
@@ -82,20 +55,11 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
             "unload_set_destination",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "package_id": self.free_package.id,
-                "barcode": "UNKNOWN",
-            },
+            params={"package_id": self.free_package.id, "barcode": "UNKNOWN"},
         )
         self.assert_response_unload_set_destination(
             response,
@@ -111,17 +75,11 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
             "unload_set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": self.free_package.id,
                 "barcode": self.customer_location.barcode,
             },
@@ -141,11 +99,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         move_line[0].move_id.location_dest_id = self.packing_sublocation_a
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
             "unload_set_destination",
@@ -192,18 +146,12 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         )
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         move_line.location_dest_id = packing_sublocation1
         response = self.service.dispatch(
             "unload_set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": self.free_package.id,
                 "barcode": packing_sublocation2.barcode,
             },
@@ -236,17 +184,11 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         )
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
             "unload_set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": self.free_package.id,
                 "barcode": packing_sublocation.barcode,
                 "confirmation": True,
@@ -256,7 +198,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         self.assertEqual(move_line.location_dest_id, packing_sublocation)
         self.assertEqual(move_line.move_id.state, "done")
         # check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,
@@ -277,11 +219,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
             move_lines, self.free_package | self.another_package
         ):
             self.service._set_destination_package(
-                zone_location,
-                picking_type,
-                move_line,
-                move_line.product_uom_qty,
-                package_dest,
+                move_line, move_line.product_uom_qty, package_dest,
             )
         free_package_line = move_lines.filtered(
             lambda l: l.result_package_id == self.free_package
@@ -292,8 +230,6 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         response = self.service.dispatch(
             "unload_set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": self.free_package.id,
                 "barcode": self.packing_location.barcode,
             },
@@ -309,7 +245,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         self.assertEqual(self.picking5.move_line_ids, another_package_line)
 
         # check response
-        buffer_line = self.service._find_buffer_move_lines(zone_location, picking_type)
+        buffer_line = self.service._find_buffer_move_lines()
         completion_info = self.service.actions_for("completion.info")
         completion_info_popup = completion_info.popup(buffer_line)
         self.assert_response_unload_single(
@@ -341,17 +277,11 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         )
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
             "unload_set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": self.free_package.id,
                 "barcode": packing_sublocation.barcode,
                 "confirmation": True,
@@ -370,7 +300,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         self.assertEqual(move_line.location_dest_id, packing_sublocation)
         self.assertEqual(move_line.move_id.state, "done")
         # check response
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,

--- a/shopfloor/tests/test_zone_picking_unload_single.py
+++ b/shopfloor/tests/test_zone_picking_unload_single.py
@@ -10,52 +10,21 @@ class ZonePickingUnloadSingleCase(ZonePickingCommonCase):
 
     """
 
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
     def test_unload_scan_pack_wrong_parameters(self):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids
-        package = move_line.package_id
-        response = self.service.dispatch(
-            "unload_scan_pack",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "package_id": package.id,
-                "barcode": "UNKNOWN",
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "unload_scan_pack",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "package_id": package.id,
-                "barcode": "UNKNOWN",
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
         # wrong package ID, and there is still a move line to unload
         # => get back on 'unload_single' screen
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
-            "unload_scan_pack",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "package_id": 1234567890,
-                "barcode": "UNKNOWN",
-            },
+            "unload_scan_pack", params={"package_id": 1234567890, "barcode": "UNKNOWN"},
         )
         completion_info = self.service.actions_for("completion.info")
         completion_info_popup = completion_info.popup(move_line)
@@ -73,15 +42,9 @@ class ZonePickingUnloadSingleCase(ZonePickingCommonCase):
             {"qty_done": 0, "shopfloor_user_id": False, "result_package_id": False}
         )
         response = self.service.dispatch(
-            "unload_scan_pack",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "package_id": 1234567890,
-                "barcode": "UNKNOWN",
-            },
+            "unload_scan_pack", params={"package_id": 1234567890, "barcode": "UNKNOWN"},
         )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response,
             zone_location,
@@ -93,13 +56,7 @@ class ZonePickingUnloadSingleCase(ZonePickingCommonCase):
         # => get back on 'start' screen
         self.pickings.move_lines._do_unreserve()
         response = self.service.dispatch(
-            "unload_scan_pack",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "package_id": 1234567890,
-                "barcode": "UNKNOWN",
-            },
+            "unload_scan_pack", params={"package_id": 1234567890, "barcode": "UNKNOWN"},
         )
         self.assert_response_start(
             response,
@@ -112,17 +69,11 @@ class ZonePickingUnloadSingleCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
             "unload_scan_pack",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": move_line.result_package_id.id,
                 "barcode": self.free_package.name,
             },
@@ -140,17 +91,11 @@ class ZonePickingUnloadSingleCase(ZonePickingCommonCase):
         )
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
-            move_line,
-            move_line.product_uom_qty,
-            self.free_package,
+            move_line, move_line.product_uom_qty, self.free_package,
         )
         response = self.service.dispatch(
             "unload_scan_pack",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": move_line.result_package_id.id,
                 "barcode": self.wrong_package.name,
             },

--- a/shopfloor/tests/test_zone_picking_zero_check.py
+++ b/shopfloor/tests/test_zone_picking_zero_check.py
@@ -10,42 +10,13 @@ class ZonePickingZeroCheckCase(ZonePickingCommonCase):
 
     """
 
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
     def test_is_zero_wrong_parameters(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-        move_line = self.picking1.move_line_ids[0]
         response = self.service.dispatch(
-            "is_zero",
-            params={
-                "zone_location_id": 1234567890,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-                "zero": True,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "is_zero",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": 1234567890,
-                "move_line_id": move_line.id,
-                "zero": True,
-            },
-        )
-        self.assert_response_start(
-            response, message=self.service.msg_store.record_not_found(),
-        )
-        response = self.service.dispatch(
-            "is_zero",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": 1234567890,
-                "zero": True,
-            },
+            "is_zero", params={"move_line_id": 1234567890, "zero": True},
         )
         self.assert_response_start(
             response, message=self.service.msg_store.record_not_found(),
@@ -57,15 +28,9 @@ class ZonePickingZeroCheckCase(ZonePickingCommonCase):
         picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids[0]
         response = self.service.dispatch(
-            "is_zero",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-                "zero": True,
-            },
+            "is_zero", params={"move_line_id": move_line.id, "zero": True},
         )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response, zone_location, picking_type, move_lines,
         )
@@ -76,15 +41,9 @@ class ZonePickingZeroCheckCase(ZonePickingCommonCase):
         picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids[0]
         response = self.service.dispatch(
-            "is_zero",
-            params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
-                "move_line_id": move_line.id,
-                "zero": False,
-            },
+            "is_zero", params={"move_line_id": move_line.id, "zero": False},
         )
-        move_lines = self.service._find_location_move_lines(zone_location, picking_type)
+        move_lines = self.service._find_location_move_lines()
         self.assert_response_select_line(
             response, zone_location, picking_type, move_lines,
         )

--- a/shopfloor_checkout_sync/tests/test_shopfloor_zone_picking_sync.py
+++ b/shopfloor_checkout_sync/tests/test_shopfloor_zone_picking_sync.py
@@ -52,13 +52,9 @@ class ZonePickingUnloadSetDestinationSync(ZonePickingCommonCase, SyncMixin):
         )
 
     def test_unload_set_destination_sync(self):
-        zone_location = self.zone_location
-        picking_type = self.picking1.picking_type_id
-
+        self.service.work.current_picking_type = self.picking1.picking_type_id
         # set the destination package
         self.service._set_destination_package(
-            zone_location,
-            picking_type,
             self.move1.move_line_ids,
             self.move1.move_line_ids.product_uom_qty,
             self.free_package,
@@ -66,8 +62,6 @@ class ZonePickingUnloadSetDestinationSync(ZonePickingCommonCase, SyncMixin):
         self.service.dispatch(
             "unload_set_destination",
             params={
-                "zone_location_id": zone_location.id,
-                "picking_type_id": picking_type.id,
                 "package_id": self.free_package.id,
                 "barcode": self.packing_sublocation.barcode,
                 "confirmation": True,

--- a/shopfloor_mobile/__manifest__.py
+++ b/shopfloor_mobile/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Shopfloor mobile",
     "summary": "Mobile frontend for WMS Shopfloor app",
-    "version": "13.0.1.7.0",
+    "version": "13.0.1.8.0",
     "development_status": "Alpha",
     "depends": ["shopfloor"],
     "author": "Camptocamp, BCIM, Akretion, Odoo Community Association (OCA)",

--- a/shopfloor_mobile/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile/static/wms/src/scenario/mixins.js
@@ -51,11 +51,7 @@ export var ScenarioBaseMixin = {
     },
     computed: {
         odoo: function() {
-            const odoo_params = {
-                process_menu_id: this.menu_item_id,
-                profile_id: this.$root.profile.id,
-                usage: this.usage,
-            };
+            const odoo_params = this._get_odoo_params();
             return this.$root.getOdoo(odoo_params);
         },
         /*
@@ -107,6 +103,19 @@ export var ScenarioBaseMixin = {
         },
     },
     methods: {
+        /**
+         * Retrieve Odoo connection params.
+         */
+        _get_odoo_params: function() {
+            return {
+                process_menu_id: this.menu_item_id,
+                profile_id: this.$root.profile.id,
+                usage: this.usage,
+            };
+        },
+        /**
+         * Retrieve current menu item ID.
+         */
         _get_menu_item_id: function() {
             const menu_id = Number.parseInt(this.$route.params.menu_id, 10);
             if (Number.isNaN(menu_id)) {

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -213,6 +213,42 @@ const TEMPLATES = {
 const ZonePicking = {
     mixins: [ScenarioBaseMixin],
     methods: {
+        /**
+         * Override to inject headers for zone location and picking type when needed.
+         */
+        _get_odoo_params: function() {
+            const params = this.$super(ScenarioBaseMixin)._get_odoo_params();
+            const zone = this.current_zone_location();
+            const picking_type = this.current_picking_type();
+            if (_.isUndefined(params.headers)) {
+                params["headers"] = {};
+            }
+            _.defaults(
+                params.headers,
+                this._get_zone_picking_headers(zone.id, picking_type.id)
+            );
+            return params;
+        },
+        /**
+         * Retrieve zone_picking scenario specific headers.
+         *
+         * The zone picking scenario requires some special headers
+         * to share some key parameters accross all methods.
+         *
+         * @param {*} zone_id: ID of current zone
+         * @param {*} picking_type_id: ID of selected picking type
+         */
+        _get_zone_picking_headers: function(zone_id, picking_type_id) {
+            let res = {};
+            if (_.isInteger(zone_id)) {
+                res["SERVICE-CTX-ZONE-LOCATION-ID"] = zone_id;
+            }
+            if (_.isInteger(picking_type_id)) {
+                res["SERVICE-CTX-PICKING-TYPE-ID"] = picking_type_id;
+            }
+            res["SERVICE-CTX-LINES-ORDER"] = this.order_lines_by;
+            return res;
+        },
         screen_klass: function() {
             return (
                 this.$super(ScenarioBaseMixin).screen_klass() +
@@ -405,19 +441,15 @@ const ZonePicking = {
             return this.list_move_lines(this.current_picking_type().id);
         },
         list_move_lines(picking_type_id) {
-            return this.wait_call(
-                this.odoo.call("list_move_lines", {
-                    zone_location_id: this.current_zone_location().id,
-                    picking_type_id: picking_type_id,
-                    order: this.order_lines_by,
-                })
+            const zone_id = this.current_zone_location().id;
+            this.odoo._update_headers(
+                this._get_zone_picking_headers(zone_id, picking_type_id)
             );
+            return this.wait_call(this.odoo.call("list_move_lines", {}));
         },
         scan_source(barcode) {
             return this.wait_call(
                 this.odoo.call("scan_source", {
-                    zone_location_id: this.current_zone_location().id,
-                    picking_type_id: this.current_picking_type().id,
                     barcode: barcode,
                 })
             );
@@ -552,12 +584,7 @@ const ZonePicking = {
                         this.scan_source(barcode);
                     },
                     on_unload_at_destination: () => {
-                        this.wait_call(
-                            this.odoo.call("prepare_unload", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
-                            })
-                        );
+                        this.wait_call(this.odoo.call("prepare_unload", {}));
                     },
                 },
                 set_line_destination: {
@@ -582,8 +609,6 @@ const ZonePicking = {
                         const data = this.state.data;
                         this.wait_call(
                             this.odoo.call("set_destination", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
                                 move_line_id: data.move_line.id,
                                 barcode: scanned.text,
                                 quantity: this.scan_destination_qty,
@@ -614,20 +639,13 @@ const ZonePicking = {
                         this.state_set_data({location_barcode: scanned.text});
                         this.wait_call(
                             this.odoo.call("set_destination_all", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
                                 barcode: scanned.text,
                                 confirmation: this.state.data.confirmation_required,
                             })
                         );
                     },
                     on_action_split: () => {
-                        this.wait_call(
-                            this.odoo.call("unload_split", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
-                            })
-                        );
+                        this.wait_call(this.odoo.call("unload_split", {}));
                     },
                 },
                 unload_single: {
@@ -638,8 +656,6 @@ const ZonePicking = {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("unload_scan_pack", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
                                 package_id: this.state.data.move_line.package_dest.id,
                                 barcode: scanned.text,
                             })
@@ -654,8 +670,6 @@ const ZonePicking = {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("unload_set_destination", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
                                 package_id: this.state.data.move_line.package_dest.id,
                                 barcode: scanned.text,
                                 confirmation: this.state.data.confirmation_required,
@@ -671,8 +685,6 @@ const ZonePicking = {
                     on_scan: scanned => {
                         this.wait_call(
                             this.odoo.call("change_pack_lot", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
                                 move_line_id: this.state.data.move_line.id,
                                 barcode: scanned.text,
                             })
@@ -689,8 +701,6 @@ const ZonePicking = {
                     on_confirm_stock_issue: () => {
                         this.wait_call(
                             this.odoo.call("stock_issue", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
                                 move_line_id: this.state.data.move_line.id,
                             })
                         );
@@ -708,8 +718,6 @@ const ZonePicking = {
                     is_zero: zero_flag => {
                         this.wait_call(
                             this.odoo.call("is_zero", {
-                                zone_location_id: this.current_zone_location().id,
-                                picking_type_id: this.current_picking_type().id,
                                 move_line_id: this.state.data.move_line.id,
                                 zero: zero_flag,
                             })

--- a/shopfloor_mobile/static/wms/src/services/odoo.js
+++ b/shopfloor_mobile/static/wms/src/services/odoo.js
@@ -10,6 +10,7 @@ export class OdooMixin {
         this.params = params;
         this.apikey = params.apikey;
         this.usage = params.usage;
+        this.headers = params.headers || {};
         this.process_menu_id = this.params.process_menu_id;
         this.profile_id = this.params.profile_id;
         this.debug = this.params.debug;
@@ -79,10 +80,16 @@ export class OdooMixin {
         if (method == "POST") {
             headers["Content-Type"] = "application/json";
         }
+        if (!_.isEmpty(this.headers)) {
+            _.merge(headers, this.headers);
+        }
         return headers;
     }
     _get_url(endpoint) {
         return "/shopfloor/" + endpoint;
+    }
+    _update_headers(headers) {
+        _.merge(this.headers, headers);
     }
 }
 


### PR DESCRIPTION
Partial refactor of zone_picking scenario to handle all common vars (zone location, picking type, order) via headers.
This makes easier to preserve the values across all methods of the scenario and make all of them consistent.

ref: 1933