### PR TITLE
[13.0] shopfloor_mobile_base: searchbar preserve focus on state refresh

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
+++ b/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
@@ -18,6 +18,11 @@ Vue.component("searchbar", {
             type: Boolean,
             default: true,
         },
+        // Allow searchbar to steal focus on screen reload
+        reload_steal_focus: {
+            type: Boolean,
+            default: true,
+        },
         autocomplete: {
             type: String,
             default: "off",
@@ -28,6 +33,9 @@ Vue.component("searchbar", {
             type: Boolean,
             default: true,
         },
+    },
+    mounted: function() {
+        this.$root.event_hub.$on("screen:reload", this.on_screen_reload);
     },
     methods: {
         search: function(e) {
@@ -42,6 +50,12 @@ Vue.component("searchbar", {
         reset: function() {
             this.entered = "";
         },
+        on_screen_reload: function(evt) {
+            if (this.reload_steal_focus)
+                $(this.$el)
+                    .find(":input[name=searchbar]")
+                    .focus();
+        },
     },
 
     template: `
@@ -52,6 +66,7 @@ Vue.component("searchbar", {
       class="searchform"
       >
     <v-text-field
+      name="searchbar"
       required v-model="entered"
       :placeholder="input_placeholder"
       :autofocus="autofocus ? 'autofocus' : null"

--- a/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
@@ -232,6 +232,7 @@ export var ScenarioBaseMixin = {
         _reload_current_state: function() {
             // Force re-computation of current state data.
             this.state = this.state_get_data();
+            this.$root.trigger("screen:reload", {}, true);
         },
         state_reset_data_all() {
             const self = this;


### PR DESCRIPTION
When clicking on a button in a scenario state
is not granted the whole screen gets refreshed
and that the input field of the searchbar
gets its focus back.
Make sure it's always preserved.

ref: 2169