### PR TITLE
[13.0] Add barcode on Package Storage Type, use it at reception screen

### DIFF
--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -392,9 +392,13 @@ class StockReceptionScreen(models.Model):
         self.current_move_line_package = barcode
 
     def on_barcode_scanned_select_packaging(self, barcode):
-        """Auto-complete the package data."""
+        """Auto-complete the package data.
+
+        The package data is filled automatically depending on
+        the barcode scanned for the package storage type.
+        """
         packaging = self.current_move_product_packaging_ids.filtered(
-            lambda o: o.barcode == barcode
+            lambda o: o.package_storage_type_id.barcode == barcode
         )[:1]
         self._autocomplete_package_data(packaging)
 

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -193,22 +193,22 @@
                                     />
                                 </div>
                                 <!-- select_packaging -->
-                                <label for="product_packaging_id" />
-                                <div>
-                                    <field
-                                        name="product_packaging_id"
-                                        class="mr8"
-                                        style="width: 15em;"
-                                        options="{'no_open': True, 'no_create': True}"
-                                        attrs="{
-                      'readonly': [('current_step', '!=', 'select_packaging')],
-                    }"
-                                    />
-                                </div>
                                 <label for="package_storage_type_id" />
                                 <div>
                                     <field
                                         name="package_storage_type_id"
+                                        class="mr8"
+                                        style="width: 15em;"
+                                        options="{'no_open': True, 'no_create': True}"
+                                        attrs="{
+                            'readonly': [('current_step', '!=', 'select_packaging')],
+                          }"
+                                    />
+                                </div>
+                                <label for="product_packaging_id" />
+                                <div>
+                                    <field
+                                        name="product_packaging_id"
                                         class="mr8"
                                         style="width: 15em;"
                                         options="{'no_open': True, 'no_create': True}"

--- a/stock_storage_type/models/stock_package_storage_type.py
+++ b/stock_storage_type/models/stock_package_storage_type.py
@@ -34,6 +34,7 @@ class StockPackageStorageType(models.Model):
         help=("Height is mandatory for packages configured with this storage type."),
         default=False,
     )
+    barcode = fields.Char("Barcode", copy=False)
 
     @api.depends("storage_location_sequence_ids")
     def _compute_storage_type_message(self):

--- a/stock_storage_type/views/stock_package_storage_type.xml
+++ b/stock_storage_type/views/stock_package_storage_type.xml
@@ -38,6 +38,7 @@
                                 widget="many2many_tags"
                             />
                             <field name="height_required" />
+                            <field name="barcode" />
                         </group>
                         <group name="msg">
                             <div colspan="2">


### PR DESCRIPTION
While in the step 'Product Packaging' of the reception screen
of an incoming transfer, allow to scan a barcode for a package
storage type. If a package storage type is found, then fill it
automatically and set the product packaging also from it.

In the reception screen, the order in which the product packaging
and the package storage type has been reversed, because it is the
latter which is now used while scanning, so it comes first now
in the user interface.