### PR TITLE
[13.0] stock_storage_type: optimize stored compute fields on stock.location

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -161,13 +161,16 @@ class StockLocation(models.Model):
     )
     def _compute_location_will_contain_product_ids(self):
         for rec in self:
-            products = self.env["product.product"].browse()
-            if rec._should_compute_will_contain_product_ids():
-                products = (
-                    rec.mapped("quant_ids.product_id")
-                    | rec.mapped("in_move_ids.product_id")
-                    | rec.mapped("in_move_line_ids.product_id")
-                )
+            if not rec._should_compute_will_contain_product_ids():
+                if rec.location_will_contain_product_ids:
+                    no_product = self.env["product.product"].browse()
+                    rec.location_will_contain_product_ids = no_product
+                continue
+            products = (
+                rec.mapped("quant_ids.product_id")
+                | rec.mapped("in_move_ids.product_id")
+                | rec.mapped("in_move_line_ids.product_id")
+            )
             rec.location_will_contain_product_ids = products
 
     @api.depends(
@@ -177,11 +180,14 @@ class StockLocation(models.Model):
     )
     def _compute_location_will_contain_lot_ids(self):
         for rec in self:
-            lots = self.env["stock.production.lot"].browse()
-            if rec._should_compute_will_contain_lot_ids():
-                lots = rec.mapped("quant_ids.lot_id") | rec.mapped(
-                    "in_move_line_ids.lot_id"
-                )
+            if not rec._should_compute_will_contain_lot_ids():
+                if rec.location_will_contain_lot_ids:
+                    no_lot = self.env["stock.production.lot"].browse()
+                    rec.location_will_contain_lot_ids = no_lot
+                continue
+            lots = rec.mapped("quant_ids.lot_id") | rec.mapped(
+                "in_move_line_ids.lot_id"
+            )
             rec.location_will_contain_lot_ids = lots
 
     @api.depends(
@@ -195,7 +201,9 @@ class StockLocation(models.Model):
             if rec.usage != "internal":
                 # No restriction should apply on customer/supplier/...
                 # locations.
-                rec.location_is_empty = True
+                if not rec.location_is_empty:
+                    # avoid write if not required
+                    rec.location_is_empty = True
                 continue
             if (
                 sum(rec.quant_ids.mapped("quantity"))

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -145,19 +145,20 @@ class StockLocation(models.Model):
 
     def _should_compute_will_contain_product_ids(self):
         return self.usage == "internal" and any(
-            location.do_not_mix_products
-            for location in self.allowed_location_storage_type_ids
+            storage_type.do_not_mix_products
+            for storage_type in self.allowed_location_storage_type_ids
         )
 
     def _should_compute_will_contain_lot_ids(self):
         return self.usage == "internal" and any(
-            location.do_not_mix_lots
-            for location in self.allowed_location_storage_type_ids
+            storage_type.do_not_mix_lots
+            for storage_type in self.allowed_location_storage_type_ids
         )
 
     def _should_compute_location_is_empty(self):
         return self.usage == "internal" and any(
-            location.only_empty for location in self.allowed_location_storage_type_ids
+            storage_type.only_empty
+            for storage_type in self.allowed_location_storage_type_ids
         )
 
     @api.depends(

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -57,7 +57,9 @@ class StockLocation(models.Model):
         compute="_compute_location_is_empty",
         store=True,
         help="technical field: True if the location is empty "
-        "and there is no pending incoming products in the location",
+        "and there is no pending incoming products in the location. "
+        " Computed only if the location needs to check for emptiness "
+        '(has an "only empty" location storage type).',
     )
 
     in_move_ids = fields.One2many(
@@ -153,6 +155,11 @@ class StockLocation(models.Model):
             for location in self.allowed_location_storage_type_ids
         )
 
+    def _should_compute_location_is_empty(self):
+        return self.usage == "internal" and any(
+            location.only_empty for location in self.allowed_location_storage_type_ids
+        )
+
     @api.depends(
         "quant_ids",
         "in_move_ids",
@@ -195,16 +202,22 @@ class StockLocation(models.Model):
         "out_move_line_ids.qty_done",
         "in_move_ids",
         "in_move_line_ids",
+        "allowed_location_storage_type_ids.only_empty",
     )
     def _compute_location_is_empty(self):
         for rec in self:
-            if rec.usage != "internal":
-                # No restriction should apply on customer/supplier/...
-                # locations.
+            # No restriction should apply on customer/supplier/...
+            # locations and we don't need to compute is empty
+            # if there is no limit on the location
+            if not rec._should_compute_location_is_empty():
+                # avoid write if not required
                 if not rec.location_is_empty:
-                    # avoid write if not required
                     rec.location_is_empty = True
                 continue
+            # we do want to keep a write here even if the value is the same
+            # to enforce concurrent transaction safety: 2 moves taking
+            # quantities in a location have to be executed sequentially
+            # or the location could remain "not empty"
             if (
                 sum(rec.quant_ids.mapped("quantity"))
                 - sum(rec.out_move_line_ids.mapped("qty_done"))


### PR DESCRIPTION
Goal: avoid writes on stock.location when not necessary

3 stored computed fields on stock.location are used for storage type-based put-aways:

* Only Empty
* Will contain products
* Will contain lots

These fields are updated depending on the move/move lines/quants that goes in (or out for `location_is_empty`) of the location. These fields are actually used when:

* Only Empty: when we want to put something in a location, and it has a location storage type "Only Empty"
* Will contain products: when we want to put something in a location, and it has a location storage type "Do not mix products"
* Will contain lots: when we want to put something in a location, and it has a location storage type "Do not mix lots"

For the 2 last fields, the commits 461a26e changed them to be computed only if the location has a storage type with "do not mix...".  In this PR, the commit 40236907 does the same for `location_is_empty`. Details in the commit.

The previous commit e89b281 ensured that we would not compute these fields for non-internal locations, but even if not computed, the value was still written. The commit 9a3da83def3 updates the value for non-internal (or any that doesn't need the computation) locations only if it changes. We want to keep writing the values on locations that needs these constraints to be satisfied even if they don't change, to guarantee the end result is correct in case of concurrent transactions.

Another improvement that could be done is to try to acquire a `FOR UPDATE NOWAIT` lock when a location has been selected for a put-away and skip to the next in case it can't, which can prevent a retry of the transaction in case of concurrent errors.