### PR TITLE
[13.0] shopfloor: adaptations for new base_rest API

### DIFF
--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -14,6 +14,7 @@ from odoo.osv import expression
 
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.component.core import AbstractComponent, WorkContext
+from odoo.addons.component.exception import NoComponentError
 
 
 def to_float(val):
@@ -196,19 +197,42 @@ class BaseShopfloorService(AbstractComponent):
             res.append(self._convert_one_record(record))
         return res
 
-    def _get_input_validator(self, method_name):
-        # override the method to get the validator in a component
-        # instead of a method, to keep things apart
-        validator_component = self.component(usage="%s.validator" % self._usage)
-        return validator_component._get_validator(method_name)
-
-    def _get_output_validator(self, method_name):
-        # override the method to get the validator in a component
-        # instead of a method, to keep things apart
+    def _get_validator_schema(self, method_name, usage_suffix):
         validator_component = self.component(
-            usage="%s.validator.response" % self._usage
+            usage="{}.{}".format(self._usage, usage_suffix)
         )
-        return validator_component._get_validator(method_name)
+        return getattr(validator_component, method_name)
+
+    # FIXME: must be replaced by a cleaner way to customize the validator
+    # handler, using: https://github.com/OCA/rest-framework/pull/99
+    def __getattr__(self, item):
+        # We have delegated the validator / return validators to dedicated
+        # components. In the new base_rest API, validator schemas are handled
+        # differently, but a backward compatibility layer adds
+        # "_validator_<method>" and "_validator_return_<method>" in the
+        # "routing" of the endpoints, which are automatically called on the
+        # service. As we have no way to replace the current service by the
+        # validator upstream, catch calls to these methods and get the schema
+        # from the validator services.
+        if item.startswith("_validator_return_"):
+            method_name = item.replace("_validator_return_", "")
+            try:
+                schema_handler = self._get_validator_schema(
+                    method_name, "validator.response"
+                )
+            except NoComponentError:
+                return super().__getattr__(item)
+            return schema_handler
+
+        if item.startswith("_validator_"):
+            method_name = item.replace("_validator_", "")
+            try:
+                schema_handler = self._get_validator_schema(method_name, "validator")
+            except NoComponentError:
+                return super().__getattr__(item)
+            return schema_handler
+
+        return super().__getattr__(item)
 
     def _response(
         self, base_response=None, data=None, next_state=None, message=None, popup=None

--- a/shopfloor/tests/common.py
+++ b/shopfloor/tests/common.py
@@ -8,6 +8,7 @@ from odoo import models
 from odoo.tests.common import Form, SavepointCase
 
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.base_rest.tests.common import RegistryMixin
 from odoo.addons.component.core import WorkContext
 from odoo.addons.component.tests.common import ComponentMixin
 
@@ -26,7 +27,7 @@ class AnyObject:
         return True
 
 
-class CommonCase(SavepointCase, ComponentMixin):
+class CommonCase(SavepointCase, RegistryMixin, ComponentMixin):
     """Base class for writing Shopfloor tests
 
     All tests are run as normal stock user by default, to check that all the
@@ -90,6 +91,7 @@ class CommonCase(SavepointCase, ComponentMixin):
         )
 
         cls.setUpComponent()
+        cls.setUpRegistry()
         cls.setUpClassUsers()
         cls.setUpClassVars()
         cls.setUpClassBaseData()

--- a/shopfloor/tests/test_db_logging.py
+++ b/shopfloor/tests/test_db_logging.py
@@ -97,7 +97,7 @@ class DBLoggingCase(DBLoggingCaseBase):
             httprequest=httprequest, extra_headers=extra_headers
         ) as mocked_request:
             entry = self.service._log_call_in_db(
-                self.env, mocked_request, _id, params, **kw
+                self.env, mocked_request, _id, params=params, **kw
             )
         expected = {
             "request_url": httprequest["url"],
@@ -110,7 +110,7 @@ class DBLoggingCase(DBLoggingCaseBase):
         self.assertRecordValues(entry, [expected])
         expected_json = {
             "result": {"data": "worked!"},
-            "params": dict(params, _id=_id),
+            "params": dict(params, args=[_id]),
             "headers": {
                 "Cookie": "<redacted>",
                 "Api-Key": "<redacted>",

--- a/shopfloor/tests/test_picking_form.py
+++ b/shopfloor/tests/test_picking_form.py
@@ -24,7 +24,7 @@ class PickingFormCase(CommonCase):
 
     def test_picking_form_get(self):
         available_carriers = self.service._get_available_carriers(self.picking)
-        response = self.service.dispatch("get", _id=self.picking.id)
+        response = self.service.dispatch("get", self.picking.id)
         self.assert_response(
             response,
             data={
@@ -42,7 +42,7 @@ class PickingFormCase(CommonCase):
         available_carriers = self.service._get_available_carriers(self.picking)
         self.picking.carrier_id = available_carriers[0]
         params = {"carrier_id": available_carriers[1].id}
-        response = self.service.dispatch("update", _id=self.picking.id, params=params)
+        response = self.service.dispatch("update", self.picking.id, params=params)
         self.assert_response(
             response,
             data={


### PR DESCRIPTION
Following changes in base_rest: https://github.com/OCA/rest-framework/pull/71

The following changes are needed:

* Adapt "dispatch" method to new base_rest API with *args 
* Fix REST services tests
* Fix validators for new base_rest API

Details in commits.

I'll do a follow-up for the last commit, replacing the `__getattr__` override by a change in `base_rest`.
But merging this already would make the CI pass.