### PR TITLE
[FIX] stock_reception_screen: last line received with button "Next Pack"

### DIFF
--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -755,8 +755,9 @@ class StockReceptionScreen(models.Model):
         package_storage_type = self.package_storage_type_id
         package_height = self.package_height
         # Validate the current package
-        if not self.process_set_package():
+        if not self.process_set_package() or self.current_step == "done":
             # Package data may be missing the first time, aborting operation
+            # OR, button Next Package was pressed when we had nothing pending.
             return
         # Stop when the current product/lot has been fully processed
         if self.current_step in ("select_product", "select_move"):


### PR DESCRIPTION
Fixes a crash that appeared when there were several lines to
pick and the last one was packed with the button "Next Pack".
For the case in which no more moves were waiting, there was
an assertion that was activated.

A test has been added to check this scenario. Because of the
test added, some refactoring in the file for tests has been done.