### PR TITLE
[13.0][IMP] shopfloor: checkout, use of delivery packages

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -100,6 +100,25 @@ class DataAction(Component):
             "qty",
         ]
 
+    @ensure_model("product.packaging")
+    def delivery_packaging(self, record, **kw):
+        return self._jsonify(record, self._delivery_packaging_parser, **kw)
+
+    def delivery_packaging_list(self, records, **kw):
+        return self.delivery_packaging(records, multi=True)
+
+    @property
+    def _delivery_packaging_parser(self):
+        return [
+            "id",
+            "name",
+            (
+                "packaging_type_id:packaging_type",
+                lambda rec, fname: rec.packaging_type_id.display_name,
+            ),
+            "barcode",
+        ]
+
     @ensure_model("stock.production.lot")
     def lot(self, record, **kw):
         return self._jsonify(record, self._lot_parser, **kw)

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -515,3 +515,9 @@ class MessageAction(Component):
             "message_type": "warning",
             "body": _("No valid package to select."),
         }
+
+    def no_delivery_packaging_available(self):
+        return {
+            "message_type": "warning",
+            "body": _("No delivery package type available."),
+        }

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -499,7 +499,19 @@ class MessageAction(Component):
     def packaging_invalid_for_carrier(self, packaging, carrier):
         return {
             "message_type": "error",
-            "body": _("Packaging {} does not match carrier {}.").format(
+            "body": _("Packaging {} is not allowed for carrier {}.").format(
                 packaging.name, carrier.name
             ),
+        }
+
+    def dest_package_not_valid(self, package):
+        return {
+            "message_type": "error",
+            "body": _("{} is not a valid destination package.").format(package.name),
+        }
+
+    def no_valid_package_to_select(self):
+        return {
+            "message_type": "warning",
+            "body": _("No valid package to select."),
         }

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -103,6 +103,14 @@ class ShopfloorSchemaAction(Component):
             "qty": {"type": "float", "required": True},
         }
 
+    def delivery_packaging(self):
+        return {
+            "id": {"required": True, "type": "integer"},
+            "name": {"type": "string", "nullable": False, "required": True},
+            "packaging_type": {"type": "string", "nullable": True, "required": True},
+            "barcode": {"type": "string", "nullable": True, "required": True},
+        }
+
     def picking_batch(self, with_pickings=False):
         schema = {
             "id": {"required": True, "type": "integer"},

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -92,15 +92,17 @@ class Checkout(Component):
         return ""
 
     def _response_for_select_dest_package(self, picking, move_lines, message=None):
-        packages = picking.mapped("move_line_ids.result_package_id")
+        packages = picking.mapped("move_line_ids.result_package_id").filtered("packaging_id")
         if not packages:
+            # FIXME: do we want to move from 'select_dest_package' to
+            # 'select_package' state? Until now (before enforcing the use of
+            # delivery package) this part of code was never reached as we
+            # always had a package on the picking (source or result)
+            # Also the response validator did not support this state...
             return self._response_for_select_package(
                 picking,
                 move_lines,
-                message={
-                    "message_type": "warning",
-                    "body": _("No valid package to select."),
-                },
+                message=self.msg_store.no_valid_package_to_select(),
             )
         picking_data = self.data.picking(picking)
         packages_data = self.data.packages(
@@ -617,26 +619,30 @@ class Checkout(Component):
         return move_line.qty_done > 0 and move_line.shopfloor_checkout_done
 
     def _is_package_allowed(self, picking, package):
-        existing_packages = picking.mapped("move_line_ids.result_package_id")
+        """Check if a package is allowed as a destination/delivery package.
+
+        A package is allowed as a destination one if it is present among
+        `picking` lines and qualified as a "delivery package" (having a
+        delivery packaging set on it).
+        """
+        existing_packages = picking.mapped("move_line_ids.result_package_id").filtered(
+            "packaging_id"
+        )
         return package in existing_packages
 
     def _put_lines_in_package(self, picking, selected_lines, package):
         """Put the current selected lines with a qty_done in a package
 
-        Note: only packages which are already a destination package for another
+        Note: only packages which are already a delivery package for another
         line of the stock picking can be selected. Packages which are the
-        source packages are allowed too (we keep the current package), but
-        since Odoo set the value of the result package to the source package by
-        default, it works by default.
+        source packages are allowed too only if it is a delivery package (we
+        keep the current package).
         """
         if not self._is_package_allowed(picking, package):
             return self._response_for_select_package(
                 picking,
                 selected_lines,
-                message={
-                    "message_type": "error",
-                    "body": _("Not a valid destination package").format(package.name),
-                },
+                message=self.msg_store.dest_package_not_valid(package),
             )
         return self._put_lines_in_allowed_package(picking, selected_lines, package)
 
@@ -676,10 +682,10 @@ class Checkout(Component):
     def scan_package_action(self, picking_id, selected_line_ids, barcode):
         """Scan a package, a lot, a product or a package to handle a line
 
-        When a package is scanned, if the package is known as the destination
-        package of one of the lines or is the source package of a selected
-        line, the package is set to be the destination package of all then
-        lines to pack.
+        When a package is scanned (only delivery ones), if the package is known
+        as the destination package of one of the lines or is the source package
+        of a selected line, the package is set to be the destination package of
+        all the lines to pack.
 
         When a product is scanned, it selects (set qty_done = reserved qty) or
         deselects (set qty_done = 0) the move lines for this product. Only
@@ -730,6 +736,12 @@ class Checkout(Component):
 
         package = search.package_from_scan(barcode)
         if package:
+            if not package.packaging_id:
+                return self._response_for_select_package(
+                    picking,
+                    selected_lines,
+                    message=self.msg_store.dest_package_not_valid(package),
+                )
             return self._put_lines_in_package(picking, selected_lines, package)
 
         # Scan delivery packaging
@@ -822,16 +834,11 @@ class Checkout(Component):
         return self._response_for_select_dest_package(picking, lines)
 
     def _set_dest_package_from_selection(self, picking, selected_lines, package):
-        if not package:
-            return self._response_for_select_dest_package(picking, selected_lines)
         if not self._is_package_allowed(picking, package):
             return self._response_for_select_dest_package(
                 picking,
                 selected_lines,
-                message={
-                    "message_type": "error",
-                    "body": _("Not a valid destination package").format(package.name),
-                },
+                message=self.msg_store.dest_package_not_valid(package),
             )
         return self._put_lines_in_allowed_package(picking, selected_lines, package)
 
@@ -859,6 +866,12 @@ class Checkout(Component):
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
         search = self._actions_for("search")
         package = search.package_from_scan(barcode)
+        if not package:
+            return self._response_for_select_dest_package(
+                picking,
+                lines,
+                message=self.msg_store.package_not_found_for_barcode(barcode),
+            )
         return self._set_dest_package_from_selection(picking, lines, package)
 
     def set_dest_package(self, picking_id, selected_line_ids, package_id):
@@ -879,6 +892,10 @@ class Checkout(Component):
             return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
         package = self.env["stock.quant.package"].browse(package_id).exists()
+        if not package:
+            return self._response_for_select_dest_package(
+                picking, lines, message=self.msg_store.record_not_found(),
+            )
         return self._set_dest_package_from_selection(picking, lines, package)
 
     def summary(self, picking_id):
@@ -1347,12 +1364,22 @@ class ShopfloorCheckoutValidatorResponse(Component):
 
     def scan_dest_package(self):
         return self._response_schema(
-            next_states={"select_dest_package", "select_line", "summary"}
+            next_states={
+                "select_dest_package",
+                "select_package",
+                "select_line",
+                "summary",
+            }
         )
 
     def set_dest_package(self):
         return self._response_schema(
-            next_states={"select_dest_package", "select_line", "summary"}
+            next_states={
+                "select_dest_package",
+                "select_package",
+                "select_line",
+                "summary",
+            }
         )
 
     def summary(self):

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -92,7 +92,9 @@ class Checkout(Component):
         return ""
 
     def _response_for_select_dest_package(self, picking, move_lines, message=None):
-        packages = picking.mapped("move_line_ids.result_package_id").filtered("packaging_id")
+        packages = picking.mapped("move_line_ids.result_package_id").filtered(
+            "packaging_id"
+        )
         if not packages:
             # FIXME: do we want to move from 'select_dest_package' to
             # 'select_package' state? Until now (before enforcing the use of
@@ -116,6 +118,19 @@ class Checkout(Component):
                 "picking": picking_data,
                 "packages": packages_data,
                 "selected_move_lines": self._data_for_move_lines(move_lines.sorted()),
+            },
+            message=message,
+        )
+
+    def _response_for_select_delivery_packaging(self, picking, packaging, message=None):
+        return self._response(
+            next_state="select_delivery_packaging",
+            data={
+                # We don't need to send the 'picking' as the mobile frontend
+                # already has this info after `select_document` state
+                # TODO adapt other endpoints to see if we can get rid of the
+                # 'picking' data
+                "packaging": self._data_for_delivery_packaging(packaging),
             },
             message=message,
         )
@@ -233,6 +248,9 @@ class Checkout(Component):
 
     def _data_for_move_lines(self, lines, **kw):
         return self.data.move_lines(lines, **kw)
+
+    def _data_for_delivery_packaging(self, packaging, **kw):
+        return self.data.delivery_packaging_list(packaging, **kw)
 
     def _data_for_stock_picking(self, picking, done=False):
         data = self.data.picking(picking)
@@ -768,7 +786,42 @@ class Checkout(Component):
     def _packaging_good_for_carrier(self, packaging, carrier):
         return packaging.package_carrier_type in ("none", carrier.delivery_type)
 
-    def new_package(self, picking_id, selected_line_ids):
+    def _get_available_delivery_packaging(self, picking):
+        return self.env["product.packaging"].search(
+            [
+                ("product_id", "=", False),
+                (
+                    "package_carrier_type",
+                    "=",
+                    picking.carrier_id.delivery_type or "none",
+                ),
+            ],
+            order="name",
+        )
+
+    def list_delivery_packaging(self, picking_id, selected_line_ids):
+        """List available delivery packaging for given picking.
+
+        Transitions:
+        * select_delivery_packaging: list available delivery packaging, the
+        user has to choose one to create the new package
+        * select_package: when no delivery packaging is available
+        """
+        picking = self.env["stock.picking"].browse(picking_id)
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
+        selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
+        delivery_packaging = self._get_available_delivery_packaging(picking)
+        if not delivery_packaging:
+            return self._response_for_select_package(
+                picking,
+                selected_lines,
+                message=self.msg_store.no_delivery_packaging_available(),
+            )
+        return self._response_for_select_delivery_packaging(picking, delivery_packaging)
+
+    def new_package(self, picking_id, selected_line_ids, packaging_id=None):
         """Add all selected lines in a new package
 
         It creates a new package and set it as the destination package of all
@@ -785,8 +838,11 @@ class Checkout(Component):
         message = self._check_picking_status(picking)
         if message:
             return self._response_for_select_document(message=message)
+        packaging = None
+        if packaging_id:
+            packaging = self.env["product.packaging"].browse(packaging_id).exists()
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
-        return self._create_and_assign_new_packaging(picking, selected_lines)
+        return self._create_and_assign_new_packaging(picking, selected_lines, packaging)
 
     def no_package(self, picking_id, selected_line_ids):
         """Process all selected lines without any package.
@@ -1119,6 +1175,16 @@ class ShopfloorCheckoutValidator(Component):
             "barcode": {"required": True, "type": "string"},
         }
 
+    def list_delivery_packaging(self):
+        return {
+            "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
+            "selected_line_ids": {
+                "type": "list",
+                "required": True,
+                "schema": {"coerce": to_int, "required": True, "type": "integer"},
+            },
+        }
+
     def new_package(self):
         return {
             "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
@@ -1127,6 +1193,7 @@ class ShopfloorCheckoutValidator(Component):
                 "required": True,
                 "schema": {"coerce": to_int, "required": True, "type": "integer"},
             },
+            "packaging_id": {"coerce": to_int, "required": False, "type": "integer"},
         }
 
     def no_package(self):
@@ -1235,6 +1302,7 @@ class ShopfloorCheckoutValidatorResponse(Component):
             ),
             "change_quantity": self._schema_selected_lines,
             "select_dest_package": self._schema_select_package,
+            "select_delivery_packaging": self._schema_select_delivery_packaging,
             "summary": self._schema_summary,
             "change_packaging": self._schema_select_packaging,
             "confirm_done": self._schema_confirm_done,
@@ -1290,6 +1358,14 @@ class ShopfloorCheckoutValidatorResponse(Component):
                 },
             },
             "picking": {"type": "dict", "schema": self.schemas.picking()},
+        }
+
+    @property
+    def _schema_select_delivery_packaging(self):
+        return {
+            "packaging": self.schemas._schema_list_of(
+                self.schemas.delivery_packaging()
+            ),
         }
 
     @property
@@ -1349,6 +1425,11 @@ class ShopfloorCheckoutValidatorResponse(Component):
     def scan_package_action(self):
         return self._response_schema(
             next_states={"select_package", "select_line", "summary"}
+        )
+
+    def list_delivery_packaging(self):
+        return self._response_schema(
+            next_states={"select_delivery_packaging", "select_package"}
         )
 
     def new_package(self):

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -1028,7 +1028,8 @@ class Checkout(Component):
         so they have to be processed again.
 
         Transitions:
-        * summary
+        * summary: if package or line are not found
+        * select_line: when package or line has been canceled
         """
         picking = self.env["stock.picking"].browse(picking_id)
         message = self._check_picking_status(picking)
@@ -1059,7 +1060,7 @@ class Checkout(Component):
         if line:
             line.write({"qty_done": 0, "shopfloor_checkout_done": False})
             msg = _("Line cancelled")
-        return self._response_for_summary(
+        return self._response_for_select_line(
             picking, message={"message_type": "success", "body": msg}
         )
 
@@ -1473,7 +1474,7 @@ class ShopfloorCheckoutValidatorResponse(Component):
         return self._response_schema(next_states={"change_packaging", "summary"})
 
     def cancel_line(self):
-        return self._response_schema(next_states={"summary"})
+        return self._response_schema(next_states={"summary", "select_line"})
 
     def done(self):
         return self._response_schema(next_states={"summary", "confirm_done"})

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -27,6 +27,7 @@ from . import test_checkout_set_qty
 from . import test_checkout_scan_package_action
 from . import test_checkout_new_package
 from . import test_checkout_no_package
+from . import test_checkout_list_delivery_packaging
 from . import test_checkout_list_package
 from . import test_checkout_summary
 from . import test_checkout_change_packaging

--- a/shopfloor/tests/models.py
+++ b/shopfloor/tests/models.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+"""Test data models to get a mapping between carrier and delivery packaging.
+
+Add a new "test" value for 'delivery_type' field of carrier and
+'package_carrier_type' field of packaging for test purpose because
+Shopfloor do not depend on 'delivery_*' modules adding the different
+delivery types.
+"""
+from odoo import fields, models
+
+
+class DeliveryCarrierTest(models.Model):
+    _inherit = "delivery.carrier"
+
+    delivery_type = fields.Selection(selection_add=[("test", "TEST")])
+
+
+class ProductPackagingTest(models.Model):
+    _inherit = "product.packaging"
+
+    package_carrier_type = fields.Selection(selection_add=[("test", "TEST")])

--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -10,6 +10,13 @@ class ActionsDataCase(ActionsDataCaseBase):
         self.assert_schema(self.schema.packaging(), data)
         self.assertDictEqual(data, self._expected_packaging(self.packaging))
 
+    def test_data_delivery_packaging(self):
+        data = self.data.delivery_packaging(self.delivery_packaging)
+        self.assert_schema(self.schema.delivery_packaging(), data)
+        self.assertDictEqual(
+            data, self._expected_delivery_packaging(self.delivery_packaging)
+        )
+
     def test_data_location(self):
         location = self.stock_location
         data = self.data.location(location)

--- a/shopfloor/tests/test_actions_data_base.py
+++ b/shopfloor/tests/test_actions_data_base.py
@@ -30,6 +30,17 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
             .sudo()
             .create({"name": "Pallet", "packaging_type_id": cls.packaging_type.id})
         )
+        cls.delivery_packaging = (
+            cls.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "Pallet",
+                    "packaging_type_id": cls.packaging_type.id,
+                    "barcode": "PALCODE",
+                }
+            )
+        )
         cls.product_b.tracking = "lot"
         cls.product_c.tracking = "lot"
         cls.picking = cls._create_picking(
@@ -136,6 +147,16 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
             "name": record.packaging_type_id.name,
             "code": record.packaging_type_id.code,
             "qty": record.qty,
+        }
+        data.update(kw)
+        return data
+
+    def _expected_delivery_packaging(self, record, **kw):
+        data = {
+            "id": record.id,
+            "name": record.name,
+            "packaging_type": record.packaging_type_id.display_name,
+            "barcode": record.barcode,
         }
         data.update(kw)
         return data

--- a/shopfloor/tests/test_checkout_cancel_line.py
+++ b/shopfloor/tests/test_checkout_cancel_line.py
@@ -86,11 +86,8 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
 
         self.assert_response(
             response,
-            next_state="summary",
-            data={
-                "picking": self._stock_picking_data(picking, done=True),
-                "all_processed": False,
-            },
+            next_state="select_line",
+            data={"picking": self._stock_picking_data(picking)},
             message={"body": "Package cancelled", "message_type": "success"},
         )
 
@@ -112,11 +109,8 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
 
         self.assert_response(
             response,
-            next_state="summary",
-            data={
-                "picking": self._stock_picking_data(picking, done=True),
-                "all_processed": False,
-            },
+            next_state="select_line",
+            data={"picking": self._stock_picking_data(picking)},
             message={"body": "Line cancelled", "message_type": "success"},
         )
 

--- a/shopfloor/tests/test_checkout_list_delivery_packaging.py
+++ b/shopfloor/tests/test_checkout_list_delivery_packaging.py
@@ -1,0 +1,120 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo_test_helper import FakeModelLoader
+
+from .test_checkout_base import CheckoutCommonCase
+from .test_checkout_select_package_base import CheckoutSelectPackageMixin
+
+
+class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
+    @classmethod
+    def _load_test_models(cls):
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .models import DeliveryCarrierTest, ProductPackagingTest
+
+        cls.loader.update_registry((DeliveryCarrierTest, ProductPackagingTest))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super(CheckoutListDeliveryPackagingCase, cls).tearDownClass()
+
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData(*args, **kwargs)
+        cls._load_test_models()
+        cls.carrier = cls.env["delivery.carrier"].search([], limit=1)
+        cls.carrier.sudo().delivery_type = "test"
+        cls.picking = cls._create_picking(
+            lines=[
+                (cls.product_a, 10),
+                (cls.product_b, 10),
+                (cls.product_c, 10),
+                (cls.product_d, 10),
+            ]
+        )
+        cls.picking.carrier_id = cls.carrier
+        cls.packaging_type = (
+            cls.env["product.packaging.type"]
+            .sudo()
+            .create({"name": "Transport Box", "code": "TB", "sequence": 0})
+        )
+        cls.delivery_packaging1 = (
+            cls.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "Box 1",
+                    "package_carrier_type": "test",
+                    "packaging_type_id": cls.packaging_type.id,
+                    "barcode": "BOX1",
+                }
+            )
+        )
+        cls.delivery_packaging2 = (
+            cls.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "Box 2",
+                    "package_carrier_type": "test",
+                    "packaging_type_id": cls.packaging_type.id,
+                    "barcode": "BOX2",
+                }
+            )
+        )
+        cls.delivery_packaging = (
+            cls.delivery_packaging1 | cls.delivery_packaging2
+        ).sorted("name")
+
+    def test_list_delivery_packaging_available(self):
+        self._fill_stock_for_moves(self.picking.move_lines, in_package=True)
+        self.picking.action_assign()
+        selected_lines = self.picking.move_line_ids
+        response = self.service.dispatch(
+            "list_delivery_packaging",
+            params={
+                "picking_id": self.picking.id,
+                "selected_line_ids": selected_lines.ids,
+            },
+        )
+        self.assert_response(
+            response,
+            next_state="select_delivery_packaging",
+            data={
+                "packaging": self.service.data.delivery_packaging_list(
+                    self.delivery_packaging
+                ),
+            },
+        )
+
+    def test_list_delivery_packaging_not_available(self):
+        self.delivery_packaging.package_carrier_type = False
+        self._fill_stock_for_moves(self.picking.move_lines, in_package=True)
+        self.picking.action_assign()
+        selected_lines = self.picking.move_line_ids
+        # for line in selected_lines:
+        #     line.qty_done = line.product_uom_qty
+        response = self.service.dispatch(
+            "list_delivery_packaging",
+            params={
+                "picking_id": self.picking.id,
+                "selected_line_ids": selected_lines.ids,
+            },
+        )
+        self.assert_response(
+            response,
+            next_state="select_package",
+            data={
+                "picking": self._picking_summary_data(self.picking),
+                "selected_move_lines": [
+                    self._move_line_data(ml) for ml in selected_lines.sorted()
+                ],
+                "packing_info": self.service._data_for_packing_info(self.picking),
+                "no_package_enabled": not self.service.options.get(
+                    "checkout__disable_no_package"
+                ),
+            },
+            message=self.service.msg_store.no_delivery_packaging_available(),
+        )

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -118,6 +118,26 @@ const Checkout = {
                     </v-row>
                 </div>
             </div>
+            <div v-if="state_is('select_delivery_packaging')">
+                <item-detail-card
+                    v-if="current_doc().record.carrier"
+                    :key="make_state_component_key(['picking-carrier', current_doc().record.id])"
+                    :record="current_doc().record.carrier"
+                    :options="{main: true, key_title: 'name', title_icon: 'mdi-truck-outline'}"
+                    />
+                <manual-select
+                    :records="state.data.packaging"
+                    :options="select_delivery_packaging_manual_select_options()"
+                    :key="make_state_component_key(['checkout', 'select-delivery-packaging'])"
+                    />
+                <div class="button-list button-vertical-list full">
+                    <v-row align="center">
+                        <v-col class="text-center" cols="12">
+                            <btn-back />
+                        </v-col>
+                    </v-row>
+                </div>
+            </div>
             <div v-if="state_is('select_dest_package')">
                 <detail-picking-select
                     :record="state.data.picking"
@@ -254,6 +274,15 @@ const Checkout = {
                         {path: "carrier.name", label: "Carrier"},
                         {path: "move_line_count", label: "Lines"},
                     ],
+                },
+            };
+        },
+        select_delivery_packaging_manual_select_options: function() {
+            return {
+                showActions: false,
+                list_item_options: {
+                    loud_title: true,
+                    fields: [{path: "packaging_type"}],
                 },
             };
         },
@@ -455,7 +484,7 @@ const Checkout = {
                     },
                     on_new_pack: () => {
                         this.wait_call(
-                            this.odoo.call("new_package", {
+                            this.odoo.call("list_delivery_packaging", {
                                 picking_id: this.state.data.picking.id,
                                 selected_line_ids: this.selectable_line_ids(),
                             })
@@ -480,6 +509,29 @@ const Checkout = {
                     on_back: () => {
                         this.state_to("select_line");
                         this.reset_notification();
+                    },
+                },
+                select_delivery_packaging: {
+                    display_info: {
+                        title: "Select delivery packaging",
+                        scan_placeholder: "Scan package type",
+                    },
+                    events: {
+                        select: "on_select",
+                        back: "on_back",
+                    },
+                    on_select: selected => {
+                        this.state.on_scan({text: selected.barcode});
+                    },
+                    on_scan: scanned => {
+                        const picking = this.current_doc().record;
+                        this.wait_call(
+                            this.odoo.call("scan_package_action", {
+                                picking_id: picking.id,
+                                selected_line_ids: this.selected_line_ids(),
+                                barcode: scanned.text,
+                            })
+                        );
                     },
                 },
                 change_quantity: {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 freezegun
+odoo_test_helper


### PR DESCRIPTION
<s>PR based on https://github.com/OCA/wms/pull/193, only the two last commits are relevant.</s>

A delivery package is a package with a delivery packaging defined ('packaging_id' field). It is a package different than internal ones (which are stored in the warehouse with their own constraints like height...).
Here we enforce the use of such delivery packages when we perform a checkout, this means that we can not use internal packages to perform a delivery.

* `list_dest_package` method ('/select_dest_package') is now listing only delivery packages
* `scan_dest_package` and 'set_dest_package' methods accept only a delivery package
* `scan_package_action` method accept only a delivery package
* Add a new state/screen when the user click on the "_New package_" button to list available delivery packaging (`select_delivery_packaging` state) for the current transfer and select one to create the package (existing `new_package` method which now accepts a packaging as parameter).

Ref. 2168