### PR TITLE
[13.0][FIX] shopfloor: handle backorders

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.2.4.0",
+    "version": "13.0.2.4.1",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",

--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -32,10 +32,14 @@ class StockAction(Component):
     def _check_backorder(self, picking, moves):
         """Check if the `picking` has to be validated as usual to create a backorder.
 
-        If the moves are equal to all available moves of the current picking
-        - but there are still unavailable moves to process - then we want to
-        create a normal backorder (i.e. the current picking is validated and
-        the remaining moves are put in a backorder as usual)
+        We want to create a normal backorder if:
+
+            - the moves are equal to all available moves of the current picking
+              but there are still unavailable moves to process
+            - the moves are not linked to unprocessed ancestor moves
         """
         assigned_moves = picking.move_lines.filtered(lambda m: m.state == "assigned")
-        return moves == assigned_moves
+        has_ancestors = bool(
+            moves.move_orig_ids.filtered(lambda m: m.state not in ("cancel", "done"))
+        )
+        return moves == assigned_moves and not has_ancestors

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -421,7 +421,8 @@ class LocationContentTransfer(Component):
 
     def _set_all_destination_lines_and_done(self, pickings, move_lines, dest_location):
         self._write_destination_on_lines(move_lines, dest_location)
-        pickings.action_done()
+        stock = self.actions_for("stock")
+        stock.validate_moves(move_lines.move_id)
 
     def _lock_lines(self, lines):
         """Lock move lines"""


### PR DESCRIPTION
When moves are validated among all scenarios, we are validating related picking the standard way (with `action_done()`) when:

1) the moves to process are equal to all assigned moves of the current picking (so we can have waiting moves in the picking, in that case a normal backorder will be created by `action_done()`), in other terms it is triggered when we are validating the last moves related to one picking,

2) the moves to process are linked to unprocessed ancestor/source moves. This condition is required because we want to avoid some business logic bound to the `_create_backorder` standard method, like the backorder strategy configured through the `stock_picking_backorder_strategy` module.

In all other cases, we want to process the current moves in their own picking (use of `extract_and_action_done()` method), letting the current picking `confirmed/waiting` with the remaining qties.

Point 1) was already implemented, this commit implements the point 2).

Also, location content transfer scenario was not using the `validate_moves()` method (already used by all scenarios to validate
moves), this commit is fixing that.


Ref. 1966