### PR TITLE
[13.0] shopfloor: fix single pack transfer fixes

### DIFF
--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -124,7 +124,7 @@ class SinglePackTransfer(Component):
         # use a sub-search on stock.picking: we shouldn't have dozens of package levels
         # for a package.
         package_level = package_level.filtered(
-            lambda pl: pl.state not in ("cancel", "done")
+            lambda pl: pl.state not in ("cancel", "done", "draft")
         )
         message = self.msg_store.no_pending_operation_for_pack(package)
         if not package_level and self.work.menu.allow_move_create:

--- a/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
@@ -36,12 +36,14 @@ export var SinglePackStatesMixin = {
                         show_cancel_button: true,
                     },
                     on_scan: (scanned, confirmation = false) => {
+                        const data = this.state.data;
                         this.state_set_data({location_barcode: scanned.text});
                         this.wait_call(
                             this.odoo.call("validate", {
-                                package_level_id: this.state.data.id,
+                                package_level_id: data.id,
                                 location_barcode: scanned.text,
-                                confirmation: confirmation,
+                                confirmation:
+                                    confirmation || data.confirmation_required,
                             })
                         );
                     },


### PR DESCRIPTION
* Ensure that if we scan again the location it gets confirmed without asking anymore
* Ensure scan package is not broken if there are stale pkg levels

ref: 2233  + 2210