### PR TITLE
[13.0] shopfloor checkout: get right carrier

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -43,6 +43,8 @@
         "delivery",
         #  OCA / product-attribute
         "product_packaging_type",
+        #  OCA / delivery
+        "stock_picking_delivery_link",
     ],
     "data": [
         "data/shopfloor_scenario_data.xml",

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -765,7 +765,7 @@ class Checkout(Component):
         # Scan delivery packaging
         packaging = search.generic_packaging_from_scan(barcode)
         if packaging:
-            carrier = picking.carrier_id
+            carrier = picking.ship_carrier_id or picking.carrier_id
             # Validate against carrier
             if carrier and not self._packaging_good_for_carrier(packaging, carrier):
                 return self._response_for_select_package(
@@ -788,16 +788,13 @@ class Checkout(Component):
 
     def _get_available_delivery_packaging(self, picking):
         model = self.env["product.packaging"]
-        if not picking.carrier_id:
+        carrier = picking.ship_carrier_id or picking.carrier_id
+        if not carrier:
             return model.browse()
         return model.search(
             [
                 ("product_id", "=", False),
-                (
-                    "package_carrier_type",
-                    "=",
-                    picking.carrier_id.delivery_type or "none",
-                ),
+                ("package_carrier_type", "=", carrier.delivery_type or "none"),
             ],
             order="name",
         )


### PR DESCRIPTION
<s>Based on https://github.com/OCA/stock-logistics-warehouse/pull/1115
Based on https://github.com/OCA/delivery-carrier/pull/354</s>

When processing pick/pack operation we have no carrier set, we have to use the carrier of the related delivery operation.

Ref. 2291