### PR TITLE
[13.0] stock_storage_type: Optimize "will contain" computed fields on stock.location

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -142,13 +142,13 @@ class StockLocation(models.Model):
             loc.leaf_location_ids = leaves
 
     def _should_compute_will_contain_product_ids(self):
-        return any(
+        return self.usage == "internal" and any(
             location.do_not_mix_products
             for location in self.allowed_location_storage_type_ids
         )
 
     def _should_compute_will_contain_lot_ids(self):
-        return any(
+        return self.usage == "internal" and any(
             location.do_not_mix_lots
             for location in self.allowed_location_storage_type_ids
         )
@@ -192,6 +192,11 @@ class StockLocation(models.Model):
     )
     def _compute_location_is_empty(self):
         for rec in self:
+            if rec.usage != "internal":
+                # No restriction should apply on customer/supplier/...
+                # locations.
+                rec.location_is_empty = True
+                continue
             if (
                 sum(rec.quant_ids.mapped("quantity"))
                 - sum(rec.out_move_line_ids.mapped("qty_done"))

--- a/stock_storage_type/tests/common.py
+++ b/stock_storage_type/tests/common.py
@@ -54,6 +54,12 @@ class TestStorageTypeCommon(SavepointCase):
         cls.internal_picking_type = ref("stock.picking_type_internal")
 
         cls.product = ref("product.product_product_9")
+        cls.product2 = cls.env["product.product"].create(
+            {"name": "Product B", "type": "product"}
+        )
+        cls.product3 = cls.env["product.product"].create(
+            {"name": "Product C", "type": "product"}
+        )
         cls.product_lot = ref("stock.product_cable_management_box")
 
         cls.cardboxes_package_storage_type = ref(


### PR DESCRIPTION
The 2 fields:

* location_will_contain_product_ids
* location_will_contain_lot_ids

Are used only when applying a related location storage type with
"do_not_mix_products" or "do_not_mix_lots". As the result of the
computed fields are stored in m2m related fields, we can prevent a
lot of insertions in these relation tables by not computing them
if they have no location storage type that will need them.

ref: 1964