### PR TITLE
[13.0][IMP] shopfloor_batch_automatic_creation: group by commercial entity

### DIFF
--- a/shopfloor_batch_automatic_creation/actions/picking_batch_auto_create.py
+++ b/shopfloor_batch_automatic_creation/actions/picking_batch_auto_create.py
@@ -21,14 +21,34 @@ class PickingBatchAutoCreateAction(Component):
 
     _advisory_lock_name = "shopfloor_batch_picking_create"
 
-    def create_batch(self, picking_types, max_pickings=0, max_weight=0, max_volume=0):
+    def create_batch(
+        self,
+        picking_types,
+        max_pickings=0,
+        max_weight=0,
+        max_volume=0,
+        group_by_commercial_partner=False,
+    ):
         self._lock()
-        pickings = self._search_pickings(picking_types, user=self.env.user)
+        search_user = self.env.user
+        pickings = self._search_pickings(picking_types, user=search_user)
         if not pickings:
+            search_user = None
             pickings = self._search_pickings(picking_types)
-
         pickings = self._sort(pickings)
-        pickings = self._apply_limits(pickings, max_pickings, max_weight, max_volume)
+        if group_by_commercial_partner:
+            # From the first operation we got, get all operations having the
+            # same commercial entity
+            picking = fields.first(pickings)
+            commercial_partner = picking.partner_id.commercial_partner_id
+            pickings = self._search_pickings(
+                picking_types, user=search_user, commercial_partner=commercial_partner
+            )
+        else:
+            # Otherwise process by priorities by applying the limits
+            pickings = self._apply_limits(
+                pickings, max_pickings, max_weight, max_volume
+            )
         if not pickings:
             return self.env["stock.picking.batch"].browse()
         return self._create_batch(pickings)
@@ -62,21 +82,29 @@ class PickingBatchAutoCreateAction(Component):
             "lock acquired to create a picking batch (%s)", self.env.user.login
         )
 
-    def _search_pickings_domain(self, picking_types, user=None):
+    def _search_pickings_domain(
+        self, picking_types, user=None, commercial_partner=None
+    ):
         domain = [
             ("picking_type_id", "in", picking_types.ids),
             ("state", "in", ("assigned", "partially_available")),
             ("batch_id", "=", False),
             ("user_id", "=", user.id if user else False),
         ]
+        if commercial_partner:
+            domain.append(
+                ("partner_id.commercial_partner_id", "=", commercial_partner.id)
+            )
         return domain
 
-    def _search_pickings(self, picking_types, user=None):
+    def _search_pickings(self, picking_types, user=None, commercial_partner=None):
         # We can't use a limit in the SQL search because the 'priority' fields
         # is sometimes empty (it seems the inverse StockPicking.priority field
         # mess up with default on stock.move), we have to sort in Python.
         return self.env["stock.picking"].search(
-            self._search_pickings_domain(picking_types, user=user)
+            self._search_pickings_domain(
+                picking_types, user=user, commercial_partner=commercial_partner
+            )
         )
 
     def _sort(self, pickings):

--- a/shopfloor_batch_automatic_creation/models/shopfloor_menu.py
+++ b/shopfloor_batch_automatic_creation/models/shopfloor_menu.py
@@ -18,6 +18,12 @@ class ShopfloorMenu(models.Model):
         " and a max quantity of 3, the batch will only contain the 2"
         " priority transfers.",
     )
+    batch_group_by_commercial_partner = fields.Boolean(
+        string="Group by commercial entity",
+        default=False,
+        help="If enabled, transfers will be grouped by commercial entity."
+        "This could mix priorities and will ignore the constraints to apply.",
+    )
     batch_create_max_picking = fields.Integer(
         string="Max transfers",
         default=0,

--- a/shopfloor_batch_automatic_creation/readme/DESCRIPTION.rst
+++ b/shopfloor_batch_automatic_creation/readme/DESCRIPTION.rst
@@ -6,6 +6,7 @@ batch is available, it automatically creates a new batch for the user.
 Some options can be configured on the Shopfloor menu:
 
 * Activate or not the batch creation
+* Group by commercial entity
 * Max number of transfer per batch
 * Max weight per batch
 * Max volume per batch

--- a/shopfloor_batch_automatic_creation/services/cluster_picking.py
+++ b/shopfloor_batch_automatic_creation/services/cluster_picking.py
@@ -19,6 +19,7 @@ class ClusterPicking(Component):
         menu = self.work.menu
         return auto_batch.create_batch(
             self.picking_types,
+            group_by_commercial_partner=menu.batch_group_by_commercial_partner,
             max_pickings=menu.batch_create_max_picking,
             max_volume=menu.batch_create_max_volume,
             max_weight=menu.batch_create_max_weight,

--- a/shopfloor_batch_automatic_creation/views/shopfloor_menu_views.xml
+++ b/shopfloor_batch_automatic_creation/views/shopfloor_menu_views.xml
@@ -12,16 +12,26 @@
                 >
                     <field name="batch_create" />
                     <field
-                        name="batch_create_max_picking"
+                        name="batch_group_by_commercial_partner"
                         attrs="{'invisible': [('batch_create', '=', False)]}"
+                    />
+                    <field
+                        name="batch_create_max_picking"
+                        attrs="{
+                          'invisible': ['|', ('batch_create', '=', False), ('batch_group_by_commercial_partner', '=', True)],
+                        }"
                     />
                     <field
                         name="batch_create_max_volume"
-                        attrs="{'invisible': [('batch_create', '=', False)]}"
+                        attrs="{
+                          'invisible': ['|', ('batch_create', '=', False), ('batch_group_by_commercial_partner', '=', True)],
+                        }"
                     />
                     <field
                         name="batch_create_max_weight"
-                        attrs="{'invisible': [('batch_create', '=', False)]}"
+                        attrs="{
+                          'invisible': ['|', ('batch_create', '=', False), ('batch_group_by_commercial_partner', '=', True)],
+                        }"
                     />
                 </group>
             </group>


### PR DESCRIPTION
New option "Group by commercial entity" allowing to create batch grouping operations of the same commercial entity.
This option ignores priorities or constraints/limits which normally apply on a batch creation.

Ref. 2328