### PR TITLE
[13.0] shopfloor: refine model and views

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.1.0",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",

--- a/shopfloor/demo/shopfloor_profile_demo.xml
+++ b/shopfloor/demo/shopfloor_profile_demo.xml
@@ -1,10 +1,8 @@
 <odoo noupdate="1">
     <record id="shopfloor_profile_hb_truck_demo" model="shopfloor.profile">
         <field name="name">Highbay Truck</field>
-        <field name="warehouse_id" ref="stock.warehouse0" />
     </record>
     <record id="shopfloor_profile_shelf_1_demo" model="shopfloor.profile">
         <field name="name">Shelf 1</field>
-        <field name="warehouse_id" ref="stock.warehouse0" />
     </record>
 </odoo>

--- a/shopfloor/i18n/shopfloor.pot
+++ b/shopfloor/i18n/shopfloor.pot
@@ -1339,11 +1339,6 @@ msgid "Visible for these profiles"
 msgstr ""
 
 #. module: shopfloor
-#: model:ir.model.fields,field_description:shopfloor.field_shopfloor_profile__warehouse_id
-msgid "Warehouse"
-msgstr ""
-
-#. module: shopfloor
 #: model:ir.model.fields.selection,name:shopfloor.selection__shopfloor_log__severity__warning
 msgid "Warning"
 msgstr ""

--- a/shopfloor/i18n/shopfloor.pot
+++ b/shopfloor/i18n/shopfloor.pot
@@ -817,9 +817,9 @@ msgstr ""
 
 #. module: shopfloor
 #: model:ir.actions.act_window,name:shopfloor.action_shopfloor_profile
-#: model:ir.model.fields,field_description:shopfloor.field_shopfloor_menu__profile_ids
-#: model:ir.ui.menu,name:shopfloor.menu_action_shopfloor_profile
-msgid "Profiles"
+#: model:ir.model.fields,field_description:shopfloor.field_shopfloor_menu__profile_id
+#: model:ir.ui.menu,name:shopfloor.menu_action_shopfloor_profil
+msgid "Profile"
 msgstr ""
 
 #. module: shopfloor
@@ -1334,8 +1334,8 @@ msgid "User"
 msgstr ""
 
 #. module: shopfloor
-#: model:ir.model.fields,help:shopfloor.field_shopfloor_menu__profile_ids
-msgid "Visible for these profiles"
+#: model:ir.model.fields,help:shopfloor.field_shopfloor_menu__profile_id
+msgid "Visible on this profile only"
 msgstr ""
 
 #. module: shopfloor

--- a/shopfloor/migrations/13.0.2.1.0/post-migration.py
+++ b/shopfloor/migrations/13.0.2.1.0/post-migration.py
@@ -1,0 +1,39 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    cr.execute(
+        """
+       SELECT shopfloor_menu_id, shopfloor_profile_id
+       FROM shopfloor_menu_shopfloor_profile_rel
+    """
+    )
+    menu_profile_ids = {}
+    for menu_id, profile_id in cr.fetchall():
+        menu_profile_ids.setdefault(menu_id, [])
+        menu_profile_ids[menu_id].append(profile_id)
+
+    for menu_id, profile_ids in menu_profile_ids.items():
+        if len(profile_ids) > 1:
+            _logger.warn(
+                "menu id %s was linked with 2 profiles (ids: %s),"
+                " only one is now possible now, menu has been"
+                " duplicated for each profile",
+                menu_id,
+                profile_ids,
+            )
+        index = 1
+        for profile_id in profile_ids:
+            menu = env["shopfloor.menu"].browse(menu_id)
+            if index > 1:
+                menu = menu.copy({"name": "{} ({})".format(menu.name, index)})
+            menu.profile_id = profile_id
+            index += 1

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -27,8 +27,8 @@ class ShopfloorMenu(models.Model):
 
     name = fields.Char(translate=True)
     sequence = fields.Integer()
-    profile_ids = fields.Many2many(
-        "shopfloor.profile", string="Profiles", help="Visible for these profiles"
+    profile_id = fields.Many2one(
+        "shopfloor.profile", string="Profile", help="Visible on this profile only"
     )
     picking_type_ids = fields.Many2many(
         comodel_name="stock.picking.type", string="Operation Types", required=True

--- a/shopfloor/models/shopfloor_profile.py
+++ b/shopfloor/models/shopfloor_profile.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ShopfloorProfile(models.Model):
@@ -8,18 +8,7 @@ class ShopfloorProfile(models.Model):
     _description = "Shopfloor profile settings"
 
     name = fields.Char(required=True)
-    warehouse_id = fields.Many2one(
-        "stock.warehouse",
-        required=True,
-        default=lambda self: self._default_warehouse_id(),
-    )
     menu_ids = fields.Many2many(
         "shopfloor.menu", string="Menus", help="Menus visible for this profile"
     )
     active = fields.Boolean(default=True)
-
-    @api.model
-    def _default_warehouse_id(self):
-        wh = self.env["stock.warehouse"].search([])
-        if len(wh) == 1:
-            return wh

--- a/shopfloor/models/shopfloor_profile.py
+++ b/shopfloor/models/shopfloor_profile.py
@@ -8,7 +8,10 @@ class ShopfloorProfile(models.Model):
     _description = "Shopfloor profile settings"
 
     name = fields.Char(required=True)
-    menu_ids = fields.Many2many(
-        "shopfloor.menu", string="Menus", help="Menus visible for this profile"
+    menu_ids = fields.One2many(
+        comodel_name="shopfloor.menu",
+        inverse_name="profile_id",
+        string="Menus",
+        help="Menus visible for this profile",
     )
     active = fields.Boolean(default=True)

--- a/shopfloor/services/menu.py
+++ b/shopfloor/services/menu.py
@@ -35,20 +35,12 @@ class ShopfloorMenu(Component):
 
     def _search(self, name_fragment=None):
         if not self.work.profile:
-            # we need to know the warehouse of the profile
-            # to load menus
+            # we need to know the profile to load menus
             return self.env["shopfloor.menu"].browse()
         domain = self._get_base_search_domain()
         if name_fragment:
             domain.append(("name", "ilike", name_fragment))
         records = self.env[self._expose_model].search(domain)
-        current_wh = self.work.profile.warehouse_id
-        records = records.filtered(
-            lambda menu: all(
-                not pt.warehouse_id or pt.warehouse_id == current_wh
-                for pt in menu.picking_type_ids
-            )
-        )
         return records
 
     def search(self, name_fragment=None):

--- a/shopfloor/services/menu.py
+++ b/shopfloor/services/menu.py
@@ -27,8 +27,8 @@ class ShopfloorMenu(Component):
                 base_domain,
                 [
                     "|",
-                    ("profile_ids", "=", False),
-                    ("profile_ids", "in", self.work.profile.ids),
+                    ("profile_id", "=", False),
+                    ("profile_id", "=", self.work.profile.id),
                 ],
             ]
         )

--- a/shopfloor/services/profile.py
+++ b/shopfloor/services/profile.py
@@ -38,10 +38,6 @@ class ShopfloorProfile(Component):
         return {
             "id": record.id,
             "name": record.name,
-            "warehouse": {
-                "id": record.warehouse_id.id,
-                "name": record.warehouse_id.name,
-            },
         }
 
 
@@ -81,11 +77,4 @@ class ShopfloorProfileValidatorResponse(Component):
         return {
             "id": {"coerce": to_int, "required": True, "type": "integer"},
             "name": {"type": "string", "nullable": False, "required": True},
-            "warehouse": {
-                "type": "dict",
-                "schema": {
-                    "id": {"coerce": to_int, "required": True, "type": "integer"},
-                    "name": {"type": "string", "nullable": False, "required": True},
-                },
-            },
         }

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -483,14 +483,8 @@ class BaseShopfloorProcess(AbstractComponent):
     _requires_header_profile = True
 
     def _get_process_picking_types(self):
-        """Return picking types for the menu and profile"""
-        # TODO make this a lazy property or computed field avoid running the
-        # filter every time?
-        picking_types = self.work.menu.picking_type_ids.filtered(
-            lambda pt: not pt.warehouse_id
-            or pt.warehouse_id == self.work.profile.warehouse_id
-        )
-        return picking_types
+        """Return picking types for the menu"""
+        return self.work.menu.picking_type_ids
 
     @property
     def picking_types(self):
@@ -498,8 +492,8 @@ class BaseShopfloorProcess(AbstractComponent):
             self.work.picking_types = self._get_process_picking_types()
         if not self.work.picking_types:
             raise exceptions.UserError(
-                _("No operation types configured on menu {} for warehouse {}.").format(
-                    self.work.menu.name, self.work.profile.warehouse_id.display_name
+                _("No operation types configured on menu {}.").format(
+                    self.work.menu.name
                 )
             )
         return self.work.picking_types

--- a/shopfloor/tests/test_app.py
+++ b/shopfloor/tests/test_app.py
@@ -24,15 +24,7 @@ class AppCase(CommonCase):
             response,
             data={
                 "profiles": [
-                    {
-                        "id": profile.id,
-                        "name": profile.name,
-                        "warehouse": {
-                            "id": profile.warehouse_id.id,
-                            "name": profile.warehouse_id.name,
-                        },
-                    }
-                    for profile in profiles
+                    {"id": profile.id, "name": profile.name} for profile in profiles
                 ],
                 "user_info": {"id": self.env.user.id, "name": self.env.user.name},
             },

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -9,8 +9,8 @@ class CheckoutCommonCase(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_checkout")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor/tests/test_cluster_picking_base.py
+++ b/shopfloor/tests/test_cluster_picking_base.py
@@ -10,8 +10,8 @@ class ClusterPickingCommonCase(CommonCase, PickingBatchMixin):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_cluster_picking")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor/tests/test_cluster_picking_batch.py
+++ b/shopfloor/tests/test_cluster_picking_batch.py
@@ -10,8 +10,8 @@ class ClusterPickingBatchCase(CommonCase, PickingBatchMixin):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_cluster_picking")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor/tests/test_db_logging.py
+++ b/shopfloor/tests/test_db_logging.py
@@ -18,8 +18,8 @@ class DBLoggingCaseBase(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_checkout")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
         with cls.work_on_services(cls, menu=cls.menu, profile=cls.profile) as work:
             cls.service = work.component(usage="checkout")
         cls.log_model = cls.env["shopfloor.log"].sudo()

--- a/shopfloor/tests/test_delivery_base.py
+++ b/shopfloor/tests/test_delivery_base.py
@@ -10,8 +10,8 @@ class DeliveryCommonCase(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_delivery")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor/tests/test_location_content_transfer_base.py
+++ b/shopfloor/tests/test_location_content_transfer_base.py
@@ -10,8 +10,8 @@ class LocationContentTransferCommonCase(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_location_content_transfer")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor/tests/test_menu.py
+++ b/shopfloor/tests/test_menu.py
@@ -25,21 +25,3 @@ class MenuCase(CommonMenuCase):
 
         my_menus = menus - menus_without_profile
         self._assert_menu_response(response, my_menus)
-
-    def test_menu_search_warehouse_filter(self):
-        """Request /menu/search with different warehouse on profile"""
-        menus = self.env["shopfloor.menu"].sudo().search([])
-        # should not be visible as the profile has another wh
-        menu_different_wh = menus[0]
-        other_wh = (
-            self.env["stock.warehouse"].sudo().create({"name": "Test", "code": "test"})
-        )
-        menu_different_wh.picking_type_ids.warehouse_id = other_wh
-
-        # should be visible to any profile
-        menu_no_wh = menus[1]
-        menu_no_wh.picking_type_ids.warehouse_id = False
-
-        response = self.service.dispatch("search")
-
-        self._assert_menu_response(response, menus - menu_different_wh)

--- a/shopfloor/tests/test_menu.py
+++ b/shopfloor/tests/test_menu.py
@@ -19,7 +19,7 @@ class MenuCase(CommonMenuCase):
         menus_without_profile = menus[0:2]
         # these menus should now be hidden for the current profile
         other_profile = self.env.ref("shopfloor.shopfloor_profile_hb_truck_demo")
-        menus_without_profile.profile_ids = other_profile
+        menus_without_profile.profile_id = other_profile
 
         response = self.service.dispatch("search")
 

--- a/shopfloor/tests/test_picking_form.py
+++ b/shopfloor/tests/test_picking_form.py
@@ -9,8 +9,8 @@ class PickingFormCase(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_checkout")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls):

--- a/shopfloor/tests/test_profile.py
+++ b/shopfloor/tests/test_profile.py
@@ -19,16 +19,8 @@ class ProfileCase(CommonCase):
             data={
                 "size": 2,
                 "records": [
-                    {
-                        "id": self.ANY,
-                        "name": "Highbay Truck",
-                        "warehouse": {"id": self.ANY, "name": "YourCompany"},
-                    },
-                    {
-                        "id": self.ANY,
-                        "name": "Shelf 1",
-                        "warehouse": {"id": self.ANY, "name": "YourCompany"},
-                    },
+                    {"id": self.ANY, "name": "Highbay Truck"},
+                    {"id": self.ANY, "name": "Shelf 1"},
                 ],
             },
         )

--- a/shopfloor/tests/test_single_pack_transfer_base.py
+++ b/shopfloor/tests/test_single_pack_transfer_base.py
@@ -10,8 +10,8 @@ class SinglePackTransferCommonBase(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_single_pallet_transfer")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor/tests/test_user.py
+++ b/shopfloor/tests/test_user.py
@@ -30,8 +30,8 @@ class UserCase(CommonMenuCase):
         # Simulate the client asking the menu
         menus = self.env["shopfloor.menu"].sudo().search([])
         menu = menus[0]
-        menu.profile_ids = self.profile
-        (menus - menu).profile_ids = self.profile2
+        menu.profile_id = self.profile
+        (menus - menu).profile_id = self.profile2
 
         response = self.service.dispatch("menu")
         self.assert_response(

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -9,8 +9,8 @@ class ZonePickingCommonCase(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_zone_picking")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassUsers(cls):

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -8,11 +8,7 @@
                 <field name="sequence" widget="handle" />
                 <field name="name" />
                 <field name="scenario" />
-                <field
-                    name="profile_ids"
-                    widget="many2many_tags"
-                    options="{'no_create': 1}"
-                />
+                <field name="profile_id" options="{'no_create': 1}" />
                 <field
                     name="picking_type_ids"
                     widget="many2many_tags"
@@ -40,11 +36,7 @@
                     <group name="main">
                         <field name="active" invisible="1" />
                         <field name="scenario" />
-                        <field
-                            name="profile_ids"
-                            widget="many2many_tags"
-                            options="{'no_create': 1}"
-                        />
+                        <field name="profile_id" options="{'no_create': 1}" />
                         <field
                             name="picking_type_ids"
                             widget="many2many_tags"
@@ -92,7 +84,7 @@
                 <field name="name" />
                 <field name="scenario" />
                 <field name="picking_type_ids" />
-                <field name="profile_ids" />
+                <field name="profile_id" />
                 <separator />
                 <filter
                     string="Archived"

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -83,14 +83,28 @@
             <search>
                 <field name="name" />
                 <field name="scenario" />
-                <field name="picking_type_ids" />
                 <field name="profile_id" />
+                <field name="picking_type_ids" />
                 <separator />
                 <filter
                     string="Archived"
                     name="inactive"
                     domain="[('active', '=', False)]"
                 />
+                <group expand="0" string="Group By">
+                    <filter
+                        string="Profile"
+                        name="groupby_profile_id"
+                        domain="[]"
+                        context="{'group_by': 'profile_id'}"
+                    />
+                    <filter
+                        string="Scenario"
+                        name="groupby_scenario"
+                        domain="[]"
+                        context="{'group_by': 'scenario'}"
+                    />
+                </group>
             </search>
         </field>
     </record>

--- a/shopfloor/views/shopfloor_profile_views.xml
+++ b/shopfloor/views/shopfloor_profile_views.xml
@@ -6,7 +6,6 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="name" />
-                <field name="warehouse_id" />
             </tree>
         </field>
     </record>
@@ -27,7 +26,6 @@
                             <field name="name" />
                         </group>
                         <group>
-                            <field name="warehouse_id" />
                             <field name="active" invisible="1" />
                         </group>
                     </group>
@@ -41,7 +39,6 @@
         <field name="arch" type="xml">
             <search>
                 <field name="name" />
-                <field name="warehouse_id" />
                 <separator />
                 <filter
                     string="Archived"

--- a/shopfloor_batch_automatic_creation/tests/test_batch_create.py
+++ b/shopfloor_batch_automatic_creation/tests/test_batch_create.py
@@ -10,8 +10,8 @@ class TestBatchCreate(CommonCase):
         super().setUpClassVars(*args, **kwargs)
         cls.menu = cls.env.ref("shopfloor.shopfloor_menu_cluster_picking")
         cls.profile = cls.env.ref("shopfloor.shopfloor_profile_shelf_1_demo")
-        cls.wh = cls.profile.warehouse_id
         cls.picking_type = cls.menu.picking_type_ids
+        cls.wh = cls.picking_type.warehouse_id
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor_mobile/static/wms/src/demo/demo.core.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.core.js
@@ -485,8 +485,8 @@ export class DemoTools {
     }
     makeProfiles() {
         const profiles = [
-            {id: 1, name: "SCH Transport", warehouse: {id: 1, name: "Schlieren"}},
-            {id: 2, name: "SCH Pick", warehouse: {id: 1, name: "Schlieren"}},
+            {id: 1, name: "SCH Transport"},
+            {id: 2, name: "SCH Pick"},
         ];
         return profiles;
     }


### PR DESCRIPTION
* Remove `warehouse_id` from the profile: only the warehouse of the operation types is used and makes sense
* Change `shopfloor.profile_ids` to a Many2one
  * It allows grouping and providing stats per menu/profile (example:
  number of move lines to process for a profile).
  * A migration script changes the relation and duplicates a menu if it
  had several profiles
* Add group bys on shopfloor menu's search view