### PR TITLE
sf_mobile_base: prevent scan multiple times

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
@@ -355,6 +355,8 @@ export var ScenarioBaseMixin = {
         },
         // Specific states methods
         on_scan: function(scanned) {
+            // Prevent scanning twice
+            if (this.$root.loading) return;
             const state = this._get_state_spec();
             if (state.on_scan) {
                 state.on_scan(scanned);


### PR DESCRIPTION
The scanning interface uses a simple input text
which is valued and submitted by the scanning device automatically.
While sending the request the focus stays on the input
hence if the user scans multiple times the same barcode
multiple requests are sent to the backend.

This change prevents this by checking if the app
is still waiting for data from the backend.

By doing so, several conflict errors are avoided
because the same action cannot be applied twice or more
for the same endpoint till the UI is unlocked.