### PR TITLE
[13.0] shopfloor: zone_picking add pick+pack option

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "13.0.4.4.3",
+    "version": "13.0.4.5.0",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",
@@ -43,6 +43,8 @@
         "delivery",
         #  OCA / product-attribute
         "product_packaging_type",
+        #  OCA / delivery
+        "stock_picking_delivery_link",
     ],
     "data": [
         "data/shopfloor_scenario_data.xml",

--- a/shopfloor/actions/__init__.py
+++ b/shopfloor/actions/__init__.py
@@ -11,3 +11,4 @@ from . import inventory
 from . import savepoint
 from . import move_line_search
 from . import stock
+from . import packaging

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -521,3 +521,9 @@ class MessageAction(Component):
             "message_type": "warning",
             "body": _("No delivery package type available."),
         }
+
+    def goods_packed_in(self, package):
+        return {
+            "message_type": "info",
+            "body": _("Goods packed into {0.name}").format(package),
+        }

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -527,3 +527,12 @@ class MessageAction(Component):
             "message_type": "info",
             "body": _("Goods packed into {0.name}").format(package),
         }
+
+    def picking_without_carrier_cannot_pack(self, picking):
+        return {
+            "message_type": "error",
+            "body": _(
+                "Pick + Pack mode ON: the picking {0.name} has no carrier set. "
+                "The system couldn't pack goods automatically."
+            ).format(picking),
+        }

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -499,8 +499,8 @@ class MessageAction(Component):
     def packaging_invalid_for_carrier(self, packaging, carrier):
         return {
             "message_type": "error",
-            "body": _("Packaging {} is not allowed for carrier {}.").format(
-                packaging.name, carrier.name
+            "body": _("Packaging '{}' is not allowed for carrier {}.").format(
+                packaging.name if packaging else _("No value"), carrier.name
             ),
         }
 

--- a/shopfloor/actions/packaging.py
+++ b/shopfloor/actions/packaging.py
@@ -14,13 +14,19 @@ class PackagingAction(Component):
         return packaging.package_carrier_type in ("none", carrier.delivery_type)
 
     def create_delivery_package(self, carrier):
-        delivery_type = carrier.delivery_type
+        default_packaging = self._get_default_packaging(carrier)
+        return self.create_package_from_packaging(default_packaging)
+
+    def _get_default_packaging(self, carrier):
         # TODO: refactor `delivery_[carrier_name]` modules
         # to have always the same field named `default_packaging_id`
         # to unify lookup of this field.
         # As alternative add a computed field.
-        default_packaging = carrier[delivery_type + "_default_packaging_id"]
-        return self.create_package_from_packaging(default_packaging)
+        # AFAIS there's no reason to have 1 field per carrier type.
+        fname = carrier.delivery_type + "_default_packaging_id"
+        if fname not in carrier._fields:
+            return self.env["product.packaging"].browse()
+        return carrier[fname]
 
     def create_package_from_packaging(self, packaging=None):
         if packaging:

--- a/shopfloor/actions/packaging.py
+++ b/shopfloor/actions/packaging.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.addons.component.core import Component
+
+
+class PackagingAction(Component):
+    """Provide methods to work with packaging operations."""
+
+    _name = "shopfloor.packaging.action"
+    _inherit = "shopfloor.process.action"
+    _usage = "packaging"
+
+    def packaging_valid_for_carrier(self, packaging, carrier):
+        return packaging.package_carrier_type in ("none", carrier.delivery_type)
+
+    def create_delivery_package(self, carrier):
+        delivery_type = carrier.delivery_type
+        # TODO: refactor `delivery_[carrier_name]` modules
+        # to have always the same field named `default_packaging_id`
+        # to unify lookup of this field.
+        # As alternative add a computed field.
+        default_packaging = carrier[delivery_type + "_default_packaging_id"]
+        return self.create_package_from_packaging(default_packaging)
+
+    def create_package_from_packaging(self, packaging=None):
+        if packaging:
+            vals = self._package_vals_from_packaging(packaging)
+        else:
+            vals = self._package_vals_without_packaging()
+        return self.env["stock.quant.package"].create(vals)
+
+    def _package_vals_from_packaging(self, packaging):
+        return {
+            "packaging_id": packaging.id,
+            "lngth": packaging.lngth,
+            "width": packaging.width,
+            "height": packaging.height,
+        }
+
+    def _package_vals_without_packaging(self):
+        return {}

--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -14,6 +14,11 @@
     <record id="scenario_zone_picking" model="shopfloor.scenario">
         <field name="name">Zone Picking</field>
         <field name="key">zone_picking</field>
+        <field name="options_edit">
+{
+    "pick_pack_same_time": true
+}
+        </field>
     </record>
     <record id="scenario_cluster_picking" model="shopfloor.scenario">
         <field name="name">Cluster Picking</field>

--- a/shopfloor/i18n/es_AR.po
+++ b/shopfloor/i18n/es_AR.po
@@ -694,7 +694,7 @@ msgstr "Producto {} pertenece a una entrega sin estado válido."
 #. module: shopfloor
 #: code:addons/shopfloor/services/checkout.py:0
 #, python-format
-msgid "Product(s) packed in {}"
+msgid "Goods packed in {}"
 msgstr "Producto(s) empaquetado(s) en {}"
 
 #. module: shopfloor

--- a/shopfloor/i18n/shopfloor.pot
+++ b/shopfloor/i18n/shopfloor.pot
@@ -667,7 +667,7 @@ msgstr ""
 #. module: shopfloor
 #: code:addons/shopfloor/services/checkout.py:0
 #, python-format
-msgid "Product(s) packed in {}"
+msgid "Goods packed in {}"
 msgstr ""
 
 #. module: shopfloor

--- a/shopfloor/migrations/13.0.4.5.0/post-migration.py
+++ b/shopfloor/migrations/13.0.4.5.0/post-migration.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import json
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    _logger.info("Update zone picking settings")
+    zp = env.ref("shopfloor.scenario_zone_picking", raise_if_not_found=False)
+    if zp:
+        options = zp.options
+        if "pick_pack_same_time" not in options:
+            options.update({"pick_pack_same_time": True})
+        zp.options_edit = json.dumps(options)

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -672,10 +672,7 @@ class Checkout(Component):
         # go back to the screen to select the next lines to pack
         return self._response_for_select_line(
             picking,
-            message={
-                "message_type": "success",
-                "body": _("Product(s) packed in {}").format(package.name),
-            },
+            message=self.msg_store.goods_packed_in(package),
         )
 
     def _prepare_vals_package_from_packaging(self, packaging):

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -671,27 +671,12 @@ class Checkout(Component):
         )
         # go back to the screen to select the next lines to pack
         return self._response_for_select_line(
-            picking,
-            message=self.msg_store.goods_packed_in(package),
+            picking, message=self.msg_store.goods_packed_in(package),
         )
 
-    def _prepare_vals_package_from_packaging(self, packaging):
-        return {
-            "packaging_id": packaging.id,
-            "lngth": packaging.lngth,
-            "width": packaging.width,
-            "height": packaging.height,
-        }
-
-    def _prepare_vals_package_without_packaging(self):
-        return {}
-
     def _create_and_assign_new_packaging(self, picking, selected_lines, packaging=None):
-        if packaging:
-            vals = self._prepare_vals_package_from_packaging(packaging)
-        else:
-            vals = self._prepare_vals_package_without_packaging()
-        package = self.env["stock.quant.package"].create(vals)
+        actions = self._actions_for("packaging")
+        package = actions.create_package_from_packaging(packaging=packaging)
         return self._put_lines_in_allowed_package(picking, selected_lines, package)
 
     def scan_package_action(self, picking_id, selected_line_ids, barcode):
@@ -781,7 +766,8 @@ class Checkout(Component):
         )
 
     def _packaging_good_for_carrier(self, packaging, carrier):
-        return packaging.package_carrier_type in ("none", carrier.delivery_type)
+        actions = self._actions_for("packaging")
+        return actions.packaging_valid_for_carrier(packaging, carrier)
 
     def _get_available_delivery_packaging(self, picking):
         model = self.env["product.packaging"]

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -20,7 +20,7 @@ class ZonePicking(Component):
 
     You will find a sequence diagram describing states and endpoints
     relationships [here](../docs/zone_picking_diag_seq.png).
-    Keep [the sequence diagram](../docs/delivery_diag_seq.plantuml)
+    Keep [the sequence diagram](../docs/zone_picking_diag_seq.plantuml)
     up-to-date if you change endpoints.
 
     Note:

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -54,6 +54,7 @@ from . import test_zone_picking_start
 from . import test_zone_picking_select_picking_type
 from . import test_zone_picking_select_line
 from . import test_zone_picking_set_line_destination
+from . import test_zone_picking_set_line_destination_pick_pack
 from . import test_zone_picking_zero_check
 from . import test_zone_picking_stock_issue
 from . import test_zone_picking_change_pack_lot

--- a/shopfloor/tests/models.py
+++ b/shopfloor/tests/models.py
@@ -14,6 +14,9 @@ class DeliveryCarrierTest(models.Model):
     _inherit = "delivery.carrier"
 
     delivery_type = fields.Selection(selection_add=[("test", "TEST")])
+    test_default_packaging_id = fields.Many2one(
+        "product.packaging", string="Default Package Type"
+    )
 
 
 class ProductPackagingTest(models.Model):

--- a/shopfloor/tests/test_checkout_list_package.py
+++ b/shopfloor/tests/test_checkout_list_package.py
@@ -164,10 +164,7 @@ class CheckoutScanSetDestPackageCase(CheckoutCommonCase, SelectDestPackageMixin)
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
             data={"picking": self._stock_picking_data(self.picking)},
-            message={
-                "message_type": "success",
-                "body": "Product(s) packed in {}".format(self.delivery_package.name),
-            },
+            message=self.msg_store.goods_packed_in(self.delivery_package),
         )
 
     def test_scan_dest_package_ok(self):

--- a/shopfloor/tests/test_checkout_new_package.py
+++ b/shopfloor/tests/test_checkout_new_package.py
@@ -57,8 +57,5 @@ class CheckoutNewPackageCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
             data={"picking": self._stock_picking_data(picking)},
-            message={
-                "message_type": "success",
-                "body": "Product(s) packed in {}".format(new_package.name),
-            },
+            message=self.msg_store.goods_packed_in(new_package),
         )

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -275,10 +275,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
                 "picking": self._stock_picking_data(picking, done=True),
                 "all_processed": True,
             },
-            message={
-                "message_type": "success",
-                "body": "Product(s) packed in {}".format(package.name),
-            },
+            message=self.msg_store.goods_packed_in(package),
         )
 
     def test_scan_package_action_scan_packaging_ok(self):
@@ -363,10 +360,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
             response,
             next_state="select_line",
             data={"picking": self._stock_picking_data(picking)},
-            message={
-                "message_type": "success",
-                "body": "Product(s) packed in {}".format(new_package.name),
-            },
+            message=self.msg_store.goods_packed_in(new_package),
         )
 
     def test_scan_package_action_scan_packaging_bad_carrier(self):
@@ -434,12 +428,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
             )
             self.assertEqual(
                 response["message"],
-                {
-                    "message_type": "success",
-                    "body": "Product(s) packed in {}".format(
-                        selected_lines.result_package_id.name
-                    ),
-                },
+                self.msg_store.goods_packed_in(selected_lines.result_package_id),
             )
 
     def test_scan_package_action_scan_not_found(self):

--- a/shopfloor/tests/test_zone_picking_set_line_destination_pick_pack.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination_pick_pack.py
@@ -1,0 +1,207 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo_test_helper import FakeModelLoader
+
+from .test_zone_picking_base import ZonePickingCommonCase
+
+
+class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
+    """Tests set_line_destination when `pick_pack_same_time` is one
+
+    * /set_destination
+
+    """
+
+    @classmethod
+    def _load_test_models(cls):
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .models import DeliveryCarrierTest, ProductPackagingTest
+
+        cls.loader.update_registry((DeliveryCarrierTest, ProductPackagingTest))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()
+
+    @classmethod
+    def setUpClassBaseData(cls, *args, **kwargs):
+        super().setUpClassBaseData(*args, **kwargs)
+        cls._load_test_models()
+        cls.carrier = cls.env["delivery.carrier"].search([], limit=1)
+        default_pkging = (
+            cls.env["product.packaging"].sudo().create({"name": "TEST DEFAULT"})
+        )
+        cls.carrier.sudo().write(
+            {
+                "delivery_type": "test",
+                "integration_level": "rate",  # avoid sending emails
+                "test_default_packaging_id": default_pkging.id,
+            }
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+        self.menu.sudo().pick_pack_same_time = True
+
+    def test_set_destination_location_no_carrier(self):
+        """Scan location but carrier not set on picking
+        """
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        move_line = self.picking1.move_line_ids
+        move_line.location_dest_id = self.shelf1
+        # Confirm the destination with the right destination
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.packing_location.barcode,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": True,
+            },
+        )
+        self.assert_response_set_line_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message=self.service.msg_store.picking_without_carrier_cannot_pack(
+                move_line.picking_id
+            ),
+        )
+
+    def test_set_destination_location_ok_carrier(self):
+        """When carried is set goods are packed into new delivery package."""
+        existing_packages = self.env["stock.quant.package"].search([])
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        move_line = self.picking1.move_line_ids
+        move_line.location_dest_id = self.shelf1
+        move_line.picking_id.carrier_id = self.carrier
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.packing_location.barcode,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": True,
+            },
+        )
+        # Check response
+        move_lines = self.service._find_location_move_lines()
+        move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
+        delivery_pkg = move_line.result_package_id
+        self.assertNotIn(delivery_pkg, existing_packages)
+        self.assertEqual(
+            delivery_pkg.packaging_id, self.carrier.test_default_packaging_id
+        )
+        message = self.msg_store.confirm_pack_moved()
+        message["body"] += "\n" + self.msg_store.goods_packed_in(delivery_pkg)["body"]
+        self.assert_response_select_line(
+            response, zone_location, picking_type, move_lines, message=message,
+        )
+
+    def test_set_destination_package_full_qty_no_carrier(self):
+        """Scan destination package, no carrier on picking.
+        """
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        moves_before = self.picking1.move_lines
+        self.assertEqual(len(moves_before), 1)
+        self.assertEqual(len(moves_before.move_line_ids), 1)
+        move_line = moves_before.move_line_ids
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.free_package.name,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": True,
+            },
+        )
+        self.assert_response_set_line_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message=self.service.msg_store.picking_without_carrier_cannot_pack(
+                move_line.picking_id
+            ),
+        )
+
+    def test_set_destination_package_full_qty_ok_carrier_bad_package(self):
+        """Scan destination package, carrier on picking, package invalid.
+        """
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        moves_before = self.picking1.move_lines
+        self.assertEqual(len(moves_before), 1)
+        self.assertEqual(len(moves_before.move_line_ids), 1)
+        move_line = moves_before.move_line_ids
+        move_line.picking_id.carrier_id = self.carrier
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.free_package.name,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": False,
+            },
+        )
+        self.assert_response_set_line_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message=self.service.msg_store.packaging_invalid_for_carrier(
+                self.free_package.packaging_id, self.carrier
+            ),
+        )
+
+    def test_set_destination_package_full_qty_ok_carrier_ok_package(self):
+        """Scan destination package, carrier on picking, package valid.
+        """
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        moves_before = self.picking1.move_lines
+        self.assertEqual(len(moves_before), 1)
+        self.assertEqual(len(moves_before.move_line_ids), 1)
+        move_line = moves_before.move_line_ids
+        move_line.picking_id.carrier_id = self.carrier
+        self.free_package.packaging_id = self.carrier.test_default_packaging_id
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.free_package.name,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": True,
+            },
+        )
+        # Check picking data
+        moves_after = self.picking1.move_lines
+        self.assertEqual(moves_before, moves_after)
+        self.assertRecordValues(
+            move_line,
+            [
+                {
+                    "result_package_id": self.free_package.id,
+                    "product_uom_qty": 10,
+                    "qty_done": 10,
+                    "shopfloor_user_id": self.env.user.id,
+                },
+            ],
+        )
+        # Check response
+        move_lines = self.service._find_location_move_lines()
+        move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
+        self.assert_response_select_line(
+            response,
+            zone_location,
+            picking_type,
+            move_lines,
+            message=self.service.msg_store.confirm_pack_moved(),
+        )

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -33,6 +33,13 @@
                   <field name="ignore_no_putaway_available_is_possible" invisible="1" />
                   <field name="ignore_no_putaway_available" />
               </group>
+              <group
+                    name="pick_pack_same_time"
+                    attrs="{'invisible': [('pick_pack_same_time_is_possible', '=', False)]}"
+                >
+                  <field name="pick_pack_same_time_is_possible" invisible="1" />
+                  <field name="pick_pack_same_time" />
+              </group>
             </group>
         </field>
     </record>

--- a/shopfloor_mobile/static/wms/src/demo/demo.checkout.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.checkout.js
@@ -135,7 +135,7 @@ const DEMO_CHECKOUT = {
         },
         message: {
             message_type: "info",
-            body: "Product(s) packed in XYZ",
+            body: "Goods packed in XYZ",
         },
     },
     scan_dest_package: {
@@ -145,7 +145,7 @@ const DEMO_CHECKOUT = {
         },
         message: {
             message_type: "info",
-            body: "Product(s) packed in XYZ",
+            body: "Goods packed in XYZ",
         },
     },
     new_package: {
@@ -155,7 +155,7 @@ const DEMO_CHECKOUT = {
         },
         message: {
             message_type: "info",
-            body: "Product(s) packed in XYZ",
+            body: "Goods packed in XYZ",
         },
     },
     no_package: {
@@ -165,7 +165,7 @@ const DEMO_CHECKOUT = {
         },
         message: {
             message_type: "info",
-            body: "Product(s) packed in XYZ",
+            body: "Goods packed in XYZ",
         },
     },
     summary: {


### PR DESCRIPTION
Zone picking can now be used for pick + pack operation at the same time.
When the flag `pick_pack_same_time` is enabled (via menu conf)
set destination will work as follow:

* if a location is scanned, a new delivery package compliant w/ selected
carrier is created

* if a package is scanned, the package is validated against the carrier

* in both cases, if the picking has no carrier the operation fails

ref: 2242