### PR TITLE
[13.0] Add validator handlers delegating to component validators

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.2.3.0",
+    "version": "13.0.2.4.0",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",


### PR DESCRIPTION
Following commit 81b9cfb3 which was a work-around, a new way to
customize the handlers for validators is added in base_rest:
https://github.com/OCA/rest-framework/pull/99

This commit uses the new component to dispatch the validators to
shopfloor's validator components.