### PR TITLE
[13.0] Shopfloor Zone Picking: fix zero check

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.2.2.0",
+    "version": "13.0.2.2.1",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -187,12 +187,10 @@ class ZonePicking(Component):
             next_state="set_line_destination", data=data, message=message
         )
 
-    def _response_for_zero_check(self, location, message=None):
-        return self._response(
-            next_state="zero_check",
-            data=self._data_for_location(location),
-            message=message,
-        )
+    def _response_for_zero_check(self, move_line, message=None):
+        data = self._data_for_location(move_line.location_id)
+        data["move_line"] = self.data.move_line(move_line)
+        return self._response(next_state="zero_check", data=data, message=message,)
 
     def _response_for_change_pack_lot(self, move_line, message=None):
         return self._response(
@@ -612,7 +610,7 @@ class ZonePicking(Component):
         # Zero check
         zero_check = self.picking_type.shopfloor_zero_check
         if zero_check and move_line.location_id.planned_qty_in_location_is_empty():
-            response = self._response_for_zero_check(move_line.location_id)
+            response = self._response_for_zero_check(move_line)
         return (location_changed, response)
 
     def _is_package_empty(self, package):
@@ -686,7 +684,7 @@ class ZonePicking(Component):
         # Zero check
         zero_check = self.picking_type.shopfloor_zero_check
         if zero_check and move_line.location_id.planned_qty_in_location_is_empty():
-            response = self._response_for_zero_check(move_line.location_id)
+            response = self._response_for_zero_check(move_line)
         return (package_changed, response)
 
     def set_destination(
@@ -1463,5 +1461,6 @@ class ShopfloorZonePickingValidatorResponse(Component):
             "zone_location": self.schemas._schema_dict_of(self.schemas.location()),
             "picking_type": self.schemas._schema_dict_of(self.schemas.picking_type()),
             "location": self.schemas._schema_dict_of(self.schemas.location()),
+            "move_line": self.schemas._schema_dict_of(self.schemas.move_line()),
         }
         return schema

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -372,7 +372,7 @@ class ZonePickingCommonCase(CommonCase):
         )
 
     def _assert_response_zero_check(
-        self, state, response, zone_location, picking_type, location, message=None,
+        self, state, response, zone_location, picking_type, move_line, message=None,
     ):
         self.assert_response(
             response,
@@ -380,20 +380,21 @@ class ZonePickingCommonCase(CommonCase):
             data={
                 "zone_location": self.data.location(zone_location),
                 "picking_type": self.data.picking_type(picking_type),
-                "location": self.data.location(location),
+                "location": self.data.location(move_line.location_id),
+                "move_line": self.data.move_line(move_line),
             },
             message=message,
         )
 
     def assert_response_zero_check(
-        self, response, zone_location, picking_type, location, message=None,
+        self, response, zone_location, picking_type, move_line, message=None,
     ):
         self._assert_response_zero_check(
             "zero_check",
             response,
             zone_location,
             picking_type,
-            location,
+            move_line,
             message=message,
         )
 

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -342,7 +342,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         self.assertTrue(location_is_empty())
         # Check response
         self.assert_response_zero_check(
-            response, zone_location, picking_type, move_line.location_id,
+            response, zone_location, picking_type, move_line
         )
 
     def test_set_destination_package_full_qty(self):
@@ -492,5 +492,5 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         self.assertTrue(location_is_empty())
         # Check response
         self.assert_response_zero_check(
-            response, zone_location, picking_type, move_line.location_id,
+            response, zone_location, picking_type, move_line,
         )

--- a/shopfloor_mobile/__manifest__.py
+++ b/shopfloor_mobile/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Shopfloor mobile",
     "summary": "Mobile frontend for WMS Shopfloor app",
-    "version": "13.0.1.8.0",
+    "version": "13.0.1.8.1",
     "development_status": "Alpha",
     "depends": ["shopfloor"],
     "author": "Camptocamp, BCIM, Akretion, Odoo Community Association (OCA)",

--- a/shopfloor_mobile/static/wms/src/i18n/i18n.en.js
+++ b/shopfloor_mobile/static/wms/src/i18n/i18n.en.js
@@ -94,7 +94,7 @@ const messages_en = {
         btn_manual_selection: "Manual selection",
         stock_zero_check: {
             confirm_stock_zero: "Confirm stock = 0",
-            confirm_stock_not_zero: "Confirm stock not empty",
+            confirm_stock_not_zero: "Declare stock not empty",
         },
         actions_popup: {
             btn_action: "Action",


### PR DESCRIPTION
## Fix "zero check" 

The client js application needs the move line's id to confirm or not the
zero quantity using "/is_zero". The backend did not send the move
line's data when going to the "zero_check" state.

## Improve wording on "zero check" screen

The zero check screen shows 2 buttons:

* Confirm stock = 0
* Confirm stock not empty

At this point, the normal situation would be that the stock is zero.
So "Confirm stock not empty" is confusing, as we do not confirm the
expected value of zero.
