### PR TITLE
sf_mobile_base: show current running env

### DIFF
--- a/shopfloor_mobile_base/readme/USAGE.rst
+++ b/shopfloor_mobile_base/readme/USAGE.rst
@@ -32,3 +32,20 @@ Customization
 ~~~~~~~~~~~~~
 
 Please refer to `shopfloor_mobile_custom_example`.
+
+
+Working environment
+~~~~~~~~~~~~~~~~~~~
+
+You can control which running env is considerd by Odoo config or env vars.
+
+
+For Odoo config: `running_env` or `shopfloor_running_env`.
+
+For env var: `RUNNING_ENV` or `SHOPFLOOR_RUNNING_ENV`.
+
+Expected key `RUNNING_ENV` is compliant w/ `server_environment` naming but is not depending on it.
+
+Additionally, as specific key for Shopfloor is supported.
+
+**You don't need `server_environment` module to use this feature.**

--- a/shopfloor_mobile_base/static/wms/src/components/misc.js
+++ b/shopfloor_mobile_base/static/wms/src/components/misc.js
@@ -377,10 +377,27 @@ Vue.component("user-session-detail", {
             type: Boolean,
             default: true,
         },
+        show_env: {
+            type: Boolean,
+            default: true,
+        },
     },
     template: `
   <div :class="$options._componentTag" data-ref="user-session-detail">
     <v-list>
+        <v-list-item v-if="show_env"
+                data-ref="session-detail-env"
+                :data-id="$root.app_info.running_env"
+                >
+            <v-list-item-avatar>
+                <v-avatar :color="$root.app_info.running_env == 'prod' ? 'primary' : 'warning'" size="36">
+                    <v-icon dark>mdi-server</v-icon>
+                </v-avatar>
+            </v-list-item-avatar>
+            <v-list-item-content>
+                <span v-text="$t('app.running_env.' + $root.app_info.running_env)" />
+            </v-list-item-content>
+        </v-list-item>
         <v-list-item v-if="show_user && $root.user.id"
                 data-ref="session-detail-user"
                 :data-id="$root.user.id"

--- a/shopfloor_mobile_base/static/wms/src/components/screen.js
+++ b/shopfloor_mobile_base/static/wms/src/components/screen.js
@@ -43,6 +43,7 @@ Vue.component("Screen", {
                 this.$root.authenticated ? "authenticated" : "anonymous",
                 this.$root.loading ? "loading" : "",
                 this.$root.demo_mode ? "demo_mode" : "",
+                "env-" + this.$root.app_info.running_env,
             ].join(" ");
         },
         screen_content_class() {

--- a/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
+++ b/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
@@ -64,6 +64,13 @@ const messages_en = {
             op_types: "Op Types:",
         },
         log_entry_link: "View / share log entry",
+        running_env: {
+            prod: "Production",
+            integration: "Integration",
+            staging: "Staging",
+            test: "Test",
+            dev: "Development",
+        },
     },
     language: {
         name: {

--- a/shopfloor_mobile_base/static/wms/src/loginpage.js
+++ b/shopfloor_mobile_base/static/wms/src/loginpage.js
@@ -55,6 +55,20 @@ export var LoginPage = Vue.component("login-page", {
     template: `
     <Screen :screen_info="screen_info" :show-menu="false">
         <v-container>
+            <v-row align="center" v-if="$root.app_info.running_env != 'prod'">
+                <v-col cols="12">
+                    <v-alert
+                        dense
+                        colored-border
+                        type="warning"
+                        border="left"
+                        elevation="2"
+                        :icon="false"
+                        >
+                        <user-session-detail :show_profile="false" :show_user="false" />
+                    </v-alert>
+                </v-col>
+            </v-row>
             <v-row
                 align="center"
                 justify="center">

--- a/shopfloor_mobile_base/static/wms/src/settings/settings.js
+++ b/shopfloor_mobile_base/static/wms/src/settings/settings.js
@@ -18,7 +18,7 @@ export var SettingsControlPanel = Vue.component("settings-control-panel", {
     template: `
         <Screen :screen_info="{title: $t('screen.settings.home.title'), klass: 'settings settings-control-panel'}">
             <v-card outlined v-if="$root.user.id">
-                <user-session-detail :show_profile="false"/>
+                <user-session-detail :show_profile="false" />
             </v-card>
             <div class="button-list button-vertical-list full">
                 <v-row align="center" v-for="page in get_pages()" :key="make_component_key([page.key])">

--- a/shopfloor_mobile_base/templates/main.xml
+++ b/shopfloor_mobile_base/templates/main.xml
@@ -27,6 +27,7 @@
                 <script type="text/javascript">
           var shopfloor_app_info = {
             app_version: "<t t-esc="app_version" />",
+            running_env: "<t t-esc="running_env" />",
             demo_mode: <t t-esc="'true' if demo_mode else 'false'" />,
           };
         </script>


### PR DESCRIPTION
Displayed on login only if env != prod:

![Screenshot from 2021-04-21 11-47-31](https://user-images.githubusercontent.com/347149/115533956-8fb99e00-a297-11eb-994a-dfb47c9f2159.png)

Displayed always on settings page and menu bottom info:

![Screenshot from 2021-04-21 11-47-50](https://user-images.githubusercontent.com/347149/115533954-8f210780-a297-11eb-88b6-7b291c4233db.png)

![Screenshot from 2021-04-21 11-48-15](https://user-images.githubusercontent.com/347149/115533951-8e887100-a297-11eb-8460-3c417fa9b1cf.png)