### PR TITLE
[13.0][IMP] stock_reception_screen: minor improvements

### DIFF
--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -37,22 +37,22 @@ class StockReceptionScreen(models.Model):
         },
         "set_quantity": {
             "label": _("Set Quantity"),
-            "next_steps": [{"next": "set_location"}],
-            "focus_field": "current_move_line_qty_done",
-        },
-        "set_location": {
-            "label": _("Set Destination"),
             "next_steps": [
                 {
-                    "before": "_before_set_location_to_select_packaging",
+                    "before": "_before_set_quantity_to_select_packaging",
                     "next": "select_packaging",
                 }
             ],
-            "focus_field": "current_move_line_location_dest_id",
+            "focus_field": "current_move_line_qty_done",
         },
         "select_packaging": {
             "label": _("Select Packaging"),
+            "next_steps": [{"next": "set_location"}],
+        },
+        "set_location": {
+            "label": _("Set Destination"),
             "next_steps": [{"next": "set_package"}],
+            "focus_field": "current_move_line_location_dest_id",
         },
         "set_package": {
             "label": _("Set Package"),
@@ -570,7 +570,7 @@ class StockReceptionScreen(models.Model):
     def process_select_packaging(self):
         self.next_step()
 
-    def _before_set_location_to_select_packaging(self):
+    def _before_set_quantity_to_select_packaging(self):
         """Auto-complete the package data matching the qty (if there is one)."""
         qty_done = self.current_move_line_qty_done
         if qty_done:
@@ -698,9 +698,6 @@ class StockReceptionScreen(models.Model):
         assert self.current_step == "set_quantity", f"step = {self.current_step}"
         self.current_move_line_qty_done = qty_done
         self.process_set_quantity()
-        #   - set the destination
-        self.current_move_line_location_dest_id = location_dest
-        self.process_set_location()
         #   - set packaging data
         assert self.current_step == "select_packaging", f"step = {self.current_step}"
         self.product_packaging_id = product_packaging
@@ -708,6 +705,10 @@ class StockReceptionScreen(models.Model):
         if self.package_storage_type_height_required:
             self.package_height = package_height
         self.process_select_packaging()
+        #   - set the destination
+        assert self.current_step == "set_location", f"step = {self.current_step}"
+        self.current_move_line_location_dest_id = location_dest
+        self.process_set_location()
         assert self.current_step == "set_package", f"step = {self.current_step}"
         return True
 

--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -284,20 +284,16 @@ class StockReceptionScreen(models.Model):
     @api.depends("package_storage_type_id.location_storage_type_ids")
     def _compute_allowed_location_dest_ids(self):
         for wiz in self:
+            domain = [("id", "child_of", wiz.picking_location_dest_id.id)]
             if wiz.package_storage_type_id:
-                wiz.allowed_location_dest_ids = self.env["stock.location"].search(
-                    [
-                        (
-                            "allowed_location_storage_type_ids",
-                            "in",
-                            wiz.package_storage_type_id.location_storage_type_ids.ids,
-                        ),
-                    ]
-                )
-            else:
-                wiz.allowed_location_dest_ids = self.env["stock.location"].search(
-                    [("id", "child_of", self.picking_location_dest_id.id)]
-                )
+                domain += [
+                    (
+                        "allowed_location_storage_type_ids",
+                        "in",
+                        wiz.package_storage_type_id.location_storage_type_ids.ids,
+                    )
+                ]
+            wiz.allowed_location_dest_ids = self.env["stock.location"].search(domain)
 
     @api.onchange("product_packaging_id")
     def onchange_product_packaging_id(self):

--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -162,6 +162,12 @@ class StockReceptionScreen(models.Model):
         "product.packaging", domain="[('product_id', '=', current_move_product_id)]",
     )
     package_storage_type_id = fields.Many2one("stock.package.storage.type",)
+    allowed_location_dest_ids = fields.One2many(
+        "stock.location",
+        string="Allowed destination locations",
+        help="Allowed destination locations based on the package storage type.",
+        compute="_compute_allowed_location_dest_ids",
+    )
     package_storage_type_height_required = fields.Boolean(
         related="package_storage_type_id.height_required"
     )
@@ -201,14 +207,20 @@ class StockReceptionScreen(models.Model):
 
     @api.depends("current_move_line_id.location_dest_id")
     def _compute_current_move_line_location_dest_id(self):
+        """Compute the default destination location for the processed line."""
         for wiz in self:
             move_line = wiz.current_move_line_id
+            # Default location
             wiz.current_move_line_location_dest_id = move_line.location_dest_id
             location = move_line.location_dest_id._get_putaway_strategy(
                 move_line.product_id
             )
             if location:
                 wiz.current_move_line_location_dest_id = location
+            # If there are some allowed destinations set the field empty,
+            # the user will choose the right one among them
+            if wiz.allowed_location_dest_ids:
+                wiz.current_move_line_location_dest_id = False
 
     def _inverse_current_move_line_location_dest_id(self):
         for wiz in self:
@@ -245,6 +257,24 @@ class StockReceptionScreen(models.Model):
     def _inverse_current_move_line_package(self):
         for wiz in self:
             wiz.current_move_line_package_stored = wiz.current_move_line_package
+
+    @api.depends("package_storage_type_id.location_storage_type_ids")
+    def _compute_allowed_location_dest_ids(self):
+        for wiz in self:
+            if wiz.package_storage_type_id:
+                wiz.allowed_location_dest_ids = self.env["stock.location"].search(
+                    [
+                        (
+                            "allowed_location_storage_type_ids",
+                            "in",
+                            wiz.package_storage_type_id.location_storage_type_ids.ids,
+                        ),
+                    ]
+                )
+            else:
+                wiz.allowed_location_dest_ids = self.env["stock.location"].search(
+                    [("id", "child_of", self.picking_location_dest_id.id)]
+                )
 
     @api.onchange("product_packaging_id")
     def onchange_product_packaging_id(self):

--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -108,6 +108,7 @@ class StockReceptionScreen(models.Model):
     current_filter_product = fields.Char(string="Filter product", copy=False)
     # current move
     current_move_id = fields.Many2one(comodel_name="stock.move", copy=False)
+    current_move_has_tracking = fields.Selection(related="current_move_id.has_tracking")
     current_move_product_id = fields.Many2one(
         related="current_move_id.product_id", string="Move's product"
     )
@@ -123,6 +124,16 @@ class StockReceptionScreen(models.Model):
     )
     current_move_product_vendor_code = fields.Char(
         related="current_move_id.vendor_code"
+    )
+    current_move_product_qty_available = fields.Float(
+        related="current_move_id.product_id.qty_available"
+    )
+    current_move_product_outgoing_qty = fields.Float(
+        related="current_move_id.product_id.outgoing_qty"
+    )
+    current_move_product_last_lot_life_date = fields.Datetime(
+        compute="_compute_current_move_product_last_lot_life_date",
+        string="Most recent exp. date",
     )
     # current move line
     current_move_line_id = fields.Many2one(comodel_name="stock.move.line", copy=False)
@@ -204,6 +215,18 @@ class StockReceptionScreen(models.Model):
                 wiz.current_step_focus_field = steps[self.current_step].get(
                     "focus_field", ""
                 )
+
+    def _compute_current_move_product_last_lot_life_date(self):
+        for wiz in self:
+            lot = self.env["stock.production.lot"].search(
+                [
+                    ("product_id", "=", wiz.current_move_product_id.id),
+                    ("life_date", "!=", False),
+                ],
+                order="life_date DESC",
+                limit=1,
+            )
+            wiz.current_move_product_last_lot_life_date = lot.life_date
 
     @api.depends("current_move_line_id.location_dest_id")
     def _compute_current_move_line_location_dest_id(self):

--- a/stock_reception_screen/tests/test_reception_screen.py
+++ b/stock_reception_screen/tests/test_reception_screen.py
@@ -110,10 +110,13 @@ class TestReceptionScreen(SavepointCase):
         # Check that a destination location is defined by default
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
-        self.screen.current_move_line_location_dest_id = self.location_dest
-        self.assertTrue(self.screen.current_move_line_location_dest_id)
-        # Set a package
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
         self.screen.button_save_step()
+        self.assertEqual(
+            self.screen.current_move_line_location_dest_id,
+            self.screen.current_move_line_location_dest_stored_id,
+        )
+        # Set a package
         self.assertEqual(self.screen.current_step, "set_package")
         self.screen.current_move_line_package = "PID-TEST-1"
         self.assertEqual(self.screen.current_move_line_package_stored, "PID-TEST-1")
@@ -147,7 +150,7 @@ class TestReceptionScreen(SavepointCase):
         # Set location
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
-        self.screen.current_move_line_location_dest_id = self.location_dest
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
         # Set a package
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
@@ -174,9 +177,12 @@ class TestReceptionScreen(SavepointCase):
         self.screen.package_height = 20
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
-        self.screen.current_move_line_location_dest_id = self.location_dest
-        self.assertTrue(self.screen.current_move_line_location_dest_id)
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
         self.screen.button_save_step()
+        self.assertEqual(
+            self.screen.current_move_line_location_dest_id,
+            self.screen.current_move_line_location_dest_stored_id,
+        )
         self.assertEqual(self.screen.current_step, "set_package")
         self.screen.current_move_line_package = "PID-TEST-2.1"
         self.assertEqual(self.screen.current_move_line_package_stored, "PID-TEST-2.1")
@@ -213,10 +219,13 @@ class TestReceptionScreen(SavepointCase):
         # Check that a destination location is defined by default
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
-        self.screen.current_move_line_location_dest_id = self.location_dest
-        self.assertTrue(self.screen.current_move_line_location_dest_id)
-        # Set a package
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
         self.screen.button_save_step()
+        self.assertEqual(
+            self.screen.current_move_line_location_dest_id,
+            self.screen.current_move_line_location_dest_stored_id,
+        )
+        # Set a package
         self.assertEqual(self.screen.current_step, "set_package")
         self.screen.current_move_line_package = "PID-TEST-1"
         self.assertEqual(self.screen.current_move_line_package_stored, "PID-TEST-1")
@@ -226,7 +235,7 @@ class TestReceptionScreen(SavepointCase):
         self.assertEqual(move_line.result_package_id.name, "PID-TEST-1")
         # Iterate on the same product/lot to scan the second package
         self.assertEqual(self.screen.current_move_line_qty_done, 4)
-        self.assertTrue(self.screen.current_move_line_location_dest_id)
+        self.assertTrue(self.screen.current_move_line_location_dest_stored_id)
         self.assertEqual(self.screen.product_packaging_id, self.product_packaging)
         self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
         self.assertEqual(self.screen.package_height, self.product_packaging.height)

--- a/stock_reception_screen/tests/test_reception_screen.py
+++ b/stock_reception_screen/tests/test_reception_screen.py
@@ -110,6 +110,7 @@ class TestReceptionScreen(SavepointCase):
         # Check that a destination location is defined by default
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_id = self.location_dest
         self.assertTrue(self.screen.current_move_line_location_dest_id)
         # Set a package
         self.screen.button_save_step()
@@ -173,6 +174,7 @@ class TestReceptionScreen(SavepointCase):
         self.screen.package_height = 20
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_id = self.location_dest
         self.assertTrue(self.screen.current_move_line_location_dest_id)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
@@ -211,6 +213,7 @@ class TestReceptionScreen(SavepointCase):
         # Check that a destination location is defined by default
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_id = self.location_dest
         self.assertTrue(self.screen.current_move_line_location_dest_id)
         # Set a package
         self.screen.button_save_step()

--- a/stock_reception_screen/tests/test_reception_screen.py
+++ b/stock_reception_screen/tests/test_reception_screen.py
@@ -101,16 +101,16 @@ class TestReceptionScreen(SavepointCase):
         # Receive 4/10 qties (corresponding to the product packaging qty)
         self.screen.current_move_line_qty_done = 4
         self.assertEqual(self.screen.current_move_line_qty_status, "lt")
-        # Check that a destination location is defined by default
-        self.screen.button_save_step()
-        self.assertEqual(self.screen.current_step, "set_location")
-        self.assertTrue(self.screen.current_move_line_location_dest_id)
         # Check package data (automatically filled normally)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
         self.assertEqual(self.screen.product_packaging_id, self.product_packaging)
         self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
         self.assertEqual(self.screen.package_height, self.product_packaging.height)
+        # Check that a destination location is defined by default
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.assertTrue(self.screen.current_move_line_location_dest_id)
         # Set a package
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
@@ -134,8 +134,6 @@ class TestReceptionScreen(SavepointCase):
         self.assertEqual(self.screen.current_step, "set_quantity")
         self.screen.current_move_line_qty_done = 6
         self.assertEqual(self.screen.current_move_line_qty_status, "eq")
-        self.screen.button_save_step()
-        self.assertEqual(self.screen.current_step, "set_location")
         # Check package data (not automatically filled as no packaging match)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
@@ -145,6 +143,10 @@ class TestReceptionScreen(SavepointCase):
         # Set mandatory package data
         self.screen.package_storage_type_id = self.storage_type_pallet
         self.screen.package_height = 20
+        # Set location
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_id = self.location_dest
         # Set a package
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
@@ -166,12 +168,12 @@ class TestReceptionScreen(SavepointCase):
         self.assertEqual(self.screen.current_step, "set_quantity")
         self.screen.current_move_line_qty_done = 20
         self.screen.button_save_step()
-        self.assertEqual(self.screen.current_step, "set_location")
-        self.assertTrue(self.screen.current_move_line_location_dest_id)
-        self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
         self.screen.package_storage_type_id = self.storage_type_pallet
         self.screen.package_height = 20
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.assertTrue(self.screen.current_move_line_location_dest_id)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
         self.screen.current_move_line_package = "PID-TEST-2.1"
@@ -200,16 +202,16 @@ class TestReceptionScreen(SavepointCase):
         # Receive 4/10 qties (corresponding to the product packaging qty)
         self.screen.current_move_line_qty_done = 4
         self.assertEqual(self.screen.current_move_line_qty_status, "lt")
-        # Check that a destination location is defined by default
-        self.screen.button_save_step()
-        self.assertEqual(self.screen.current_step, "set_location")
-        self.assertTrue(self.screen.current_move_line_location_dest_id)
         # Check package data (automatically filled normally)
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
         self.assertEqual(self.screen.product_packaging_id, self.product_packaging)
         self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
         self.assertEqual(self.screen.package_height, self.product_packaging.height)
+        # Check that a destination location is defined by default
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.assertTrue(self.screen.current_move_line_location_dest_id)
         # Set a package
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_package")
@@ -278,7 +280,6 @@ class TestReceptionScreen(SavepointCase):
         self.screen.current_move_line_lot_life_date = fields.Datetime.today()
         self.screen.button_save_step()
         self.screen.current_move_line_qty_done = 1
-        self.screen.button_save_step()
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
         self.assertFalse(self.screen.product_packaging_id)

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -255,10 +255,30 @@
                                     />
                                 </div>
                                 <!-- set_location -->
-                                <label for="current_move_line_location_dest_id" />
-                                <div>
+                                <label
+                                    for="current_move_line_location_dest_id"
+                                    attrs="{'invisible': [('current_step', '=', 'set_location')]}"
+                                    string="Destination"
+                                />
+                                <div
+                                    attrs="{'invisible': [('current_step', '=', 'set_location')]}"
+                                >
                                     <field
                                         name="current_move_line_location_dest_id"
+                                        class="mr8"
+                                        readonly="1"
+                                        options="{'no_open': True}"
+                                    />
+                                </div>
+                                <label
+                                    for="current_move_line_location_dest_stored_id"
+                                    attrs="{'invisible': [('current_step', '!=', 'set_location')]}"
+                                />
+                                <div
+                                    attrs="{'invisible': [('current_step', '!=', 'set_location')]}"
+                                >
+                                    <field
+                                        name="current_move_line_location_dest_stored_id"
                                         class="mr8"
                                         attrs="{
                       'required': [('current_step', '=', 'set_location')],

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -178,20 +178,6 @@
                                         attrs="{'invisible': [('current_move_line_qty_status', '!=', 'gt')]}"
                                     />
                                 </div>
-                                <!-- set_location -->
-                                <label for="current_move_line_location_dest_id" />
-                                <div>
-                                    <field
-                                        name="current_move_line_location_dest_id"
-                                        class="mr8"
-                                        attrs="{
-                      'required': [('current_step', '=', 'set_location')],
-                      'readonly': [('current_step', '!=', 'set_location')],
-                    }"
-                                        options="{'no_open': True, 'no_create_edit': True}"
-                                        domain="[('id', 'child_of', picking_location_dest_id), ('usage', '!=', 'view')]"
-                                    />
-                                </div>
                                 <!-- select_packaging -->
                                 <label for="package_storage_type_id" />
                                 <div>
@@ -231,6 +217,20 @@
                                         attrs="{
                             'readonly': [('current_step', '!=', 'select_packaging')],
                           }"
+                                    />
+                                </div>
+                                <!-- set_location -->
+                                <label for="current_move_line_location_dest_id" />
+                                <div>
+                                    <field
+                                        name="current_move_line_location_dest_id"
+                                        class="mr8"
+                                        attrs="{
+                      'required': [('current_step', '=', 'set_location')],
+                      'readonly': [('current_step', '!=', 'set_location')],
+                    }"
+                                        options="{'no_open': True, 'no_create_edit': True}"
+                                        domain="[('id', 'child_of', picking_location_dest_id), ('usage', '!=', 'view')]"
                                     />
                                 </div>
                                 <!-- set_package -->

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -91,28 +91,62 @@
                 <field name="current_step_focus_field" invisible="1" />
                 <field name="picking_location_dest_id" invisible="1" />
                 <field name="current_move_id" invisible="1" />
+                <field name="current_move_has_tracking" invisible="1" />
                 <field name="current_move_product_id" invisible="1" />
                 <field name="current_move_line_id" invisible="1" />
                 <field name="package_storage_type_height_required" invisible="1" />
                 <field name="allowed_location_dest_ids" invisible="1" />
                 <div class="o_screen_data">
                     <div class="o_screen_data_content" name="data">
-                        <group attrs="{'invisible': [('current_move_id', '=', False)]}">
-                            <label for="current_move_product_display_name" />
-                            <div>
-                                <field
-                                    name="current_move_product_display_name"
-                                    class="mr8"
+                        <group
+                            attrs="{'invisible': [('current_move_id', '=', False)]}"
+                            col="4"
+                        >
+                            <group colspan="2">
+                                <label for="current_move_product_display_name" />
+                                <div>
+                                    <field
+                                        name="current_move_product_display_name"
+                                        class="mr8"
+                                    />
+                                </div>
+                                <label for="current_move_product_vendor_code" />
+                                <div>
+                                    <field
+                                        name="current_move_product_vendor_code"
+                                        class="mr8"
+                                    />
+                                </div>
+                            </group>
+                            <group colspan="2">
+                                <label for="current_move_product_qty_available" />
+                                <div>
+                                    <field
+                                        name="current_move_product_qty_available"
+                                        class="mr8"
+                                    />
+                                </div>
+                                <label for="current_move_product_outgoing_qty" />
+                                <div>
+                                    <field
+                                        name="current_move_product_outgoing_qty"
+                                        class="mr8"
+                                    />
+                                </div>
+                                <label
+                                    for="current_move_product_last_lot_life_date"
+                                    attrs="{'invisible': [('current_move_has_tracking', '=', 'none')]}"
                                 />
-                            </div>
-                            <label for="current_move_product_vendor_code" />
-                            <div>
-                                <field
-                                    name="current_move_product_vendor_code"
-                                    class="mr8"
-                                />
-                            </div>
-                            <hr colspan="2" />
+                                <div
+                                    attrs="{'invisible': [('current_move_has_tracking', '=', 'none')]}"
+                                >
+                                    <field
+                                        name="current_move_product_last_lot_life_date"
+                                        class="mr8"
+                                    />
+                                </div>
+                            </group>
+                            <hr colspan="4" />
                         </group>
                         <group
                             attrs="{'invisible': [('current_move_line_id', '=', False)]}"

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -94,6 +94,7 @@
                 <field name="current_move_product_id" invisible="1" />
                 <field name="current_move_line_id" invisible="1" />
                 <field name="package_storage_type_height_required" invisible="1" />
+                <field name="allowed_location_dest_ids" invisible="1" />
                 <div class="o_screen_data">
                     <div class="o_screen_data_content" name="data">
                         <group attrs="{'invisible': [('current_move_id', '=', False)]}">
@@ -230,7 +231,7 @@
                       'readonly': [('current_step', '!=', 'set_location')],
                     }"
                                         options="{'no_open': True, 'no_create_edit': True}"
-                                        domain="[('id', 'child_of', picking_location_dest_id), ('usage', '!=', 'view')]"
+                                        domain="[('usage', '!=', 'view'), ('id', 'in', allowed_location_dest_ids)]"
                                     />
                                 </div>
                                 <!-- set_package -->


### PR DESCRIPTION
- invert the `set_location` and `select_packaging` steps
- filter the list of available destinations based on the package storage type
- product info: display the qty available, outgoing qty and the most recent expiry date

Ref. 1967

- Do not use anymore a compute+inverse field to handle the destination location of the processed move line to avoid sync issues. Instead a dedicated field is now used to handle the user's input (and its initial/default value)

Ref. 2039