### PR TITLE
[13.0][ADD] s_r_screen_mrp_subcontracting: compatibility layer

### DIFF
--- a/setup/stock_reception_screen_mrp_subcontracting/odoo/addons/stock_reception_screen_mrp_subcontracting
+++ b/setup/stock_reception_screen_mrp_subcontracting/odoo/addons/stock_reception_screen_mrp_subcontracting
@@ -1,0 +1,1 @@
+../../../../stock_reception_screen_mrp_subcontracting

--- a/setup/stock_reception_screen_mrp_subcontracting/setup.py
+++ b/setup/stock_reception_screen_mrp_subcontracting/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/stock_reception_screen/tests/common.py
+++ b/stock_reception_screen/tests/common.py
@@ -1,0 +1,76 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests.common import SavepointCase
+
+
+class Common(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.storage_type_pallet = cls.env.ref(
+            "stock_storage_type.package_storage_type_pallets"
+        )
+        cls.storage_type_pallet.barcode = "123"
+        cls.product = cls.env.ref("product.product_delivery_01")
+        cls.product.tracking = "lot"
+        cls.product_packaging = cls._create_packaging("PKG TEST", cls.product, qty=4)
+
+        cls.product_2 = cls.env.ref("product.product_delivery_02")
+        cls.product_2.tracking = "none"
+        cls.product_2_packaging = cls._create_packaging(
+            "PKG TEST 2", cls.product_2, qty=2
+        )
+
+        cls.location_dest = cls.env.ref("stock.stock_location_stock")
+        cls.location_src = cls.env.ref("stock.stock_location_suppliers")
+        cls.picking = cls._create_picking_in(partner=cls.env.ref("base.res_partner_1"))
+        cls._create_picking_line(cls.picking, cls.product, 10)
+        cls._create_picking_line(cls.picking, cls.product_2, 10)
+        cls.picking.action_confirm()
+        cls.picking.action_reception_screen_open()
+        cls.screen = cls.picking.reception_screen_id
+
+    @classmethod
+    def _create_picking_line(cls, picking, product, qty):
+        return cls.env["stock.move"].create(
+            {
+                "picking_id": picking.id,
+                "name": product.display_name,
+                "product_id": product.id,
+                "product_uom": product.uom_id.id,
+                "product_uom_qty": qty,
+                "location_id": cls.location_src.id,
+                "location_dest_id": cls.location_dest.id,
+            }
+        )
+
+    @classmethod
+    def _create_picking_in(cls, partner):
+        return cls.env["stock.picking"].create(
+            {
+                "partner_id": partner.id,
+                "location_id": cls.location_src.id,
+                "location_dest_id": cls.location_dest.id,
+                "picking_type_id": cls.env.ref("stock.picking_type_in").id,
+            }
+        )
+
+    @classmethod
+    def _create_packaging(cls, name, product, qty):
+        return cls.env["product.packaging"].create(
+            {
+                "name": name,
+                "product_id": product.id,
+                "qty": qty,
+                "package_storage_type_id": cls.storage_type_pallet.id,
+                "height": 200,
+                "width": 500,
+                "lngth": 500,
+                "max_weight": 10,
+            }
+        )

--- a/stock_reception_screen/tests/test_reception_screen.py
+++ b/stock_reception_screen/tests/test_reception_screen.py
@@ -2,80 +2,11 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import exceptions, fields
-from odoo.tests.common import SavepointCase
+
+from .common import Common
 
 
-class TestReceptionScreen(SavepointCase):
-    at_install = False
-    post_install = True
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
-        cls.storage_type_pallet = cls.env.ref(
-            "stock_storage_type.package_storage_type_pallets"
-        )
-        cls.storage_type_pallet.barcode = "123"
-        cls.product = cls.env.ref("product.product_delivery_01")
-        cls.product.tracking = "lot"
-        cls.product_packaging = cls._create_packaging("PKG TEST", cls.product, qty=4)
-
-        cls.product_2 = cls.env.ref("product.product_delivery_02")
-        cls.product_2.tracking = "none"
-        cls.product_2_packaging = cls._create_packaging(
-            "PKG TEST 2", cls.product_2, qty=2
-        )
-
-        cls.location_dest = cls.env.ref("stock.stock_location_stock")
-        cls.location_src = cls.env.ref("stock.stock_location_suppliers")
-        cls.picking = cls._create_picking_in(partner=cls.env.ref("base.res_partner_1"))
-        cls._create_picking_line(cls.picking, cls.product, 10)
-        cls._create_picking_line(cls.picking, cls.product_2, 10)
-        cls.picking.action_confirm()
-        cls.picking.action_reception_screen_open()
-        cls.screen = cls.picking.reception_screen_id
-
-    @classmethod
-    def _create_picking_line(cls, picking, product, qty):
-        return cls.env["stock.move"].create(
-            {
-                "picking_id": picking.id,
-                "name": product.display_name,
-                "product_id": product.id,
-                "product_uom": product.uom_id.id,
-                "product_uom_qty": qty,
-                "location_id": cls.location_src.id,
-                "location_dest_id": cls.location_dest.id,
-            }
-        )
-
-    @classmethod
-    def _create_picking_in(cls, partner):
-        return cls.env["stock.picking"].create(
-            {
-                "partner_id": partner.id,
-                "location_id": cls.location_src.id,
-                "location_dest_id": cls.location_dest.id,
-                "picking_type_id": cls.env.ref("stock.picking_type_in").id,
-            }
-        )
-
-    @classmethod
-    def _create_packaging(cls, name, product, qty):
-        return cls.env["product.packaging"].create(
-            {
-                "name": name,
-                "product_id": product.id,
-                "qty": qty,
-                "package_storage_type_id": cls.storage_type_pallet.id,
-                "height": 200,
-                "width": 500,
-                "lngth": 500,
-                "max_weight": 10,
-            }
-        )
-
+class TestReceptionScreen(Common):
     def test_reception_screen(self):
         # Select the product to receive
         self.assertEqual(self.screen.current_step, "select_product")

--- a/stock_reception_screen_mrp_subcontracting/__init__.py
+++ b/stock_reception_screen_mrp_subcontracting/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizards

--- a/stock_reception_screen_mrp_subcontracting/__manifest__.py
+++ b/stock_reception_screen_mrp_subcontracting/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+{
+    "name": "Stock - Reception screen (Subcontract Productions integration)",
+    "summary": "Reception screen integrated with subcontracted productions.",
+    "version": "13.0.1.0.0",
+    "category": "Stock",
+    "license": "AGPL-3",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/wms",
+    "depends": [
+        "mrp_subcontracting",
+        # OCA/wms
+        "stock_reception_screen",
+    ],
+    "data": [],
+    "installable": True,
+    "auto_install": True,
+    "development_status": "Alpha",
+}

--- a/stock_reception_screen_mrp_subcontracting/models/__init__.py
+++ b/stock_reception_screen_mrp_subcontracting/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_reception_screen
+from . import stock_move_line

--- a/stock_reception_screen_mrp_subcontracting/models/stock_move_line.py
+++ b/stock_reception_screen_mrp_subcontracting/models/stock_move_line.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def unlink(self):
+        # Overridden to not unlink lines of finished products moves
+        # if the context key 'subcontracting_skip_unlink' is set
+        if self.env.context.get("subcontracting_skip_unlink"):
+            return False
+        return super().unlink()

--- a/stock_reception_screen_mrp_subcontracting/models/stock_reception_screen.py
+++ b/stock_reception_screen_mrp_subcontracting/models/stock_reception_screen.py
@@ -1,0 +1,55 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class StockReceptionScreen(models.Model):
+    _inherit = "stock.reception.screen"
+
+    def _split_move(self, move, qty):
+        # Overridden to remove the link between the move of finished product
+        # and the move to receive to ease the split
+        move_is_subcontract = move.is_subcontract
+        move_move_orig = move.move_orig_ids
+        if move_is_subcontract:
+            move.move_orig_ids = False
+        new_move_id = super()._split_move(move, qty)
+        if move_is_subcontract:
+            new_move = move.browse(new_move_id)
+            new_move.move_orig_ids = move_move_orig
+            move.move_orig_ids = move_move_orig
+        return new_move_id
+
+    def _validate_current_move(self):
+        # Overridden to automatically recheck availability each time a move
+        # is validated to reserve qties from the production for remaining moves
+        res = super()._validate_current_move()
+        if self.current_move_id.is_subcontract:
+            if self.picking_id.state not in ("cancel", "done"):
+                self.picking_id.action_assign()
+        return res
+
+    def _action_done_move(self, move):
+        if move.is_subcontract:
+            move = move.with_context(cancel_backorder=False)
+        res = super()._action_done_move(move)
+        return res
+
+    def _action_done_picking(self):
+        # Overridden to unlink existing move lines of finished products
+        # as it is done in 'picking.action_done' in module 'mrp_subcontracting',
+        # but here we do this only one time and not each time we iterate on
+        # received move (which removes each time the move line created by the
+        # previous received move, as in the context of reception screen we
+        # could have received the goods in several moves while having only one
+        # finished product move)
+        for move in self.picking_id.move_lines:
+            if not move.is_subcontract:
+                continue
+            if move._has_tracked_subcontract_components():
+                move.move_orig_ids.filtered(
+                    lambda m: m.state not in ("done", "cancel")
+                ).move_line_ids.unlink()
+        self = self.with_context(subcontracting_skip_unlink=True)
+        return super()._action_done_picking()

--- a/stock_reception_screen_mrp_subcontracting/readme/CONTRIBUTORS.rst
+++ b/stock_reception_screen_mrp_subcontracting/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Sébastien Alix <sebastien.alix@camptocamp.com>

--- a/stock_reception_screen_mrp_subcontracting/readme/DESCRIPTION.rst
+++ b/stock_reception_screen_mrp_subcontracting/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+This module makes compatible the reception screen flow with subcontracted goods
+(`mrp_subcontracting` module).

--- a/stock_reception_screen_mrp_subcontracting/tests/__init__.py
+++ b/stock_reception_screen_mrp_subcontracting/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_reception_screen

--- a/stock_reception_screen_mrp_subcontracting/tests/test_reception_screen.py
+++ b/stock_reception_screen_mrp_subcontracting/tests/test_reception_screen.py
@@ -1,0 +1,86 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields
+
+from odoo.addons.stock_reception_screen.tests.common import Common
+
+
+class TestReceptionScreenMrpSubcontracting(Common):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # product.product_delivery_02 has a subcontracted BoM defined with
+        # 'mrp_subcontracting' installed
+        cls.picking = cls._create_picking_in(partner=cls.env.ref("base.res_partner_12"))
+        cls._create_picking_line(cls.picking, cls.product_2, 4)
+        cls.picking.action_confirm()
+        cls.picking.action_reception_screen_open()
+        cls.screen = cls.picking.reception_screen_id
+
+    def test_reception_screen_with_subcontracted_products(self):
+        # Select the product to receive
+        self.assertEqual(self.screen.current_step, "select_product")
+        move = fields.first(self.screen.picking_filtered_move_lines)
+        move.action_select_product()
+        # Receive 2/4 qties (corresponding to the product packaging qty)
+        self.assertEqual(self.screen.current_step, "set_quantity")
+        self.screen.current_move_line_qty_done = 2
+        self.assertEqual(self.screen.current_move_line_qty_status, "lt")
+        # Check package data (automatically filled normally)
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "select_packaging")
+        self.assertEqual(self.screen.product_packaging_id, self.product_2_packaging)
+        self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
+        self.assertEqual(self.screen.package_height, self.product_2_packaging.height)
+        # Check that a destination location is defined by default
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
+        self.screen.button_save_step()
+        self.assertEqual(
+            self.screen.current_move_line_location_dest_id,
+            self.screen.current_move_line_location_dest_stored_id,
+        )
+        # Set a package
+        self.assertEqual(self.screen.current_step, "set_package")
+        self.screen.current_move_line_package = "PID-TEST-1"
+        self.assertEqual(self.screen.current_move_line_package_stored, "PID-TEST-1")
+        move_line = self.screen.current_move_line_id
+        self.assertFalse(move_line.result_package_id)
+        self.assertEqual(len(self.picking.move_lines), 1)
+        self.screen.button_save_step()
+        self.assertEqual(move_line.result_package_id.name, "PID-TEST-1")
+        # The first 2 qties should be validated, creating a 2nd move to process
+        self.assertEqual(len(self.picking.move_lines), 2)
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_quantity")
+        self.screen.current_move_line_qty_done = 2
+        self.assertEqual(self.screen.current_move_line_qty_status, "eq")
+        self.screen.button_save_step()
+        # Check package data (automatically filled as before)
+        self.assertEqual(self.screen.current_step, "select_packaging")
+        self.assertEqual(self.screen.product_packaging_id, self.product_2_packaging)
+        self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
+        self.assertEqual(self.screen.package_height, self.product_2_packaging.height)
+        self.screen.button_save_step()
+        # Set location
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
+        # Set a package
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_package")
+        self.screen.current_move_line_package = "PID-TEST-2"
+        self.assertEqual(self.screen.current_move_line_package_stored, "PID-TEST-2")
+        move_line = self.screen.current_move_line_id
+        self.assertFalse(move_line.result_package_id)
+        self.screen.button_save_step()  # Reception done
+        self.assertEqual(move_line.result_package_id.name, "PID-TEST-2")
+        # Check that the manufacturing order is now done
+        production = self.picking.move_lines.move_orig_ids.production_id
+        self.assertEqual(production.state, "done")
+        self.assertEqual(production.move_finished_ids.product_uom_qty, 4)
+        self.assertEqual(production.move_finished_ids.quantity_done, 4)
+        self.assertEqual(production.move_finished_ids.state, "done")
+        for ml in production.finished_move_line_ids:
+            self.assertEqual(ml.qty_done, 2)

--- a/stock_reception_screen_mrp_subcontracting/wizards/__init__.py
+++ b/stock_reception_screen_mrp_subcontracting/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import mrp_product_produce

--- a/stock_reception_screen_mrp_subcontracting/wizards/mrp_product_produce.py
+++ b/stock_reception_screen_mrp_subcontracting/wizards/mrp_product_produce.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class MrpProductProduce(models.TransientModel):
+    _inherit = "mrp.product.produce"
+
+    def _record_production(self):
+        # Overridden to unlink existing move lines when the components
+        # consumption is recorded. As a result we will get only new move lines
+        # related to the production, avoiding issues when processing them with
+        # the reception screen.
+        dest_moves = self.move_finished_ids.move_dest_ids.filtered(
+            lambda m: m.state not in ("done", "cancel")
+        )
+        incoming = "incoming" in dest_moves.mapped("picking_code")
+        if incoming:
+            dest_moves._do_unreserve()
+        res = super()._record_production()
+        if incoming:
+            dest_moves._action_assign()
+        return res


### PR DESCRIPTION
New module to make compatible the reception screen with the `mrp_subcontracting` module.

With the reception screen we allowed to receive goods move by move (each time validated), and this new module makes this flow compatible with subcontracted goods.

Ref. 2472