### PR TITLE
[13.0] shopfloor: delivery picking done only if moves are done

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -1,10 +1,20 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, models
+from odoo.tools.float_utils import float_compare
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
+
+    def _qty_is_satisfied(self):
+        compare = float_compare(
+            self.quantity_done,
+            self.product_uom_qty,
+            precision_rounding=self.product_uom.rounding,
+        )
+        # greater or equal
+        return compare in (0, 1)
 
     def split_other_move_lines(self, move_lines, intersection=False):
         """Substract `move_lines` from `move.move_line_ids`, put the result

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -322,15 +322,30 @@ class Delivery(Component):
             )
         return self._response_for_deliver(new_picking)
 
-    def _action_picking_done(self, picking):
-        """Try to validate the stock picking if all its lines have been processed.
+    def _action_picking_done(self, picking, force=False):
+        """Try to validate the stock picking if all quantities are satisfied.
 
         Return `True` if the picking has been validated successfully.
+
+        :param picking: stock.picking recordset
+        :param force: bypass check and set picking as done no matter if satisfied.
+            You will likely get a backorder for not processed lines.
         """
-        move_lines_done = all(
-            [line.qty_done >= line.product_uom_qty for line in picking.move_line_ids]
-        )
-        if move_lines_done:
+
+        if picking.state == "done":
+            return True
+        if force:
+            picking.action_done()
+            return True
+        all_done = False
+        for move in picking.move_lines:
+            if move.state in ("done", "cancel"):
+                continue
+            all_done = move._qty_is_satisfied()
+            if not all_done:
+                # At least one move not satisfied, cannot mark as done automatically
+                break
+        if all_done:
             picking.action_done()
             return True
         return False
@@ -511,7 +526,7 @@ class Delivery(Component):
                 return self._response_for_deliver(
                     message=self.msg_store.transfer_no_qty_done()
                 )
-            picking.action_done()
+            self._action_picking_done(picking, force=True)
             return self._response_for_deliver(
                 message=self.msg_store.transfer_complete(picking)
             )


### PR DESCRIPTION
Before this change the check for done qty was done only on move lines.
Now the check is at move level, so that if there's any move not fully satisfied
the picking is not set to done automatically and you have to confirm.

ref: 2212