### PR TITLE
[13.0][FIX] stock_reception_screen: split the move before validating

### DIFF
--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -1,7 +1,12 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import _, api, exceptions, fields, models
+from odoo import _, api, exceptions, fields, models, tools
+
+
+def gt(value1, value2, digits):
+    """Return True if value1 is greater than value2"""
+    return tools.float_compare(value1, value2, precision_digits=digits) == 1
 
 
 class StockReceptionScreen(models.Model):
@@ -490,12 +495,19 @@ class StockReceptionScreen(models.Model):
             self.process_select_move()
 
     def _validate_current_move(self):
-        """Split the current move with the move line qty done and
-        validate it.
-        It is performed right after the processing of the current move (so
-        before checking the next move to process).
-        """
+        """Split the current move with the move line qty done and validate it."""
         if self.current_move_line_id and self.current_move_id:
+            remaining_qty = (
+                self.current_move_id.product_uom_qty
+                - self.current_move_line_id.qty_done
+            )
+            # We don't want to create a new move with a negative qty if we
+            # receive more than expected.
+            digits = self.env["decimal.precision"].precision_get(
+                "Product Unit of Measure"
+            )
+            if gt(remaining_qty, 0, digits=digits):
+                self.current_move_id._split(remaining_qty)
             moves_todo = self.picking_id.move_lines.filtered(
                 lambda m: m.state not in ["done", "cancel"]
             )
@@ -520,7 +532,6 @@ class StockReceptionScreen(models.Model):
         """Check if there is remaining moves to process for the
         selected product.
         """
-        # self._validate_current_move()
         if not self.current_filter_product:
             return False
         moves_to_process_ok = any(

--- a/stock_reception_screen/tests/test_reception_screen.py
+++ b/stock_reception_screen/tests/test_reception_screen.py
@@ -174,7 +174,7 @@ class TestReceptionScreen(SavepointCase):
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "select_packaging")
         self.screen.package_storage_type_id = self.storage_type_pallet
-        self.screen.package_height = 20
+        self.screen.package_height = 20  # Received more than expected, 20 instead of 10
         self.screen.button_save_step()
         self.assertEqual(self.screen.current_step, "set_location")
         self.screen.current_move_line_location_dest_stored_id = self.location_dest


### PR DESCRIPTION
When we process a partial qty on the last move of the operation, the
operation should not be validated otherwise it'll create a backorder for
the remaining qty to receive.
Instead we have to split the current move with the remaining qty to
receive, so we get two moves and we only validate the current one.
Before commit 707013a8105ae5cf86008b0a3014dbeb1fba0cb6 it was not necessary
because the call to `_action_done` were already taking care of splitting
the partial processed qty to a new move.

Ref. 2139