### PR TITLE
[13.0] Shopfloor: Improve check valid destination + align checks in all scenario

### DIFF
--- a/shopfloor/README.rst
+++ b/shopfloor/README.rst
@@ -105,6 +105,7 @@ Contributors
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 * Benoit Guillot <benoit.guillot@akretion.com>
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Design
 ~~~~~~

--- a/shopfloor/readme/CONTRIBUTORS.rst
+++ b/shopfloor/readme/CONTRIBUTORS.rst
@@ -4,6 +4,7 @@
 * Alexandre Fayolle <alexandre.fayolle@camptocamp.com>
 * Benoit Guillot <benoit.guillot@akretion.com>
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Design
 ~~~~~~

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -1,4 +1,5 @@
-# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from werkzeug.exceptions import BadRequest
@@ -179,9 +180,7 @@ class Checkout(Component):
         if not picking:
             location = search.location_from_scan(barcode)
             if location:
-                if not location.is_sublocation_of(
-                    self.picking_types.mapped("default_location_src_id")
-                ):
+                if not self.is_src_location_valid(location):
                     return self._response_for_select_document(
                         message=self.msg_store.location_not_allowed()
                     )

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1,4 +1,5 @@
-# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, fields
 from odoo.osv import expression
@@ -933,24 +934,20 @@ class ClusterPicking(Component):
             return self._unload_end(batch)
 
         first_line = fields.first(lines)
-        picking_type = fields.first(batch.picking_ids).picking_type_id
         scanned_location = self._actions_for("search").location_from_scan(barcode)
         if not scanned_location:
             return self._response_for_unload_all(
                 batch, message=self.msg_store.no_location_found()
             )
-        if not scanned_location.is_sublocation_of(
-            picking_type.default_location_dest_id
-        ) or not scanned_location.is_sublocation_of(
-            lines.mapped("move_id.location_dest_id"), func=all
-        ):
+        if not self.is_dest_location_valid(lines.move_id, scanned_location):
             return self._response_for_unload_all(
                 batch, message=self.msg_store.dest_location_not_allowed()
             )
 
-        if not scanned_location.is_sublocation_of(first_line.location_dest_id):
-            if not confirmation:
-                return self._response_for_confirm_unload_all(batch)
+        if not confirmation and self.is_dest_location_to_confirm(
+            first_line.location_dest_id, scanned_location
+        ):
+            return self._response_for_confirm_unload_all(batch)
 
         self._unload_write_destination_on_lines(lines, scanned_location)
         completion_info = self._actions_for("completion.info")
@@ -1099,25 +1096,19 @@ class ClusterPicking(Component):
         # Lock move lines that will be updated
         self._lock_lines(lines)
         first_line = fields.first(lines)
-        picking_type = fields.first(batch.picking_ids).picking_type_id
         scanned_location = self._actions_for("search").location_from_scan(barcode)
         if not scanned_location:
             return self._response_for_unload_set_destination(
                 batch, package, message=self.msg_store.no_location_found()
             )
-
-        if not scanned_location.is_sublocation_of(
-            picking_type.default_location_dest_id
-        ) or not scanned_location.is_sublocation_of(
-            lines.mapped("move_id.location_dest_id"), func=all
-        ):
+        if not self.is_dest_location_valid(lines.move_id, scanned_location):
             return self._response_for_unload_set_destination(
                 batch, package, message=self.msg_store.dest_location_not_allowed()
             )
-
-        if not scanned_location.is_sublocation_of(first_line.location_dest_id):
-            if not confirmation:
-                return self._response_for_confirm_unload_set_destination(batch, package)
+        if not confirmation and self.is_dest_location_to_confirm(
+            first_line.location_dest_id, scanned_location
+        ):
+            return self._response_for_confirm_unload_set_destination(batch, package)
 
         self._unload_write_destination_on_lines(lines, scanned_location)
 

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -1,5 +1,6 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # Copyright 2020 Akretion (http://www.akretion.com)
+# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, exceptions
 
@@ -60,3 +61,33 @@ class BaseShopfloorProcess(AbstractComponent):
                 return self.msg_store.stock_picking_not_available(picking)
             if picking.picking_type_id not in self.picking_types:
                 return self.msg_store.cannot_move_something_in_picking_type()
+
+    def is_src_location_valid(self, location):
+        """Check the source location is valid for given process.
+
+        We ensure the source is valid regarding one of the picking types of the
+        process.
+        """
+        return location.is_sublocation_of(self.picking_types.default_location_src_id)
+
+    def is_dest_location_valid(self, moves, location):
+        """Check the destination location is valid for given moves.
+
+        We ensure the destination is either valid regarding the picking
+        destination location or the move destination location. With the push
+        rules in the module stock_dynamic_routing in OCA/wms, it is possible
+        that the move destination is not anymore a child of the picking default
+        destination (as it is the last pushed move that now respects this
+        condition and not anymore this one that has a destination to an
+        intermediate location)
+        """
+        return location.is_sublocation_of(
+            moves.picking_id.location_dest_id, func=all
+        ) or location.is_sublocation_of(moves.location_dest_id, func=all)
+
+    def is_dest_location_to_confirm(self, location_dest_id, location):
+        """Check the destination location requires confirmation
+
+        The location is valid but not the expected one: ask for confirmation
+        """
+        return not location.is_sublocation_of(location_dest_id)

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -1,4 +1,5 @@
-# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2020 Akretion (http://www.akretion.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import fields
@@ -76,9 +77,7 @@ class SinglePackTransfer(Component):
                 self.msg_store.package_not_found_for_barcode(barcode)
             )
 
-        if not package.location_id.is_sublocation_of(
-            picking_types.mapped("default_location_src_id")
-        ):
+        if not self.is_src_location_valid(package.location_id):
             return self._response_for_start(
                 message=self.msg_store.package_not_allowed_in_src_location(
                     barcode, picking_types
@@ -129,8 +128,8 @@ class SinglePackTransfer(Component):
         message = self.msg_store.no_pending_operation_for_pack(package)
         if not package_level and self.work.menu.allow_move_create:
             package_level = self._create_package_level(package)
-            if not package_level.location_dest_id.is_sublocation_of(
-                picking_types.default_location_dest_id
+            if not self.is_dest_location_valid(
+                package_level.move_line_ids.move_id, package_level.location_dest_id
             ):
                 package_level = None
                 savepoint.rollback()
@@ -191,19 +190,8 @@ class SinglePackTransfer(Component):
         picking.action_assign()
         return package_level
 
-    def _is_move_state_valid(self, move):
-        return move.state != "cancel"
-
-    def _is_dest_location_valid(self, move, scanned_location):
-        """Forbid a dest location to be used"""
-        return scanned_location.is_sublocation_of(
-            move.picking_id.picking_type_id.default_location_dest_id
-        ) and scanned_location.is_sublocation_of(move.location_dest_id)
-
-    def _is_dest_location_to_confirm(self, move, scanned_location):
-        """Destination that could be used but need confirmation"""
-        move_dest_location = move.move_line_ids[0].location_dest_id
-        return not scanned_location.is_sublocation_of(move_dest_location)
+    def _is_move_state_valid(self, moves):
+        return all(move.state != "cancel" for move in moves)
 
     def validate(self, package_level_id, location_barcode, confirmation=False):
         """Validate the transfer"""
@@ -215,11 +203,11 @@ class SinglePackTransfer(Component):
                 message=self.msg_store.operation_not_found()
             )
 
-        # if we have more than one move, we should assume they go to the same
-        # place
-        move_line = package_level.move_line_ids[0]
-        move = move_line.move_id
-        if not self._is_move_state_valid(move):
+        # Do not use package_level.move_ids, this is only filled in when the
+        # moves have been created from a manually encoded package level, not
+        # when a package has been reserved for existing moves
+        moves = package_level.move_line_ids.move_id
+        if not self._is_move_state_valid(moves):
             return self._response_for_start(
                 message=self.msg_store.operation_has_been_canceled_elsewhere()
             )
@@ -230,22 +218,23 @@ class SinglePackTransfer(Component):
                 package_level, message=self.msg_store.no_location_found()
             )
 
-        if not self._is_dest_location_valid(move, scanned_location):
+        if not self.is_dest_location_valid(moves, scanned_location):
             return self._response_for_scan_location(
                 package_level, message=self.msg_store.dest_location_not_allowed()
             )
 
-        if self._is_dest_location_to_confirm(move, scanned_location):
-            if not confirmation:
-                return self._response_for_scan_location(
-                    package_level,
-                    confirmation_required=True,
-                    message=self.msg_store.confirm_location_changed(
-                        move_line.location_dest_id, scanned_location
-                    ),
-                )
+        if not confirmation and self.is_dest_location_to_confirm(
+            package_level.location_dest_id, scanned_location
+        ):
+            return self._response_for_scan_location(
+                package_level,
+                confirmation_required=True,
+                message=self.msg_store.confirm_location_changed(
+                    package_level.location_dest_id, scanned_location
+                ),
+            )
 
-        self._set_destination_and_done(move, scanned_location)
+        self._set_destination_and_done(package_level, scanned_location)
         return self._router_validate_success(package_level)
 
     def _is_last_move(self, move):
@@ -262,12 +251,12 @@ class SinglePackTransfer(Component):
             completion_info_popup = completion_info.popup(package_level.move_line_ids)
         return self._response_for_start(message=message, popup=completion_info_popup)
 
-    def _set_destination_and_done(self, move, scanned_location):
+    def _set_destination_and_done(self, package_level, scanned_location):
         # when writing the destination on the package level, it writes
         # on the move lines
-        move.move_line_ids.package_level_id.location_dest_id = scanned_location
+        package_level.location_dest_id = scanned_location
         stock = self._actions_for("stock")
-        stock.validate_moves(move)
+        stock.validate_moves(package_level.move_line_ids.move_id)
 
     def cancel(self, package_level_id):
         package_level = self.env["stock.package_level"].browse(package_level_id)

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1,4 +1,5 @@
-# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import functools
 from collections import defaultdict
@@ -407,9 +408,7 @@ class ZonePicking(Component):
         zone_location = search.location_from_scan(barcode)
         if not zone_location:
             return self._response_for_start(message=self.msg_store.no_location_found())
-        if not zone_location.is_sublocation_of(
-            self.work.menu.picking_type_ids.mapped("default_location_src_id")
-        ):
+        if not self.is_src_location_valid(zone_location):
             return self._response_for_start(
                 message=self.msg_store.location_not_allowed()
             )
@@ -602,19 +601,14 @@ class ZonePicking(Component):
         # if `confirmation is True
         # Ask confirmation to the user if the scanned location is not in the
         # expected ones but is valid (in picking type's default destination)
-        if not location.is_sublocation_of(
-            self.picking_type.default_location_dest_id
-        ) or not location.is_sublocation_of(
-            move_line.move_id.location_dest_id, func=all
-        ):
+        if not self.is_dest_location_valid(move_line.move_id, location):
             response = self._response_for_set_line_destination(
                 move_line, message=self.msg_store.dest_location_not_allowed(),
             )
             return (location_changed, response)
 
-        if (
-            not location.is_sublocation_of(move_line.location_dest_id)
-            and not confirmation
+        if not confirmation and self.is_dest_location_to_confirm(
+            move_line.location_dest_id, location
         ):
             response = self._response_for_set_line_destination(
                 move_line,
@@ -1128,9 +1122,8 @@ class ZonePicking(Component):
             if len(location_dest) != 1:
                 error = self.msg_store.lines_different_dest_location()
             # check if the scanned location is allowed
-            if not location.is_sublocation_of(
-                self.picking_type.default_location_dest_id
-            ):
+            moves = buffer_lines.mapped("move_id")
+            if not self.is_dest_location_valid(moves, location):
                 error = self.msg_store.location_not_allowed()
             if error:
                 return self._set_destination_all_response(buffer_lines, message=error)
@@ -1139,19 +1132,19 @@ class ZonePicking(Component):
             #     destination set on buffer lines
             #   - To confirm if the scanned destination is not a child of the
             #     current destination set on buffer lines
-            if not location.is_sublocation_of(buffer_lines.location_dest_id):
-                if not confirmation:
-                    return self._response_for_unload_all(
-                        buffer_lines,
-                        message=self.msg_store.confirm_location_changed(
-                            first(buffer_lines.location_dest_id), location
-                        ),
-                        confirmation_required=True,
-                    )
+            if not confirmation and self.is_dest_location_to_confirm(
+                buffer_lines.location_dest_id, location
+            ):
+                return self._response_for_unload_all(
+                    buffer_lines,
+                    message=self.msg_store.confirm_location_changed(
+                        first(buffer_lines.location_dest_id), location
+                    ),
+                    confirmation_required=True,
+                )
             # the scanned location is still valid, use it
             self._write_destination_on_lines(buffer_lines, location)
             # set lines to done + refresh buffer lines (should be empty)
-            moves = buffer_lines.mapped("move_id")
             # split move lines to a backorder move
             # if quantity is not fully satisfied
             # TODO: update tests
@@ -1281,11 +1274,8 @@ class ZonePicking(Component):
         search = self._actions_for("search")
         location = search.location_from_scan(barcode)
         if location:
-            if not location.is_sublocation_of(
-                self.picking_type.default_location_dest_id
-            ) or not location.is_sublocation_of(
-                buffer_lines.move_id.location_dest_id, func=all
-            ):
+            moves = buffer_lines.mapped("move_id")
+            if not self.is_dest_location_valid(moves, location):
                 return self._response_for_unload_set_destination(
                     first(buffer_lines),
                     message=self.msg_store.dest_location_not_allowed(),
@@ -1295,19 +1285,19 @@ class ZonePicking(Component):
             #     destination set on buffer lines
             #   - To confirm if the scanned destination is not a child of the
             #     current destination set on buffer lines
-            if not location.is_sublocation_of(buffer_lines.location_dest_id):
-                if not confirmation:
-                    return self._response_for_unload_set_destination(
-                        first(buffer_lines),
-                        message=self.msg_store.confirm_location_changed(
-                            first(buffer_lines.location_dest_id), location
-                        ),
-                        confirmation_required=True,
-                    )
+            if not confirmation and self.is_dest_location_to_confirm(
+                buffer_lines.location_dest_id, location
+            ):
+                return self._response_for_unload_set_destination(
+                    first(buffer_lines),
+                    message=self.msg_store.confirm_location_changed(
+                        first(buffer_lines.location_dest_id), location
+                    ),
+                    confirmation_required=True,
+                )
             # the scanned location is valid, use it
             self._write_destination_on_lines(buffer_lines, location)
             # set lines to done + refresh buffer lines (should be empty)
-            moves = buffer_lines.mapped("move_id")
             # split move lines to a backorder move
             # if quantity is not fully satisfied
             for move in moves:

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -345,13 +345,13 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
     def test_set_destination_all_error_location_move_invalid(self):
         """Endpoint called with a barcode for an invalid location
 
-        It is invalid when the location is not the destination location or
-        sublocation of move line's move
+        It is invalid when the location is not a sublocation of the picking
+        or move destination
         """
         move_lines = self.move_lines
         self._set_dest_package_and_done(move_lines, self.bin1)
-        move_lines.write({"location_dest_id": self.packing_a_location.id})
         move_lines[0].move_id.location_dest_id = self.packing_a_location
+        move_lines[0].picking_id.location_dest_id = self.packing_a_location
 
         response = self.service.dispatch(
             "set_destination_all",
@@ -740,10 +740,10 @@ class ClusterPickingUnloadScanDestinationCase(ClusterPickingUnloadingCommonCase)
     def test_unload_scan_destination_error_location_move_invalid(self):
         """Endpoint called with a barcode for an invalid location
 
-        It is invalid when the location is not the destination location or
-        sublocation of the move line's move
+        It is invalid when the location is not a sublocation of the picking
+        or move destination
         """
-        self.bin1_lines[0].move_id.location_dest_id = self.packing_a_location
+        self.bin1_lines[0].picking_id.location_dest_id = self.packing_a_location
         response = self.service.dispatch(
             "unload_scan_destination",
             params={

--- a/shopfloor/tests/test_location_content_transfer_set_destination_all.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_all.py
@@ -289,10 +289,14 @@ class LocationContentTransferSetDestinationAllCase(LocationContentTransferCommon
         )
 
     def test_set_destination_all_dest_location_move_invalid(self):
-        """The scanned destination location is not in the move's dest location"""
-        # if we have at least one move which does not match the scanned location
+        """The scanned destination location is not in the picking and move's
+        dest location
+        """
+        # if we have at least one move which does not match the scanned
+        # location
         # we forbid the action
         self.pickings.move_lines[0].location_dest_id = self.shelf1
+        self.pickings[0].location_dest_id = self.shelf1
         response = self.service.dispatch(
             "set_destination_all",
             params={

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -113,13 +113,14 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         )
 
     def test_set_destination_package_dest_location_move_nok(self):
-        """Scanned destination location not valid (different as move)"""
+        """Scanned destination location not valid (different as move and picking)"""
         package_level = self.picking1.package_level_ids[0]
         # if the move related to the package level has a destination
         # location not a parent or equal to the scanned location,
         # refuse the action
         move = package_level.move_line_ids.move_id
         move.location_dest_id = self.shelf1
+        move.picking_id.location_dest_id = self.shelf1
         response = self.service.dispatch(
             "set_destination_package",
             params={
@@ -293,12 +294,13 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         )
 
     def test_set_destination_line_dest_location_move_nok(self):
-        """Scanned destination location not valid (different as move)"""
+        """Scanned destination location not valid (different as picking and move)"""
         move_line = self.picking2.move_line_ids[0]
         # if the move related to the move line has a destination
         # location not a parent or equal to the scanned location,
         # refuse the action
         move_line.move_id.location_dest_id = self.shelf1
+        move_line.picking_id.location_dest_id = self.shelf1
         response = self.service.dispatch(
             "set_destination_line",
             params={

--- a/shopfloor/tests/test_single_pack_transfer_putaway.py
+++ b/shopfloor/tests/test_single_pack_transfer_putaway.py
@@ -75,9 +75,11 @@ class TestSinglePackTransferPutaway(SinglePackTransferCommonBase):
         # no package level created to move the package
         self.assertFalse(package_levels)
 
-    def test_putaway_move_dest_not_child_of_picking_type_dest(self):
+    def test_putaway_move_dest_not_child_of_picking_dest(self):
         """Putaway is applied on move but the destination location is not a
         child of the default picking type destination location.
+        Case where the picking is created by scanning a package level. Then the
+        move destination is according to the putaway and valid.
         """
         # Change the default destination location of the picking type
         # to get it outside of the putaway destination
@@ -92,19 +94,7 @@ class TestSinglePackTransferPutaway(SinglePackTransferCommonBase):
             }
         )
         # Check the result
-        existing_package_levels = self.env["stock.package_level"].search(
-            [("package_id", "=", self.package.id)]
-        )
         response = self.service.dispatch(
             "start", params={"barcode": self.shelf1.barcode}
         )
-        self.assert_response(
-            response,
-            next_state="start",
-            data=self.ANY,
-            message=self.service.msg_store.package_unable_to_transfer(self.package),
-        )
-        current_package_levels = self.env["stock.package_level"].search(
-            [("package_id", "=", self.package.id)]
-        )
-        self.assertEqual(existing_package_levels, current_package_levels)
+        self.assert_response(response, next_state="scan_location", data=self.ANY)

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -98,13 +98,13 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         )
 
     def test_set_destination_location_move_invalid_location(self):
-        # Confirm the destination with a wrong destination, outside of move's
-        # move line (should not happen)
+        # Confirm the destination with a wrong destination, outside of picking
+        # and move's move line (should not happen)
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids
-        move_line.location_dest_id = self.packing_sublocation_a
         move_line.move_id.location_dest_id = self.packing_sublocation_a
+        move_line.picking_id.location_dest_id = self.packing_sublocation_a
         response = self.service.dispatch(
             "set_destination",
             params={

--- a/shopfloor/tests/test_zone_picking_unload_set_destination.py
+++ b/shopfloor/tests/test_zone_picking_unload_set_destination.py
@@ -97,6 +97,7 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids
         move_line[0].move_id.location_dest_id = self.packing_sublocation_a
+        move_line[0].picking_id.location_dest_id = self.packing_sublocation_a
         # set the destination package
         self.service._set_destination_package(
             move_line, move_line.product_uom_qty, self.free_package,


### PR DESCRIPTION
We ensure the destination is either valid regarding the picking default destination or the move destination. With the push rules in the module stock_dynamic_routing in OCA/wms, it is possible that the move destination is not anymore a child of the picking default destination (as it is the last pushed move that now respects this condition and not anymore this one that has a destination to an intermediate location)

Extract the location checks in a component to ensure the same checks are applied in all scenario

cc @sebalix @simahawk 