### PR TITLE
[130][IMP] shopfloor mobile carrier display

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -43,6 +43,7 @@ class DataAction(Component):
             "note",
             ("partner_id:partner", self._partner_parser),
             ("carrier_id:carrier", self._simple_record_parser()),
+            ("ship_carrier_id:ship_carrier", self._simple_record_parser()),
             "move_line_count",
             "package_level_count",
             "bulk_line_count",

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -23,6 +23,7 @@ class ShopfloorSchemaAction(Component):
             "weight": {"required": True, "nullable": True, "type": "float"},
             "partner": self._schema_dict_of(self._simple_record()),
             "carrier": self._schema_dict_of(self._simple_record(), required=False),
+            "ship_carrier": self._schema_dict_of(self._simple_record(), required=False),
             "scheduled_date": {"type": "string", "nullable": False, "required": True},
         }
 

--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -109,6 +109,7 @@ class ActionsDataCase(ActionsDataCaseBase):
             "weight": 110.0,
             "partner": {"id": self.customer.id, "name": self.customer.name},
             "carrier": {"id": carrier.id, "name": carrier.name},
+            "ship_carrier": None,
         }
         self.assertEqual(data.pop("scheduled_date").split("T")[0], "2020-08-03")
         self.assertDictEqual(data, expected)

--- a/shopfloor/tests/test_actions_data_detail.py
+++ b/shopfloor/tests/test_actions_data_detail.py
@@ -113,6 +113,7 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "name": picking.name,
             "note": "read me",
             "origin": "created by test",
+            "ship_carrier": None,
             "weight": 110.0,
             "partner": {"id": self.customer.id, "name": self.customer.name},
             "carrier": {"id": picking.carrier_id.id, "name": picking.carrier_id.name},

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -54,9 +54,10 @@ const Checkout = {
             </div>
             <div v-if="state_is('select_line')">
                 <item-detail-card
-                    v-if="state.data.picking.carrier"
+                    v-if="current_carrier()"
+                    :card_color="utils.colors.color_for('detail_carrier_card')"
                     :key="make_state_component_key(['picking-carrier', state.data.picking.id])"
-                    :record="state.data.picking.carrier"
+                    :record="current_carrier()"
                     :options="{main: true, key_title: 'name', title_icon: 'mdi-truck-outline'}"
                     />
                 <detail-picking-select
@@ -246,6 +247,11 @@ const Checkout = {
         },
     },
     methods: {
+        current_carrier: function() {
+            return (
+                this.state.data.picking.carrier || this.state.data.picking.ship_carrier
+            );
+        },
         screen_title: function() {
             if (_.isEmpty(this.current_doc()) || this.state_is("confirm_start"))
                 return this.menu_item().name;

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -79,6 +79,13 @@ const ClusterPicking = {
             </div>
 
             <div class="unload-all" v-if="state_is('unload_all')">
+                <item-detail-card
+                    v-if="current_carrier()"
+                    :card_color="utils.colors.color_for('success')"
+                    :key="make_state_component_key(['batch-picking', state.data.id])"
+                    :record="current_carrier()"
+                    :options="{main: true, key_title: 'name', title_icon: 'mdi-truck-outline'}"
+                    />
                 <v-card class="main">
                     <v-card-title>
                         <div class="main-info">
@@ -117,6 +124,13 @@ const ClusterPicking = {
         },
     },
     methods: {
+        current_carrier: function() {
+            const pick = this.current_picking();
+            if (!pick) {
+                return null;
+            }
+            return pick.carrier || pick.ship_carrier;
+        },
         screen_title: function() {
             if (_.isEmpty(this.current_batch()) || this.state_is("confirm_start"))
                 return this.menu_item().name;


### PR DESCRIPTION
In the backend add the carrier computed from the module
`stock_picking_delivery_link` into the picking data send.

In the frontend: checkout, set the color of the carrier card in green

* Add the carrier on the cluster picking last screen.
* On the checkout and the cluster picking improve the carrier display by using the one added in the backend if needed.
* Set the carrier card in green.