### PR TITLE
[13.0][FIX] s_storage_type: no storage type for delivery

### DIFF
--- a/stock_storage_type/models/stock_quant_package.py
+++ b/stock_storage_type/models/stock_quant_package.py
@@ -45,6 +45,11 @@ class StockQuantPackage(models.Model):
 
     def _sync_storage_type_from_packaging(self):
         for package in self:
+            if package.packaging_id:
+                # Do not set package storage type for delivery packages
+                # to not trigger constraint like height requirement
+                # (we are delivering them, not storing them)
+                continue
             storage_type = package.product_packaging_id.package_storage_type_id
             if not storage_type:
                 continue
@@ -52,6 +57,11 @@ class StockQuantPackage(models.Model):
 
     def _sync_storage_type_from_single_product(self):
         for package in self:
+            if package.packaging_id:
+                # Do not set package storage type for delivery packages
+                # to not trigger constraint like height requirement
+                # (we are delivering them, not storing them)
+                continue
             storage_type = package.single_product_id.product_package_storage_type_id
             if not storage_type:
                 continue

--- a/stock_storage_type/tests/__init__.py
+++ b/stock_storage_type/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_package_height_required
 from . import test_storage_type_move
 from . import test_storage_type_putaway_strategy
 from . import test_stock_location
+from . import test_auto_assign_storage_type

--- a/stock_storage_type/tests/test_auto_assign_storage_type.py
+++ b/stock_storage_type/tests/test_auto_assign_storage_type.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from .common import TestStorageTypeCommon
+
+
+class TestAutoAssignStorageType(TestStorageTypeCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product_packaging = cls.product_lot_pallets_product_packaging
+        cls.package_storage_type = cls.product_packaging.package_storage_type_id
+
+    def test_auto_assign_package_storage_type_without_packaging_id(self):
+        """Packages without `packaging_id` are internal packages and they
+        are intended to be stored in the warehouse.
+        On such packages storage type is automatically defined.
+        """
+        package = self.env["stock.quant.package"].create(
+            {"name": "TEST", "product_packaging_id": self.product_packaging.id}
+        )
+        self.assertEqual(package.package_storage_type_id, self.package_storage_type)
+
+    def test_auto_assign_package_storage_type_with_packaging_id(self):
+        """Packages with `packaging_id` are delivery packages and they are not
+        intended to be stored in the warehouse.
+        On such packages storage type is not set.
+        """
+        # Set a delivery packaging (which is a product.packaging without product_id set)
+        packaging = self.env["product.packaging"].create({"name": "TEST"})
+        package = self.env["stock.quant.package"].create(
+            {
+                "name": "TEST",
+                "product_packaging_id": self.product_packaging.id,
+                "packaging_id": packaging.id,
+            }
+        )
+        self.assertFalse(package.package_storage_type_id)


### PR DESCRIPTION
There is no need to set a package storage type on delivery packages (we
are not storing them).
This avoid to trigger blocking constraints (like height).