### PR TITLE
[13.0][IMP] shopfloor: Add standard messages for Checkout Packing Info

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.2.5.0",
+    "version": "13.0.2.6.0",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",
@@ -39,6 +39,10 @@
         # TODO: used for picking.carrier_id detail info.
         # This must be an optional dep
         "delivery",
+        # If "delivery" must be an optional dep, then sales_team must be also.
+        # Added to make normal sales users CRUD the shopfloor packing info.
+        # It is indirectly imported by "delivery".
+        "sales_team",
         #  OCA / product-attribute
         "product_packaging_type",
     ],
@@ -54,6 +58,7 @@
         "views/stock_picking_views.xml",
         "views/shopfloor_profile_views.xml",
         "views/shopfloor_log_views.xml",
+        "views/shopfloor_packing_info_views.xml",
         "views/menus.xml",
     ],
     "demo": [
@@ -61,5 +66,6 @@
         "demo/stock_picking_type_demo.xml",
         "demo/shopfloor_menu_demo.xml",
         "demo/shopfloor_profile_demo.xml",
+        "demo/shopfloor_packing_info_demo.xml",
     ],
 }

--- a/shopfloor/demo/shopfloor_packing_info_demo.xml
+++ b/shopfloor/demo/shopfloor_packing_info_demo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="package_20kg" model="shopfloor.packing.info">
+        <field name="name">Package 20kg</field>
+        <field name="text">Max weight per package 20kg</field>
+    </record>
+    <record id="pallet_170cm" model="shopfloor.packing.info">
+        <field name="name">Pallet 1.7m</field>
+        <field name="text">Pallet height limit 1.7m</field>
+    </record>
+</odoo>

--- a/shopfloor/migrations/13.0.2.6.0/post-migration.py
+++ b/shopfloor/migrations/13.0.2.6.0/post-migration.py
@@ -1,0 +1,61 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+import hashlib
+import os
+
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+
+    shopfloor_packing_info = env["shopfloor.packing.info"]
+    res_partner = env["res.partner"]
+    ir_model_data = env["ir.model.data"]
+
+    env.cr.execute(
+        """
+        SELECT id, COALESCE(shopfloor_packing_info_tmp, '') AS packing_info_old
+        FROM res_partner
+        WHERE active = TRUE;
+        """
+    )
+
+    for row in env.cr.dictfetchall():
+        partner_id = int(row["id"])
+        packing_info_full = row["packing_info_old"].strip()
+        if packing_info_full:
+            partner = res_partner.browse(partner_id)
+
+            # We assume the name is the first line, if there are several.
+            linesep_pos = packing_info_full.find(os.linesep)
+            if linesep_pos == -1:
+                packing_info_name = packing_info_full
+            else:
+                packing_info_name = packing_info_full[:linesep_pos]
+
+            # If a record already exists, assign it; otherwise: create and assign.
+            packing_info_record = shopfloor_packing_info.search(
+                [("name", "=", packing_info_name), ("text", "=", packing_info_full)],
+                limit=1,
+            )
+            if packing_info_record:
+                partner.shopfloor_packing_info_id = packing_info_record
+            else:
+                packing_info_record = shopfloor_packing_info.create(
+                    {"name": packing_info_name, "text": packing_info_full}
+                )
+                partner.shopfloor_packing_info_id = packing_info_record
+                xml_id = hashlib.md5(packing_info_full.encode("utf-8")).hexdigest()
+                ir_model_data._update_xmlids(
+                    [
+                        {
+                            "xml_id": "shopfloor.packing_info_{}".format(xml_id),
+                            "record": packing_info_record,
+                            "noupdate": True,
+                        }
+                    ]
+                )
+    openupgrade.drop_columns(env.cr, [("res_partner", "shopfloor_packing_info_tmp")])

--- a/shopfloor/migrations/13.0.2.6.0/pre-migration.py
+++ b/shopfloor/migrations/13.0.2.6.0/pre-migration.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+from openupgradelib import openupgrade  # pylint: disable=W7936
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+    openupgrade.copy_columns(
+        env.cr,
+        {
+            "res_partner": [
+                ("shopfloor_packing_info", "shopfloor_packing_info_tmp", None,)
+            ],
+        },
+    )

--- a/shopfloor/models/__init__.py
+++ b/shopfloor/models/__init__.py
@@ -2,6 +2,7 @@ from . import priority_postpone_mixin
 from . import res_partner
 from . import shopfloor_menu
 from . import shopfloor_log
+from . import shopfloor_packing_info
 from . import stock_picking_type
 from . import shopfloor_profile
 from . import stock_inventory

--- a/shopfloor/models/res_partner.py
+++ b/shopfloor/models/res_partner.py
@@ -6,4 +6,8 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    shopfloor_packing_info = fields.Text(string="Checkout Packing Information")
+    shopfloor_packing_info_id = fields.Many2one(
+        "shopfloor.packing.info",
+        ondelete="restrict",
+        string="Checkout Packing Information",
+    )

--- a/shopfloor/models/shopfloor_packing_info.py
+++ b/shopfloor/models/shopfloor_packing_info.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA (https://www.camptocamp.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class ShopfloorPackingInfo(models.Model):
+    _name = "shopfloor.packing.info"
+    _description = "Shopfloor Packing Info"
+
+    name = fields.Char("Name", required=True)
+    text = fields.Text("Text", required=True)
+    active = fields.Boolean("Active", default=True)
+
+    def unlink(self):  # pylint: disable=W8106
+        """Archive, not unlink"""
+        self.write({"active": False})
+
+    def toggle_active(self):
+        for record in self:
+            record.active = not record.active

--- a/shopfloor/models/stock_picking.py
+++ b/shopfloor/models/stock_picking.py
@@ -17,8 +17,8 @@ class StockPicking(models.Model):
     shopfloor_display_packing_info = fields.Boolean(
         related="picking_type_id.shopfloor_display_packing_info",
     )
-    shopfloor_packing_info = fields.Text(
-        string="Packing information", related="partner_id.shopfloor_packing_info",
+    shopfloor_packing_info_id = fields.Many2one(
+        string="Packing information", related="partner_id.shopfloor_packing_info_id",
     )
 
     @api.depends(

--- a/shopfloor/security/ir.model.access.csv
+++ b/shopfloor/security/ir.model.access.csv
@@ -4,3 +4,6 @@
 "access_shopfloor_profile_users","shopfloor profile","model_shopfloor_profile","stock.group_stock_user",1,0,0,0
 "access_shopfloor_profile_stock_manager","shopfloor profile inventory manager","model_shopfloor_profile","stock.group_stock_manager",1,1,1,1
 "access_shopfloor_log","access_shopfloor_log","model_shopfloor_log","stock.group_stock_manager",1,0,0,0
+"access_shopfloor_packing_info_user","shopfloor packing info user","model_shopfloor_packing_info","stock.group_stock_user",1,0,0,0
+"access_shopfloor_packing_info_manager","shopfloor packing info manager","model_shopfloor_packing_info","stock.group_stock_manager",1,1,1,0
+"access_shopfloor_packing_info_salesman","shopfloor packing info salesman","model_shopfloor_packing_info","sales_team.group_sale_salesman",1,1,1,0

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -85,7 +85,11 @@ class Checkout(Component):
 
     def _data_for_packing_info(self, picking):
         if picking.picking_type_id.shopfloor_display_packing_info:
-            return picking.shopfloor_packing_info or ""
+            return (
+                picking.shopfloor_packing_info_id
+                and picking.shopfloor_packing_info_id.text
+                or ""
+            )
         return ""
 
     def _response_for_select_dest_package(self, picking, move_lines, message=None):

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -68,3 +68,4 @@ from . import test_scan_anything
 from . import test_stock_split
 from . import test_picking_form
 from . import test_db_logging
+from . import test_shopfloor_packing_info

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -35,7 +35,12 @@ class CheckoutScanLineCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
         picking = self._create_picking(
             lines=[(self.product_a, 10), (self.product_b, 10)]
         )
-        picking.sudo().partner_id.shopfloor_packing_info = "Please do it like this!"
+        shopfloor_packing_info = (
+            self.env["shopfloor.packing.info"]
+            .sudo()
+            .create({"name": "Test", "text": "Please do it like this!"})
+        )
+        picking.sudo().partner_id.shopfloor_packing_info_id = shopfloor_packing_info
         picking.sudo().picking_type_id.shopfloor_display_packing_info = True
         move1 = picking.move_lines[0]
         move2 = picking.move_lines[1]

--- a/shopfloor/tests/test_checkout_select_package_base.py
+++ b/shopfloor/tests/test_checkout_select_package_base.py
@@ -20,7 +20,9 @@ class CheckoutSelectPackageMixin:
                     self._move_line_data(ml) for ml in selected_lines.sorted()
                 ],
                 "picking": self._picking_summary_data(picking),
-                "packing_info": picking.shopfloor_packing_info if packing_info else "",
+                "packing_info": picking.shopfloor_packing_info_id.text
+                if packing_info
+                else "",
                 "no_package_enabled": no_package_enabled,
             },
             message=message,

--- a/shopfloor/tests/test_shopfloor_packing_info.py
+++ b/shopfloor/tests/test_shopfloor_packing_info.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Camptocamp SA (http2://www.camptocamp.com)
+# License AGPL-3.0 or later (http2://www.gnu.org/licenses/agpl.html)
+from odoo.tests.common import SavepointCase
+
+
+class TestShopfloorPackingInfo(SavepointCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_unlink(self):
+        packing_info = self.env["shopfloor.packing.info"].create(
+            {"name": "Test Name", "text": "Test Text"}
+        )
+        partner = self.env["res.partner"].create(
+            {"name": "Partner", "shopfloor_packing_info_id": packing_info.id}
+        )
+        self.assertTrue(packing_info.active)
+        self.assertEqual(partner.shopfloor_packing_info_id, packing_info)
+        packing_info.unlink()
+        self.assertFalse(packing_info.active)
+        self.assertEqual(partner.shopfloor_packing_info_id, packing_info)

--- a/shopfloor/views/menus.xml
+++ b/shopfloor/views/menus.xml
@@ -19,6 +19,12 @@
         sequence="20"
     />
     <menuitem
+        action="action_shopfloor_packing_info"
+        id="menu_action_shopfloor_packing_info"
+        parent="menu_shopfloor_settings"
+        sequence="25"
+    />
+    <menuitem
         action="action_shopfloor_log"
         id="menu_action_shopfloor_log"
         parent="menu_shopfloor_settings"

--- a/shopfloor/views/res_partner.xml
+++ b/shopfloor/views/res_partner.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//page[@name='sales_purchases']/group" position="inside">
                 <group string="Shopfloor" name="shopfloor">
-                    <field name="shopfloor_packing_info" />
+                    <field name="shopfloor_packing_info_id" />
                 </group>
             </xpath>
         </field>

--- a/shopfloor/views/shopfloor_packing_info_views.xml
+++ b/shopfloor/views/shopfloor_packing_info_views.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="shopfloor_packing_info_tree_view" model="ir.ui.view">
+        <field name="name">shopfloor.packing.info tree</field>
+        <field name="model">shopfloor.packing.info</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name" />
+                <field name="text" />
+                <field name="active" />
+            </tree>
+        </field>
+    </record>
+    <record id="shopfloor_packing_info_form_view" model="ir.ui.view">
+        <field name="name">shopfloor.packing.info form</field>
+        <field name="model">shopfloor.packing.info</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <field name="active" invisible="1" />
+                    <button
+                        type="object"
+                        name="toggle_active"
+                        string="Archive"
+                        attrs="{'invisible': [('active', '=', False)]}"
+                    />
+                    <button
+                        type="object"
+                        name="toggle_active"
+                        string="Restore"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
+                </header>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name" />
+                            <field name="text" />
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+    <record id="shopfloor_packing_info_search_view" model="ir.ui.view">
+        <field name="name">shopfloor.packing.info search</field>
+        <field name="model">shopfloor.packing.info</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <field name="text" />
+                <field name="active" />
+                <separator />
+                <filter
+                    string="All"
+                    name="all"
+                    domain="[('active', 'in', [False, True])]"
+                />
+            </search>
+        </field>
+    </record>
+    <record id="action_shopfloor_packing_info" model="ir.actions.act_window">
+        <field name="name">Checkout Packing Informations</field>
+        <field name="res_model">shopfloor.packing.info</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{}</field>
+        <field
+            name="view_ids"
+            eval="[(5, 0, 0),
+            (0, 0, {'view_mode': 'tree', 'view_id': ref('shopfloor.shopfloor_packing_info_tree_view')}),
+            (0, 0, {'view_mode': 'form', 'view_id': ref('shopfloor.shopfloor_packing_info_form_view')})]"
+        />
+        <field name="help" type="html">
+            <p class="o_view_nocontent_empty_folder">
+                Create a shopfloor packing information to be reused among customers.
+            </p>
+        </field>
+    </record>
+</odoo>

--- a/shopfloor/views/stock_picking_views.xml
+++ b/shopfloor/views/stock_picking_views.xml
@@ -12,7 +12,7 @@
                 <group name="shopfloor">
                     <field name="shopfloor_display_packing_info" invisible="1" />
                     <field
-                        name="shopfloor_packing_info"
+                        name="shopfloor_packing_info_id"
                         attrs="{'invisible':[('shopfloor_display_packing_info', '=', False)]}"
                     />
                 </group>
@@ -24,7 +24,7 @@
                 <group name="shopfloor">
                     <field name="shopfloor_display_packing_info" invisible="1" />
                     <field
-                        name="shopfloor_packing_info"
+                        name="shopfloor_packing_info_id"
                         attrs="{'invisible':[('shopfloor_display_packing_info', '=', False)]}"
                     />
                 </group>


### PR DESCRIPTION
This PR adds the option to choose predefined messages for the
parameter "Checkout Packing Info", that is set on the res.partner
and reused in other places. For this, the original text field
shopfloor_packing_info has been transformed into a Many2one that
points to the new model shopfloor.packing.info. Thus, the field
in the res.partner has been renamed to shopfloor_packing_info_id,
that has caused some renames in other files that used it. These
new messages are archived instead of deleted, to keep track of
old messages associated to existing (or archived) res.partners.

The new predefined messages can be created directly in the partner
or in the menu Inventory > Settings > Shopfloor.

To migrate the data, the existing data has been migrated by assuming
that the first line is the name while all the content is for the text
of the new model.