### PR TITLE
[13.0][FIX] shopfloor: handle better lines priority

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -749,7 +749,7 @@ class ClusterPicking(Component):
                 batch, message=self.msg_store.operation_not_found()
             )
         # flag as postponed
-        move_line.shopfloor_postponed = True
+        move_line.shopfloor_postpone(self._lines_to_pick(batch))
         return self._pick_after_skip_line(move_line)
 
     def _pick_after_skip_line(self, move_line):

--- a/shopfloor/tests/test_cluster_picking_skip.py
+++ b/shopfloor/tests/test_cluster_picking_skip.py
@@ -60,17 +60,29 @@ class ClusterPickingSkipLineCase(ClusterPickingCommonCase):
         )
 
         # skip line from loc 1
+        previous_priority = loc1_lines[0].shopfloor_priority
         self._skip_line(loc1_lines[0], loc1_lines[1])
+        self.assertEqual(loc1_lines[0].shopfloor_priority, previous_priority + 1)
+        loc1_lines.invalidate_cache(["shopfloor_postponed"])
         self.assertTrue(loc1_lines[0].shopfloor_postponed)
 
         # 2nd line, next is 1st from 2nd location
         self.assertFalse(loc1_lines[1].shopfloor_postponed)
         self._skip_line(loc1_lines[1], loc2_lines[0])
+        # Priority is now the current max + 1
+        self.assertEqual(
+            loc1_lines[1].shopfloor_priority, loc1_lines[0].shopfloor_priority + 1
+        )
+        loc1_lines.invalidate_cache(["shopfloor_postponed"])
         self.assertTrue(loc1_lines[1].shopfloor_postponed)
 
         # 3rd line, next is 4th
         self.assertFalse(loc2_lines[0].shopfloor_postponed)
         self._skip_line(loc2_lines[0], loc2_lines[1])
+        self.assertEqual(
+            loc2_lines[0].shopfloor_priority, loc1_lines[1].shopfloor_priority + 1
+        )
+        loc1_lines.invalidate_cache(["shopfloor_postponed"])
         self.assertTrue(loc2_lines[0].shopfloor_postponed)
 
 

--- a/shopfloor/tests/test_location_content_transfer_single.py
+++ b/shopfloor/tests/test_location_content_transfer_single.py
@@ -326,6 +326,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
 
     def test_postpone_package_ok(self):
         package_level = self.picking1.move_line_ids.package_level_id
+        previous_priority = package_level.shopfloor_priority
         self.assertFalse(package_level.shopfloor_postponed)
         response = self.service.dispatch(
             "postpone_package",
@@ -335,6 +336,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
             },
         )
         self.assertTrue(package_level.shopfloor_postponed)
+        self.assertEqual(package_level.shopfloor_priority, previous_priority + 1)
         move_lines = self.service._find_transfer_move_lines(self.content_loc)
         self.assert_response_start_single(
             response, move_lines.mapped("picking_id"),
@@ -384,12 +386,14 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
 
     def test_postpone_line_ok(self):
         move_line = self.picking2.move_line_ids[0]
+        previous_priority = move_line.shopfloor_priority
         self.assertFalse(move_line.shopfloor_postponed)
         response = self.service.dispatch(
             "postpone_line",
             params={"location_id": self.content_loc.id, "move_line_id": move_line.id},
         )
         self.assertTrue(move_line.shopfloor_postponed)
+        self.assertEqual(move_line.shopfloor_priority, previous_priority + 1)
         move_lines = self.service._find_transfer_move_lines(self.content_loc)
         self.assert_response_start_single(
             response, move_lines.mapped("picking_id"),


### PR DESCRIPTION
**Before:**
when postponing lines to process, the priority was set to a
constant value 9999. But if all remaining lines to process have been
postponed, their priority was all set to 9999 (= no order) and it is
impossible to know what was the first lines which have been postponed
and that we should care about.
Also, the `shopfloor_postponed` boolean field was returning `True` if
the current priority was equal to 9999.

**After:**
Now to postpone a line we have to call the `shopfloor_postpone()`
method which will increment the priority of the line based on the max
priority used among all other lines of the current scope.
As a result, lines will always been ordered as expected, but as a
side-effect the `shopfloor_postponed` boolean field will always return
`True` as soon as the line has been postponed, but this is probably not
an issue in the lifecycle of the processed line.

Ref. 2018