### PR TITLE
[13.0] stock_available_to_promise_release: Fix horizon - count released move outside horizon

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -112,7 +112,10 @@ class StockMove(models.Model):
         }
         horizon_date = self._promise_reservation_horizon_date()
         if horizon_date:
-            sql += " AND m.date_expected <= %(horizon)s "
+            sql += (
+                " AND (m.need_release IS true AND m.date_expected <= %(horizon)s "
+                "      OR m.need_release IS false)"
+            )
             params["horizon"] = horizon_date
         return sql, params
 

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -105,6 +105,9 @@ class PromiseReleaseCommonCase(common.SavepointCase):
 
     @classmethod
     def _update_qty_in_location(cls, location, product, quantity):
+        quants = cls.env["stock.quant"]._gather(product, location, strict=True)
+        # this method adds the quantity to the current quantity, so remove it
+        quantity -= sum(quants.mapped("quantity"))
         cls.env["stock.quant"]._update_available_quantity(product, location, quantity)
         cls.env["product.product"].invalidate_cache(
             fnames=[

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -296,6 +296,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             self.env["stock.move"].invalidate_cache(
                 fnames=["previous_promised_qty", "ordered_available_to_promise_uom_qty"]
             )
+            self.assertEqual(picking.move_lines.previous_promised_qty, 0)
             self.assertEqual(
                 picking5.move_lines.ordered_available_to_promise_uom_qty, 15
             )


### PR DESCRIPTION
When a move is released, it must be counted in the stock previously promised even when it is outside horizon.
Only moves outside the horizon that are not released yet should not be counted.

cc @guewen 