### PR TITLE
[FIX] stock_dynamic_routing_reserve_rule: fix Reservation Rules

### DIFF
--- a/stock_dynamic_routing_reserve_rule/models/stock_routing.py
+++ b/stock_dynamic_routing_reserve_rule/models/stock_routing.py
@@ -78,7 +78,7 @@ class StockRouting(models.Model):
     def action_view_reserve_rule(self):
         picking_types = self.picking_type_id | self.rule_ids.picking_type_id
         reserve_rules = self.env["stock.reserve.rule"].search(
-            [("picking_type_id", "in", picking_types.ids)]
+            [("picking_type_ids", "in", picking_types.ids)]
         )
         context = self.env.context
         if len(picking_types) == 1:


### PR DESCRIPTION
Button to access the reservation rules from a dynamic routing
crashed because of a bad name in a field, probably because of
an old refactoring.
