### PR TITLE
[13.0] stock_available_to_promise_release: Fix release of operation containing canceled moves

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -301,7 +301,7 @@ class StockMove(models.Model):
         for move in self:
             if not move.need_release:
                 continue
-            if move.state not in ("confirmed", "waiting"):
+            if move.state not in ("confirmed", "waiting", "done", "cancel"):
                 continue
             available_quantity = move.ordered_available_to_promise_qty
             if float_compare(available_quantity, 0, precision_digits=precision) <= 0:
@@ -337,6 +337,8 @@ class StockMove(models.Model):
         released_pickings = pulled_moves.picking_id
         unreleased_moves = released_pickings.move_lines - pulled_moves
         for unreleased_move in unreleased_moves:
+            if unreleased_move.state in ("done", "cancel"):
+                continue
             # no split will occur as we keep the same qty, but the move
             # will be assigned to a new stock.picking
             original_picking = unreleased_move.picking_id

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -43,7 +43,7 @@ class PromiseReleaseCommonCase(common.SavepointCase):
         """Create picking chain
 
         It runs the procurement group to create the moves required for
-        a product. According to the WH, it creates the pick/pack/ship
+        a product. According to the WH, it creates the pick+ship
         moves.
 
         Products must be a list of tuples (product, quantity) or


### PR DESCRIPTION
Supersedes the previous PR: https://github.com/OCA/wms/pull/55
Copy-paste the description:

If a delivery contains moves from multiple sales order and one of the SO
is canceled, the canceled moves should not be split not moved to a
separate operation.

This PR only adds a unit test (last commit).