### PR TITLE
[13.0] shopfloor: fix wrong message for zone_picking.set_destination

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -693,6 +693,7 @@ class ZonePicking(Component):
         # the field ``shopfloor_user_id`` is updated with the current user
         move_line.shopfloor_user_id = user or self.env.user
 
+    # flake8: noqa: C901
     def set_destination(
         self, move_line_id, barcode, quantity, confirmation=False,
     ):
@@ -771,7 +772,10 @@ class ZonePicking(Component):
                 )
                 if response:
                     if extra_message:
-                        response["message"]["body"] += "\n" + extra_message["body"]
+                        if response.get("message"):
+                            response["message"]["body"] += "\n" + extra_message["body"]
+                        else:
+                            response["message"] = extra_message
                     return response
 
         # When the barcode is a package


### PR DESCRIPTION
When trying to set a destination, it can happen that message is empty when next step is zero check.
This PR normalizes the message in such case.

ref: 2526