### PR TITLE
[13.0][IMP] Reception screen warning messages

### DIFF
--- a/stock_reception_screen/__manifest__.py
+++ b/stock_reception_screen/__manifest__.py
@@ -18,8 +18,6 @@
         "stock_quant_package_dimension",
         # OCA/wms
         "stock_storage_type",
-        # OCA/web
-        "web_notify",
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -190,6 +190,23 @@ class StockReceptionScreen(models.Model):
     package_height = fields.Integer()
     # == / Packaging fields ==
 
+    warn_notification = fields.Char(default=False)
+    warn_notification_html = fields.Html(compute="_compute_warn_notification")
+
+    @api.depends("warn_notification")
+    def _compute_warn_notification(self):
+        warn_massage_html = """
+        <div class="alert alert-warning" role="alert">
+            {}
+        </div>
+        """
+        if self.warn_notification:
+            self.warn_notification_html = warn_massage_html.format(
+                self.warn_notification
+            )
+        else:
+            self.warn_notification_html = False
+
     @api.depends("picking_id.move_lines", "current_filter_product")
     def _compute_picking_filtered_move_lines(self):
         for screen in self:
@@ -350,6 +367,7 @@ class StockReceptionScreen(models.Model):
 
     def on_barcode_scanned_select_product(self, barcode):
         """Try to find the corresponding product based on the barcode."""
+        self.warn_notification = False
         moves = self.picking_id.move_lines
         # First find a moves corresponding to the barcode
         move = moves.filtered(lambda o: o.product_id.barcode == barcode)
@@ -360,9 +378,7 @@ class StockReceptionScreen(models.Model):
         if not move:
             move = moves.filtered(lambda o: barcode in o.product_id.name)
         if not move:
-            self.env.user.notify_warning(
-                message="", title=_("Product '{}' not found.").format(barcode)
-            )
+            self.warn_notification = _("Product '{}' not found.").format(barcode)
             return
         # If there are several moves/products corresponding to the search
         # criteria we want to propose the user to choose the right one
@@ -395,9 +411,7 @@ class StockReceptionScreen(models.Model):
             ]
         )
         if lot:
-            self.env.user.notify_info(
-                message="", title=_("Reuse the existing lot {}.").format(barcode)
-            )
+            self.warn_notification = _("Reuse the existing lot {}.").format(barcode)
         else:
             lot_vals = {
                 "name": barcode,
@@ -554,10 +568,9 @@ class StockReceptionScreen(models.Model):
         return self.current_move_id.has_tracking != "none"
 
     def process_set_lot_number(self):
+        self.warn_notification = False
         if not self.current_move_line_id.lot_id:
-            self.env.user.notify_warning(
-                message="", title=_("You have to fill the lot number.")
-            )
+            self.warn_notification = _("You have to fill the lot number.")
             return
         # Saving the lot number for next operation
         self.current_move_id.last_move_line_lot_id = self.current_move_line_id.lot_id
@@ -565,10 +578,9 @@ class StockReceptionScreen(models.Model):
 
     def process_set_expiry_date(self):
         """Set the lot life date on a move line."""
+        self.warn_notification = False
         if not self.current_move_line_lot_life_date:
-            self.env.user.notify_warning(
-                message="", title=_("You have to set an expiry date.")
-            )
+            self.warn_notification = _("You have to set an expiry date.")
             return
         if (
             self.current_move_line_lot_id.life_date
@@ -579,13 +591,10 @@ class StockReceptionScreen(models.Model):
             previous_life_date_str = self.current_move_line_lot_id.life_date.strftime(
                 lang.date_format
             )
-            self.env.user.notify_warning(
-                message="",
-                title=_(
-                    "You cannot set a date prior to previous one ({})".format(
-                        previous_life_date_str
-                    )
-                ),
+            self.warn_notification = _(
+                "You cannot set a date prior to previous one ({})".format(
+                    previous_life_date_str
+                )
             )
             return
         self.current_move_line_lot_id.life_date = self.current_move_line_lot_life_date
@@ -593,9 +602,7 @@ class StockReceptionScreen(models.Model):
 
     def process_set_quantity(self):
         if not self.current_move_line_qty_done:
-            self.env.user.notify_warning(
-                message="", title=_("You have to set the received quantity.")
-            )
+            self.warn_notification = _("You have to set the received quantity.")
             return
         self.next_step()
 
@@ -641,10 +648,9 @@ class StockReceptionScreen(models.Model):
         return True
 
     def process_set_location(self):
+        self.warn_notification = False
         if not self.current_move_line_location_dest_stored_id:
-            self.env.user.notify_warning(
-                message="", title=_("You have to set the destination.")
-            )
+            self.warn_notification = _("You have to set the destination.")
             return
         self.current_move_line_id.location_dest_id = (
             self.current_move_line_location_dest_stored_id
@@ -688,9 +694,11 @@ class StockReceptionScreen(models.Model):
         (allowing to quit the reception screen via the exit button and resume
         the step later).
         """
+        self.warn_notification = False
         if not self.package_storage_type_id:
-            msg = _("The storage type is mandatory before going further.")
-            self.env.user.notify_warning(message="", title=msg)
+            self.warn_notification = _(
+                "The storage type is mandatory before going further."
+            )
             return False
         if (
             self.product_packaging_id
@@ -706,8 +714,9 @@ class StockReceptionScreen(models.Model):
                 or not self.product_packaging_id.max_weight
             )
         ):
-            msg = _("Product packaging info are missing. Please use the CUBISCAN.")
-            self.env.user.notify_warning(message="", title=msg)
+            self.warn_notification = _(
+                "Product packaging info are missing. Please use the CUBISCAN."
+            )
             return False
         return True
 

--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -367,7 +367,6 @@ class StockReceptionScreen(models.Model):
 
     def on_barcode_scanned_select_product(self, barcode):
         """Try to find the corresponding product based on the barcode."""
-        self.warn_notification = False
         moves = self.picking_id.move_lines
         # First find a moves corresponding to the barcode
         move = moves.filtered(lambda o: o.product_id.barcode == barcode)
@@ -568,7 +567,6 @@ class StockReceptionScreen(models.Model):
         return self.current_move_id.has_tracking != "none"
 
     def process_set_lot_number(self):
-        self.warn_notification = False
         if not self.current_move_line_id.lot_id:
             self.warn_notification = _("You have to fill the lot number.")
             return
@@ -578,7 +576,6 @@ class StockReceptionScreen(models.Model):
 
     def process_set_expiry_date(self):
         """Set the lot life date on a move line."""
-        self.warn_notification = False
         if not self.current_move_line_lot_life_date:
             self.warn_notification = _("You have to set an expiry date.")
             return
@@ -648,7 +645,6 @@ class StockReceptionScreen(models.Model):
         return True
 
     def process_set_location(self):
-        self.warn_notification = False
         if not self.current_move_line_location_dest_stored_id:
             self.warn_notification = _("You have to set the destination.")
             return
@@ -694,7 +690,6 @@ class StockReceptionScreen(models.Model):
         (allowing to quit the reception screen via the exit button and resume
         the step later).
         """
-        self.warn_notification = False
         if not self.package_storage_type_id:
             self.warn_notification = _(
                 "The storage type is mandatory before going further."
@@ -732,6 +727,8 @@ class StockReceptionScreen(models.Model):
         self.ensure_one()
         if not self.current_move_id and not self.current_move_line_id:
             return
+        # Reset warning
+        self.warn_notification = False
         method = "process_{}".format(self.current_step)
         getattr(self, method)()
         return True
@@ -749,6 +746,8 @@ class StockReceptionScreen(models.Model):
         if not self.current_move_id and not self.current_move_line_id:
             return
         assert self.current_step == "set_package", f"step = {self.current_step}"
+        # Reset warning
+        self.warn_notification = False
         # Copy relevant data for the next package
         qty_done = self.current_move_line_qty_done
         location_dest = self.current_move_line_location_dest_stored_id

--- a/stock_reception_screen/views/stock_reception_screen.xml
+++ b/stock_reception_screen/views/stock_reception_screen.xml
@@ -26,8 +26,12 @@
                             <field name="picking_origin" readonly="1" />
                         </group>
                     </div>
-                    <div class="o_screen_header_right o_screen_header_content">
-                        <field name="picking_state" />
+                    <div class="o_screen_header_right o_screen_header_content ">
+                        <field name="warn_notification_html" readonly="1" />
+                        <field
+                            name="picking_state"
+                            attrs="{'invisible': [('warn_notification_html', '!=', False)]}"
+                        />
                     </div>
                 </div>
                 <div class="o_screen_actions">


### PR DESCRIPTION
### Context: 
Currently we use `web_notify` to show warning messages in the reception screen. But we noticed some bug:
If several tabs are open in the browser loading reception screen, sometimes the message is raised in the tab which is not currently visible. So far I coudn't find the solution for this bug.

### As an alternative solution I propose:
- Warning messages are stored in a HTML field and shown in the view if needed
- Dependency of `web_notify` can be removed.
