### PR TITLE
[13.0] shopfloor_mobile: misc fixes for qty display

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/detail/detail_transfer.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_transfer.js
@@ -46,6 +46,7 @@ Vue.component("detail-transfer", {
             };
         },
         line_list_fields() {
+            const self = this;
             return [
                 {
                     path: "product.display_name",
@@ -58,8 +59,22 @@ Vue.component("detail-transfer", {
                     action_val_path: "package_src.name",
                 },
                 {path: "lot.name", label: "Lot", action_val_path: "lot.name"},
-                {path: "product.qty_reserved", label: "Qty reserved"},
-                {path: "product.qty_available", label: "Qty in stock"},
+                {
+                    path: "product.qty_reserved",
+                    label: "Qty reserved",
+                    render_component: "packaging-qty-picker-display",
+                    render_options: function(record) {
+                        return self.utils.wms.move_line_qty_picker_options(record);
+                    },
+                },
+                {
+                    path: "product.qty_available",
+                    label: "Qty in stock",
+                    render_component: "packaging-qty-picker-display",
+                    render_options: function(record) {
+                        return self.utils.wms.move_line_qty_picker_options(record);
+                    },
+                },
             ];
         },
         grouped_lines() {

--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -155,6 +155,7 @@ export var PackagingQtyPickerMixin = {
                 mode: "",
                 available_packaging: [],
                 uom: {},
+                pkg_name_key: "code", // This comes from packaging type
             });
             return opts;
         },
@@ -283,10 +284,9 @@ export var PackagingQtyPickerDisplay = Vue.component("packaging-qty-picker-displ
 <div :class="[$options._componentTag, opts.mode ? 'mode-' + opts.mode: '', 'd-inline']">
     <span class="packaging" v-for="(pkg, index) in visible_packaging" :key="make_component_key([pkg.id])">
         <span class="pkg-qty" v-text="qty_by_pkg[pkg.id] || 0" />
-        <span class="pkg-name" v-text="pkg[opts.pkg_name_key || 'name']" /><span class="sep" v-if="index != Object.keys(visible_packaging).length - 1">, </span>
+        <span class="pkg-name" v-text="pkg[opts.pkg_name_key]" /><span class="sep" v-if="index != Object.keys(visible_packaging).length - 1">, </span>
     </span>
-    <!-- TOOO: use product uom -->
-    <span class="min-unit">({{ opts.init_value }} Units)</span>
+    <span class="min-unit">({{ opts.init_value }} {{ unit_uom.name }})</span>
 </div>
 `,
 });

--- a/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_select.js
+++ b/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_select.js
@@ -80,14 +80,14 @@ Vue.component("picking-select-package-content", {
                 <span class="label">Taken:</span>
                 <packaging-qty-picker-display
                     :key="make_component_key(['qty-picker-widget', 'taken', record.id])"
-                    :options="utils.wms.move_line_qty_picker_options(record, {init_value: record.qty_done, non_zero_only: true, pkg_name_key: 'code'})"
+                    :options="utils.wms.move_line_qty_picker_options(record, {init_value: record.qty_done})"
                     />
             </div>
             <div class="qty requested">
                 <span class="label">Requested:</span>
                 <packaging-qty-picker-display
                     :key="make_component_key(['qty-picker-widget', 'requested', record.id])"
-                    :options="utils.wms.move_line_qty_picker_options(record, {non_zero_only: true, pkg_name_key: 'code'})"
+                    :options="utils.wms.move_line_qty_picker_options(record)"
                     />
             </div>
             <div class="vendor-code">

--- a/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_summary.js
+++ b/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_summary.js
@@ -157,7 +157,7 @@ Vue.component("picking-summary-product-detail", {
                     <span class="label">Qty:</span>
                     <packaging-qty-picker-display
                         :key="make_component_key(['picking-summary', 'qty-picker-widget', 'done', record.id])"
-                        :options="utils.wms.move_line_qty_picker_options(record, {init_value: record.qty_done, non_zero_only: true, pkg_name_key: 'code'})"
+                        :options="utils.wms.move_line_qty_picker_options(record, {init_value: record.qty_done})"
                         />
                 </div>
             </v-list-item-subtitle>

--- a/shopfloor_mobile/static/wms/src/demo/demo.checkout.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.checkout.js
@@ -6,6 +6,19 @@
 
 import {demotools} from "/shopfloor_mobile_base/static/wms/src/demo/demo.core.js";
 
+const DEMO_CASE = {
+    by_menu_id: {},
+};
+
+const checkout_menu_case1 = demotools.addAppMenu(
+    {
+        name: "Checkout: case 1",
+        scenario: "checkout",
+        picking_types: [{id: 27, name: "Random type"}],
+    },
+    "co_1"
+);
+
 const select_pack_picking = demotools.makePicking(
     {},
     {lines_count: 5, line_random_pack: true, line_random_dest: true}
@@ -32,6 +45,18 @@ const summary_picking = demotools.makePicking(
     },
     {no_lines: true}
 );
+
+const data_for_select_package = {
+    next_state: "select_package",
+    data: {
+        select_package: {
+            picking: select_pack_picking,
+            selected_move_lines: select_pack_picking.move_lines,
+        },
+    },
+};
+
+let data_for_set_line_qty = _.cloneDeep(data_for_select_package);
 
 const DEMO_CHECKOUT = {
     scan_document: {
@@ -78,32 +103,22 @@ const DEMO_CHECKOUT = {
             },
         },
     },
-    select_line: {
-        next_state: "select_package",
-        data: {
-            select_package: {
-                picking: select_pack_picking,
-                selected_move_lines: select_pack_picking.move_lines,
-            },
-        },
+    select_line: data_for_select_package,
+    set_line_qty: function(data) {
+        let res = data_for_set_line_qty;
+        let line = res.data.select_package.selected_move_lines.filter(function(x) {
+            return x.id == data.move_line_id;
+        })[0];
+        line.qty_done = line.quantity;
+        return res;
     },
-    select_package: {
-        data: {
-            select_package: {
-                picking: select_pack_picking,
-                selected_move_lines: select_pack_picking.move_lines,
-            },
-        },
-    },
-    reset_line_qty: {
-        next_state: "select_package",
-        data: {
-            select_package: {
-                picking: select_pack_picking,
-                // simulate unselecting 1 line
-                selected_move_lines: select_pack_picking.move_lines,
-            },
-        },
+    reset_line_qty: function(data) {
+        let res = data_for_set_line_qty;
+        let line = res.data.select_package.selected_move_lines.filter(function(x) {
+            return x.id == data.move_line_id;
+        })[0];
+        line.qty_done = 0;
+        return res;
     },
     list_dest_package: {
         next_state: "select_dest_package",
@@ -234,5 +249,7 @@ const DEMO_CHECKOUT = {
         },
     },
 };
+
+DEMO_CASE.by_menu_id[checkout_menu_case1] = DEMO_CHECKOUT;
 
 demotools.add_case("checkout", DEMO_CHECKOUT);

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -157,7 +157,7 @@ const Checkout = {
                 <item-detail-card :card_color="utils.colors.color_for('screen_step_done')"
                     :key="make_state_component_key(['location_src'])"
                     :record="state.data.line"
-                    :options="{main: true, key_title: 'location_src.name', title_action_field: {action_val_path: 'location_src.barcode'}}"
+                :options="{main: true, key_title: 'location_src.name', title_action_field: {action_val_path: 'location_src.barcode'}, }"
                     />
                 <item-detail-card :card_color="utils.colors.color_for('screen_step_done')"
                     :key="make_state_component_key(['product'])"
@@ -289,6 +289,7 @@ const Checkout = {
         select_line_manual_select_opts: function() {
             return {
                 group_color: this.utils.colors.color_for("screen_step_todo"),
+                card_klass: "loud-labels",
             };
         },
         select_package_manual_select_opts: function() {

--- a/shopfloor_mobile/static/wms/src/wms_utils.js
+++ b/shopfloor_mobile/static/wms/src/wms_utils.js
@@ -244,6 +244,7 @@ export class WMSUtils {
             init_value: line.quantity,
             available_packaging: line.product.packaging,
             uom: line.product.uom,
+            non_zero_only: true,
         };
         return _.extend(opts, override || {});
     }

--- a/shopfloor_mobile_base/static/wms/src/demo/demo.core.js
+++ b/shopfloor_mobile_base/static/wms/src/demo/demo.core.js
@@ -34,18 +34,22 @@ export class DemoTools {
         this.packaging = [
             this.makePackaging({
                 name: "Little Box",
+                code: "LB",
                 qty: 50,
             }),
             this.makePackaging({
                 name: "Box",
+                code: "BX",
                 qty: 100,
             }),
             this.makePackaging({
                 name: "Big Box",
+                code: "BB",
                 qty: 500,
             }),
             this.makePackaging({
-                name: "Pallette",
+                name: "Pallet",
+                code: "PL",
                 qty: 5000,
             }),
         ];
@@ -179,8 +183,8 @@ export class DemoTools {
     makePackaging(defaults = {}, options = {}) {
         _.defaults(defaults, {
             name: "Packaging",
+            code: "PKG",
             qty: 1,
-            qty_unit: "Unit",
         });
         const rec = this.makeSimpleRecord(defaults, options);
         this.index_record("name", rec, "packaging");
@@ -377,14 +381,17 @@ export class DemoTools {
         _.defaults(options, {
             qty_done_random: true,
         });
-        const qty = this.getRandomInt(100);
+        const product = this.makeProduct();
+        // Always get a multiple of real packaging
+        const random_pkg = this.randomItemFromArray(product.packaging);
+        const qty = random_pkg.qty * this.getRandomInt(10);
         let qty_done = options.qty_done_full ? qty : defaults.qty_done;
         qty_done = options.qty_done_random ? this.getRandomInt(qty) : qty_done;
         return _.defaults({}, defaults, {
             id: this.getRandomInt(),
             quantity: qty,
             qty_done: qty_done,
-            product: this.makeProduct(),
+            product: product,
             lot: this.makeLot(),
             package_src: this.makePack({name_prefix: "PACK-SRC"}),
             package_dest: this.makePack({name_prefix: "PACK-DST"}),


### PR DESCRIPTION
Aim: unify qty picker display across screens. Mainly: always display total units, always use pkg type code instead of name.

ref: 2535