### PR TITLE
[13.0] Optimize "location_is_empty" computed field on stock.location

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -143,19 +143,20 @@ class StockLocation(models.Model):
 
     def _should_compute_will_contain_product_ids(self):
         return self.usage == "internal" and any(
-            location.do_not_mix_products
-            for location in self.allowed_location_storage_type_ids
+            location_storage_type.do_not_mix_products
+            for location_storage_type in self.allowed_location_storage_type_ids
         )
 
     def _should_compute_will_contain_lot_ids(self):
         return self.usage == "internal" and any(
-            location.do_not_mix_lots
-            for location in self.allowed_location_storage_type_ids
+            location_storage_type.do_not_mix_lots
+            for location_storage_type in self.allowed_location_storage_type_ids
         )
 
     def _should_compute_is_empty(self):
         return self.usage == "internal" and any(
-            location.only_empty for location in self.allowed_location_storage_type_ids
+            location_storage_type.only_empty
+            for location_storage_type in self.allowed_location_storage_type_ids
         )
 
     @api.depends(


### PR DESCRIPTION
This field is used only when applying a related location storage
type with "only_empty". As the field is computed each time
a stock.move, a stock.move.line or a quant references a location
and the computation reads all the quants and moves linked to
the location, we can prevent a lot of read and computation by
not computing this if it has no location storage type that will
need it. (ex 'Output' location).