### PR TITLE
[13.0] Change sorting of locations in the pack putaway computation

### DIFF
--- a/stock_storage_type/README.rst
+++ b/stock_storage_type/README.rst
@@ -62,16 +62,16 @@ storage type.
 
 Storage locations linked to the package storage are processed sequentially, if
 said storage location is a child of the move line's destination location (i.e
-either the put-away location or the move's destination location), then it will
-be searched in order to find a children location that is allowed according to
-the restrictions defined on the stock location storage types.
+either the put-away location or the move's destination location).
+For each location, their packs storage strategy is applied as well as the
+restrictions defined on the stock location storage types.
 If no suitable location is found, the next location in the sequence will be
 searched and so on.
 
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
+For the packs putaway strategy "none", the location is considered as is.  For
+the "ordered children" strategy, children locations are sorted by first by max
+height which is a physical constraint to respect, then pack putaway sequence
+which allow to favor for example some level or corridor, and finally by name.
 
 **Table of contents**
 
@@ -119,12 +119,14 @@ Authors
 ~~~~~~~
 
 * Camptocamp
+* BCIM
 
 Contributors
 ~~~~~~~~~~~~
 
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -1,13 +1,13 @@
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Stock Storage Type",
     "summary": "Manage packages and locations storage types",
-    "version": "13.0.1.12.0",
-    "development_status": "Alpha",
+    "version": "13.0.1.13.0",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/wms",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/stock_storage_type/demo/stock_location.xml
+++ b/stock_storage_type/demo/stock_location.xml
@@ -25,6 +25,10 @@
         <field name="name">Bin 3</field>
         <field name="location_id" ref="stock_location_cardboxes" />
     </record>
+    <record id="stock_location_cardboxes_bin_4" model="stock.location">
+        <field name="name">Bin 4</field>
+        <field name="location_id" ref="stock_location_cardboxes" />
+    </record>
     <record id="stock_location_pallets" model="stock.location">
         <field name="name">Pallets storage area</field>
         <field
@@ -48,6 +52,10 @@
     </record>
     <record id="stock_location_pallets_bin_3" model="stock.location">
         <field name="name">Pallets Bin 3</field>
+        <field name="location_id" ref="stock_location_pallets" />
+    </record>
+    <record id="stock_location_pallets_bin_4" model="stock.location">
+        <field name="name">Pallets Bin 4</field>
         <field name="location_id" ref="stock_location_pallets" />
     </record>
     <record id="stock_location_pallets_reserve" model="stock.location">
@@ -75,6 +83,10 @@
         <field name="name">Pallets Reserve Bin 3</field>
         <field name="location_id" ref="stock_location_pallets_reserve" />
     </record>
+    <record id="stock_location_pallets_reserve_bin_4" model="stock.location">
+        <field name="name">Pallets Reserve Bin 4</field>
+        <field name="location_id" ref="stock_location_pallets_reserve" />
+    </record>
     <record id="stock_location_cardboxes_reserve" model="stock.location">
         <field name="name">Cardboxes reserve storage area</field>
         <field
@@ -98,6 +110,10 @@
     </record>
     <record id="stock_location_cardboxes_reserve_bin_3" model="stock.location">
         <field name="name">Cardboxes Reserve Bin 3</field>
+        <field name="location_id" ref="stock_location_cardboxes_reserve" />
+    </record>
+    <record id="stock_location_cardboxes_reserve_bin_4" model="stock.location">
+        <field name="name">Cardboxes Reserve Bin 4</field>
         <field name="location_id" ref="stock_location_cardboxes_reserve" />
     </record>
 </odoo>

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -1,6 +1,9 @@
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 import logging
+
+from psycopg2 import sql
 
 from odoo import api, fields, models
 from odoo.tools import float_compare
@@ -49,6 +52,7 @@ class StockLocation(models.Model):
         "locations according to the restrictions defined on their "
         "respective location storage types.",
     )
+    pack_putaway_sequence = fields.Integer()
     storage_location_sequence_ids = fields.One2many(
         "stock.storage.location.sequence",
         "location_id",
@@ -361,9 +365,53 @@ class StockLocation(models.Model):
         locations = self.browse()
         if self.pack_putaway_strategy == "none":
             locations = self
-        elif self.pack_putaway_strategy == "ordered_locations":
-            locations = self._get_ordered_leaf_locations()
+        else:
+            locations = self._get_sorted_leaf_locations(products)
         return locations
+
+    def _get_sorted_leaf_locations_orderby(self, products):
+        """Return SQL orderby clause and params for sorting locations
+
+        First, locations are ordered by max height, knowing that a max height of 0
+        means "no limit" and as such it should be among the last locations.
+        Then, they are ordered by a sequence and name.
+        """
+        self.env["stock.location"].flush(
+            ["max_height", "pack_putaway_sequence", "name"]
+        )
+        orderby = []
+        if self.pack_putaway_strategy == "ordered_locations":
+            orderby = [
+                "CASE WHEN max_height > 0 THEN max_height ELSE 'Infinity' END",
+                "pack_putaway_sequence",
+                "name",
+            ]
+        return ", ".join(orderby), []
+
+    def _get_sorted_leaf_locations(self, products):
+        """Return sorted leaf sub-locations
+
+        The locations are candidate locations that will be evaluated one per
+        one in order to find the first available location. They must be leaf
+        locations where we can actually put goods.
+        """
+        if not self.leaf_location_ids:
+            return self.leaf_location_ids
+        query = self._where_calc([("id", "in", self.leaf_location_ids.ids)])
+        from_clause, where_clause, where_params = query.get_sql()
+        orderby_clause, orderby_params = self._get_sorted_leaf_locations_orderby(
+            products
+        )
+        query = sql.SQL(
+            "SELECT id FROM {table} WHERE {where} ORDER BY {orderby}"
+        ).format(
+            table=sql.Identifier(self._table),
+            where=sql.SQL(where_clause),
+            orderby=sql.SQL(orderby_clause),
+        )
+        self._cr.execute(query, where_params + orderby_params)
+        location_ids = [x[0] for x in self.env.cr.fetchall()]
+        return self.env["stock.location"].browse(location_ids)
 
     def select_first_allowed_location(self, package_storage_type, quants, products):
         allowed = self.select_allowed_locations(
@@ -527,20 +575,3 @@ class StockLocation(models.Model):
         ]
         valid_locations = self.browse(ordered_valid_location_ids)
         return valid_locations
-
-    def _get_ordered_leaf_locations(self):
-        """Return ordered leaf sub-locations
-
-        The locations are candidate locations that will be evaluated one per
-        one in order to find the first available location. They must be leaf
-        locations where we can actually put goods.
-
-        Locations are ordered by max height, knowing that a max height of 0
-        means "no limit" and as such it should be among the last locations.
-        """
-        if not self.leaf_location_ids:
-            return self.leaf_location_ids
-        max_height = max(self.leaf_location_ids.mapped("max_height"))
-        return self.leaf_location_ids.sorted(
-            lambda l: l.max_height if l.max_height else (max_height + 1)
-        )

--- a/stock_storage_type/readme/CONTRIBUTORS.rst
+++ b/stock_storage_type/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>

--- a/stock_storage_type/readme/DESCRIPTION.rst
+++ b/stock_storage_type/readme/DESCRIPTION.rst
@@ -35,8 +35,13 @@ storage type.
 
 Storage locations linked to the package storage are processed sequentially, if
 said storage location is a child of the move line's destination location (i.e
-either the put-away location or the move's destination location), then it will
-be searched in order to find a children location that is allowed according to
-the restrictions defined on the stock location storage types.
+either the put-away location or the move's destination location).
+For each location, their packs storage strategy is applied as well as the
+restrictions defined on the stock location storage types.
 If no suitable location is found, the next location in the sequence will be
 searched and so on.
+
+For the packs putaway strategy "none", the location is considered as is.  For
+the "ordered children" strategy, children locations are sorted by first by max
+height which is a physical constraint to respect, then pack putaway sequence
+which allow to favor for example some level or corridor, and finally by name.

--- a/stock_storage_type/tests/common.py
+++ b/stock_storage_type/tests/common.py
@@ -36,8 +36,8 @@ class TestStorageTypeCommon(SavepointCase):
         cls.cardboxes_bin_3_location = ref(
             "stock_storage_type.stock_location_cardboxes_bin_3"
         )
-        cls.cardboxes_bin_4_location = cls.cardboxes_bin_1_location.copy(
-            {"name": "Bin 4"}
+        cls.cardboxes_bin_4_location = ref(
+            "stock_storage_type.stock_location_cardboxes_bin_4"
         )
         cls.env["stock.location"]._parent_store_compute()
         cls.pallets_bin_1_location = ref(
@@ -48,6 +48,9 @@ class TestStorageTypeCommon(SavepointCase):
         )
         cls.pallets_bin_3_location = ref(
             "stock_storage_type.stock_location_pallets_bin_3"
+        )
+        cls.pallets_bin_4_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_4"
         )
 
         cls.receipts_picking_type = ref("stock.picking_type_in")

--- a/stock_storage_type/tests/test_stock_location.py
+++ b/stock_storage_type/tests/test_stock_location.py
@@ -8,7 +8,6 @@ class TestStockLocation(TestStorageTypeCommon):
     def setUpClass(cls):
         super().setUpClass()
         ref = cls.env.ref
-        cls.areas.write({"pack_putaway_strategy": "ordered_locations"})
         cls.pallets_reserve_bin_1_location = ref(
             "stock_storage_type.stock_location_pallets_reserve_bin_1"
         )
@@ -18,11 +17,24 @@ class TestStockLocation(TestStorageTypeCommon):
         cls.pallets_reserve_bin_3_location = ref(
             "stock_storage_type.stock_location_pallets_reserve_bin_3"
         )
+        cls.pallets_reserve_bin_4_location = ref(
+            "stock_storage_type.stock_location_pallets_reserve_bin_4"
+        )
 
     def test_get_ordered_leaf_locations(self):
+        sublocation = self.stock_location.copy(
+            {
+                "name": "Sub-location",
+                "pack_putaway_strategy": "ordered_locations",
+                "location_id": self.stock_location.id,
+            }
+        )
+        self.areas.write({"location_id": sublocation.id})
+
         # Test with the same max_height on all related storage types (0 here)
+        ordered_locations = sublocation.get_storage_locations(self.product)
         self.assertEqual(
-            self.areas._get_ordered_leaf_locations().ids,
+            ordered_locations.ids,
             (
                 self.cardboxes_bin_1_location
                 | self.cardboxes_bin_2_location
@@ -31,16 +43,19 @@ class TestStockLocation(TestStorageTypeCommon):
                 | self.pallets_bin_1_location
                 | self.pallets_bin_2_location
                 | self.pallets_bin_3_location
+                | self.pallets_bin_4_location
                 | self.pallets_reserve_bin_1_location
                 | self.pallets_reserve_bin_2_location
                 | self.pallets_reserve_bin_3_location
+                | self.pallets_reserve_bin_4_location
             ).ids,
         )
         # Set the max_height on pallets storage type higher than the others
         self.pallets_location_storage_type.max_height = 2
         self.cardboxes_location_storage_type.max_height = 1
+        ordered_locations = sublocation.get_storage_locations(self.product)
         self.assertEqual(
-            self.areas._get_ordered_leaf_locations().ids,
+            ordered_locations.ids,
             (
                 self.cardboxes_bin_1_location
                 | self.cardboxes_bin_2_location
@@ -49,23 +64,28 @@ class TestStockLocation(TestStorageTypeCommon):
                 | self.pallets_bin_1_location
                 | self.pallets_bin_2_location
                 | self.pallets_bin_3_location
+                | self.pallets_bin_4_location
                 | self.pallets_reserve_bin_1_location
                 | self.pallets_reserve_bin_2_location
                 | self.pallets_reserve_bin_3_location
+                | self.pallets_reserve_bin_4_location
             ).ids,
         )
         # Set the max_height on cardboxes storage type higher than the others
         self.pallets_location_storage_type.max_height = 1
         self.cardboxes_location_storage_type.max_height = 2
+        ordered_locations = sublocation.get_storage_locations(self.product)
         self.assertEqual(
-            self.areas._get_ordered_leaf_locations().ids,
+            ordered_locations.ids,
             (
                 self.pallets_bin_1_location
                 | self.pallets_bin_2_location
                 | self.pallets_bin_3_location
+                | self.pallets_bin_4_location
                 | self.pallets_reserve_bin_1_location
                 | self.pallets_reserve_bin_2_location
                 | self.pallets_reserve_bin_3_location
+                | self.pallets_reserve_bin_4_location
                 | self.cardboxes_bin_1_location
                 | self.cardboxes_bin_2_location
                 | self.cardboxes_bin_3_location

--- a/stock_storage_type/tests/test_storage_type.py
+++ b/stock_storage_type/tests/test_storage_type.py
@@ -30,6 +30,9 @@ class TestStorageType(SavepointCase):
         cls.cardboxes_bin_3 = cls.env.ref(
             "stock_storage_type.stock_location_cardboxes_bin_3"
         )
+        cls.cardboxes_bin_4 = cls.env.ref(
+            "stock_storage_type.stock_location_cardboxes_bin_4"
+        )
 
     def test_location_allowed_storage_types(self):
         # As cardboxes location storage type is defined on parent stock

--- a/stock_storage_type/views/stock_location.xml
+++ b/stock_storage_type/views/stock_location.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="removal_strategy_id" position="after">
                 <field name="pack_putaway_strategy" />
+                <field name="pack_putaway_sequence" />
                 <field
                     name="allowed_location_storage_type_ids"
                     widget="many2many_tags"

--- a/stock_storage_type_buffer/tests/test_storage_type_buffer.py
+++ b/stock_storage_type_buffer/tests/test_storage_type_buffer.py
@@ -168,6 +168,9 @@ class TestStorageTypeBuffer(TestStorageTypeCommon):
             <li>
                 <span>WH/Stock/Pallets storage area/Pallets Bin 3</span>
             </li>
+            <li>
+                <span>WH/Stock/Pallets storage area/Pallets Bin 4</span>
+            </li>
         </ul>
         """
         self.assertEqual(
@@ -201,6 +204,9 @@ class TestStorageTypeBuffer(TestStorageTypeCommon):
             </li>
             <li>
                 <span>WH/Stock/Pallets storage area/Pallets Bin 3</span>
+            </li>
+            <li>
+                <span>WH/Stock/Pallets storage area/Pallets Bin 4</span>
             </li>
         </ul>
         <p>

--- a/stock_storage_type_putaway_abc/README.rst
+++ b/stock_storage_type_putaway_abc/README.rst
@@ -28,10 +28,20 @@ Stock Storage Type ABC Strategy
 This module implements chaotic storage 'ABC' according to Package Storage Type
 and Location Storage Type.
 
-.. IMPORTANT::
-   This is an alpha version, the data model and design can change at any time without warning.
-   Only for development or testing purpose, do not use in production.
-   `More details on development status <https://odoo-community.org/page/development-status>`_
+The locations and products get an 'a', 'b' or 'c' storage (by default 'b').
+
+For the computation of the putaway, the locations are sorted first by max
+height which is a physical constraint to respect, then by 'ABC' as following:
+
+* if the product is 'a', then locations are sorted by 'a', 'b', 'c'
+* if the product is 'b', then locations are sorted by 'b', 'c', 'a'
+* if the product is 'c', then locations are sorted by 'c', 'b', 'a'
+
+Then by pack putaway sequence (this allow to favor for example some level or
+corridor), and finally randomly.
+
+The storage type putaway computation will then apply on the list of locations
+the additional restrictions and take the first valid location.
 
 **Table of contents**
 
@@ -55,11 +65,13 @@ Authors
 ~~~~~~~
 
 * Camptocamp
+* BCIM
 
 Contributors
 ~~~~~~~~~~~~
 
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_storage_type_putaway_abc/__manifest__.py
+++ b/stock_storage_type_putaway_abc/__manifest__.py
@@ -1,13 +1,13 @@
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 {
     "name": "Stock Storage Type ABC Strategy",
     "summary": "Advanced storage strategy ABC for WMS",
-    "version": "13.0.1.1.0",
-    "development_status": "Alpha",
+    "version": "13.0.2.0.0",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/wms",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/stock_storage_type_putaway_abc/models/stock_location.py
+++ b/stock_storage_type_putaway_abc/models/stock_location.py
@@ -1,25 +1,10 @@
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from random import shuffle
-
 from odoo import api, fields, models
 from odoo.fields import first
 
 ABC_SELECTION = [("a", "A"), ("b", "B"), ("c", "C")]
-
-
-def gather_location_ids(abc_sorted, max_heights_sorted, locations_grouped):
-    """Return a list of location IDs sorted on `abc_sorted` then
-    on `max_heights_sorted`.
-    """
-    location_ids = []
-    for abc_key in abc_sorted:
-        group_ids_per_height = locations_grouped.get(abc_key)
-        if not group_ids_per_height:
-            continue
-        for max_height in max_heights_sorted:
-            location_ids.extend(group_ids_per_height.get(max_height, []))
-    return location_ids
 
 
 class StockLocation(models.Model):
@@ -47,51 +32,23 @@ class StockLocation(models.Model):
                     current_location = current_location.location_id
             location.display_abc_storage = display_abc_storage
 
-    def get_storage_locations(self, products=None):
-        if products is None:
-            products = self.env["product.product"]
-        if self.pack_putaway_strategy == "abc":
-            return self._get_abc_locations(products)
-        return super().get_storage_locations(products)
-
-    def _get_abc_locations(self, products):
-        return self.leaf_location_ids._sort_abc_locations(first(products).abc_storage)
-
-    def _sort_abc_locations(self, product_abc):
-        product_abc = product_abc or "a"
-        # group locations by abc_storage and max_height
-        data = self.read_group(
-            [("id", "in", self.ids)], ["max_height"], ["max_height"],
-        )
-        locations_grouped = {}
-        max_heights = set()
-        for line in data:
-            domain = line["__domain"]
-            locations = self.search(domain)
-            for loc in locations:
-                locations_grouped.setdefault(loc.abc_storage, {}).setdefault(
-                    line["max_height"], []
-                )
-                locations_grouped[loc.abc_storage][line["max_height"]].append(loc.id)
-            # keep a list of available max heights
-            max_heights.add(line["max_height"])
-        # sort max heights and take care to put any 0 value at the end
-        max_heights = list(max_heights)
-        max_heights.sort()
-        if 0 in max_heights:
-            max_heights.pop(max_heights.index(0))
-            max_heights.append(0)
-        # shuffle each abc_storage/max_height chunk
-        for line in locations_grouped.values():
-            for max_height in line:
-                shuffle(line[max_height])
-        # prepare the result
+    def _get_sorted_leaf_locations_orderby(self, products):
+        if not self.pack_putaway_strategy == "abc":
+            return super()._get_sorted_leaf_locations_orderby(products)
+        product_abc = first(products).abc_storage or "a"
         if product_abc == "a":
-            location_ids = gather_location_ids("abc", max_heights, locations_grouped)
+            abc_seq = "a", "b", "c"
         elif product_abc == "b":
-            location_ids = gather_location_ids("bca", max_heights, locations_grouped)
+            abc_seq = "b", "c", "a"
         elif product_abc == "c":
-            location_ids = gather_location_ids("cba", max_heights, locations_grouped)
-        else:
-            raise ValueError("product_abc = %s" % product_abc)
-        return self.env["stock.location"].browse(location_ids)
+            abc_seq = "c", "b", "a"
+        self.env["stock.location"].flush(
+            ["abc_storage", "max_height", "pack_putaway_sequence", "name"]
+        )
+        orderby = [
+            "CASE WHEN max_height > 0 THEN max_height ELSE 'Infinity' END",
+            "array_position(%s, abc_storage::text)",
+            "pack_putaway_sequence",
+            "random()",
+        ]
+        return ", ".join(orderby), [list(abc_seq)]

--- a/stock_storage_type_putaway_abc/readme/CONTRIBUTORS.rst
+++ b/stock_storage_type_putaway_abc/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Akim Juillerat <akim.juillerat@camptocamp.com>
+* Jacques-Etienne Baudoux <je@bcim.be>

--- a/stock_storage_type_putaway_abc/readme/DESCRIPTION.rst
+++ b/stock_storage_type_putaway_abc/readme/DESCRIPTION.rst
@@ -1,2 +1,17 @@
 This module implements chaotic storage 'ABC' according to Package Storage Type
 and Location Storage Type.
+
+The locations and products get an 'a', 'b' or 'c' storage (by default 'b').
+
+For the computation of the putaway, the locations are sorted first by max
+height which is a physical constraint to respect, then by 'ABC' as following:
+
+* if the product is 'a', then locations are sorted by 'a', 'b', 'c'
+* if the product is 'b', then locations are sorted by 'b', 'c', 'a'
+* if the product is 'c', then locations are sorted by 'c', 'b', 'a'
+
+Then by pack putaway sequence (this allow to favor for example some level or
+corridor), and finally randomly.
+
+The storage type putaway computation will then apply on the list of locations
+the additional restrictions and take the first valid location.

--- a/stock_storage_type_putaway_abc/tests/test_abc_location.py
+++ b/stock_storage_type_putaway_abc/tests/test_abc_location.py
@@ -1,4 +1,5 @@
-# Copyright 2019 Camptocamp SA
+# Copyright 2019-2021 Camptocamp SA
+# Copyright 2019-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo.tests import SavepointCase
 
@@ -18,71 +19,95 @@ class TestAbcLocation(SavepointCase):
         cls.stock_location = ref("stock.stock_location_stock")
         cls.cardboxes_location = ref("stock_storage_type.stock_location_cardboxes")
         cls.pallets_location = ref("stock_storage_type.stock_location_pallets")
-        cls.cardboxes_bin_1_location = ref(
-            "stock_storage_type.stock_location_cardboxes_bin_1"
-        )
-        cls.cardboxes_bin_2_location = ref(
+        cls.cardboxes_bin_a_location = ref(
             "stock_storage_type.stock_location_cardboxes_bin_2"
         )
-        cls.cardboxes_bin_3_location = ref(
+        cls.cardboxes_bin_b1_location = ref(
+            "stock_storage_type.stock_location_cardboxes_bin_4"
+        )
+        cls.cardboxes_bin_b2_location = ref(
+            "stock_storage_type.stock_location_cardboxes_bin_1"
+        )
+        cls.cardboxes_bin_c_location = ref(
             "stock_storage_type.stock_location_cardboxes_bin_3"
         )
-        cls.pallets_bin_1_location = ref(
-            "stock_storage_type.stock_location_pallets_bin_1"
+        cls.pallets_bin_a_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_3"
         )
-        cls.pallets_bin_2_location = ref(
+        cls.pallets_bin_b1_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_4"
+        )
+        cls.pallets_bin_b2_location = ref(
             "stock_storage_type.stock_location_pallets_bin_2"
         )
-        cls.pallets_bin_3_location = ref(
-            "stock_storage_type.stock_location_pallets_bin_3"
+        cls.pallets_bin_c_location = ref(
+            "stock_storage_type.stock_location_pallets_bin_1"
         )
         cls.product = ref("product.product_product_9")
 
     def test_display_abc_storage_one_level(self):
         self.cardboxes_location.write({"pack_putaway_strategy": "abc"})
-        self.assertTrue(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_1_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_2_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_3_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_a_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_c_location.display_abc_storage)
         self.cardboxes_location.write({"pack_putaway_strategy": "ordered_locations"})
-        self.assertFalse(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_1_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_2_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_3_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_a_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_c_location.display_abc_storage)
 
     def test_display_abc_storage_two_levels(self):
         self.stock_location.write({"pack_putaway_strategy": "abc"})
-        self.assertTrue(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertTrue(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertTrue(self.pallets_bin_1_location.display_abc_storage)
-        self.assertTrue(self.pallets_bin_2_location.display_abc_storage)
-        self.assertTrue(self.pallets_bin_3_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertTrue(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_a_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertTrue(self.pallets_bin_c_location.display_abc_storage)
         self.stock_location.write({"pack_putaway_strategy": "none"})
-        self.assertFalse(self.cardboxes_bin_1_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_2_location.display_abc_storage)
-        self.assertFalse(self.cardboxes_bin_3_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_1_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_2_location.display_abc_storage)
-        self.assertFalse(self.pallets_bin_3_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_a_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.cardboxes_bin_c_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_a_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b1_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_b2_location.display_abc_storage)
+        self.assertFalse(self.pallets_bin_c_location.display_abc_storage)
 
     def test_abc_ordered(self):
         self.cardboxes_location.write({"pack_putaway_strategy": "abc"})
-        self.cardboxes_bin_1_location.write({"abc_storage": "b"})
-        self.cardboxes_bin_2_location.write({"abc_storage": "a"})
-        self.cardboxes_bin_3_location.write({"abc_storage": "c"})
+        self.cardboxes_bin_a_location.write(
+            {"abc_storage": "a", "pack_putaway_sequence": 3}
+        )
+        self.cardboxes_bin_b1_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 1}
+        )
+        self.cardboxes_bin_b2_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 2}
+        )
+        self.cardboxes_bin_c_location.write(
+            {"abc_storage": "c", "pack_putaway_sequence": 1}
+        )
         self.product.write({"abc_storage": "a"})
         ordered_locations = self.cardboxes_location.get_storage_locations(self.product)
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_2_location
-                | self.cardboxes_bin_1_location
-                | self.cardboxes_bin_3_location
+                self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
             ).ids,
         )
         self.product.write({"abc_storage": "b"})
@@ -90,9 +115,10 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.cardboxes_bin_2_location
+                self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
             ).ids,
         )
         self.product.write({"abc_storage": "c"})
@@ -100,9 +126,10 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_3_location
-                | self.cardboxes_bin_1_location
-                | self.cardboxes_bin_2_location
+                self.cardboxes_bin_c_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_a_location
             ).ids,
         )
 
@@ -116,12 +143,22 @@ class TestAbcLocation(SavepointCase):
         # configure putaway strategy for all locations
         sublocation.write({"pack_putaway_strategy": "abc"})
         # configure abc storage on locations
-        self.cardboxes_bin_1_location.write({"abc_storage": "b"})
-        self.cardboxes_bin_2_location.write({"abc_storage": "a"})
-        self.cardboxes_bin_3_location.write({"abc_storage": "c"})
-        self.pallets_bin_1_location.write({"abc_storage": "b"})
-        self.pallets_bin_2_location.write({"abc_storage": "a"})
-        self.pallets_bin_3_location.write({"abc_storage": "c"})
+        self.cardboxes_bin_a_location.write({"abc_storage": "a"})
+        self.cardboxes_bin_b1_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 1}
+        )
+        self.cardboxes_bin_b2_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 2}
+        )
+        self.cardboxes_bin_c_location.write({"abc_storage": "c"})
+        self.pallets_bin_a_location.write({"abc_storage": "a"})
+        self.pallets_bin_b1_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 1}
+        )
+        self.pallets_bin_b2_location.write(
+            {"abc_storage": "b", "pack_putaway_sequence": 2}
+        )
+        self.pallets_bin_c_location.write({"abc_storage": "c"})
         # Test with a product abc_storage=A
         #   - with max height on pallets storage type higher than the cardboxes one
         self.product.write({"abc_storage": "a"})
@@ -131,12 +168,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
+                self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.pallets_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
             ).ids,
         )
         #   - with max height on cardboxes storage type higher than the pallets one
@@ -146,12 +185,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.pallets_bin_2_location
-                | self.cardboxes_bin_2_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_3_location
+                self.pallets_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
             ).ids,
         )
         #   - with max height "no-limit" on pallets storage type
@@ -161,12 +202,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
+                self.cardboxes_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.pallets_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
             ).ids,
         )
         # Test with a product abc_storage=B
@@ -178,12 +221,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
+                self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.pallets_bin_a_location
             ).ids,
         )
         #   - with max height on cardboxes storage type higher than the pallets one
@@ -193,12 +238,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.pallets_bin_1_location
-                | self.cardboxes_bin_1_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_2_location
-                | self.cardboxes_bin_2_location
+                self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.pallets_bin_a_location
+                | self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
             ).ids,
         )
         #   - with max height "no-limit" on pallets storage type
@@ -208,12 +255,14 @@ class TestAbcLocation(SavepointCase):
         self.assertEqual(
             ordered_locations.ids,
             (
-                self.cardboxes_bin_1_location
-                | self.pallets_bin_1_location
-                | self.cardboxes_bin_3_location
-                | self.pallets_bin_3_location
-                | self.cardboxes_bin_2_location
-                | self.pallets_bin_2_location
+                self.cardboxes_bin_b1_location
+                | self.cardboxes_bin_b2_location
+                | self.cardboxes_bin_c_location
+                | self.cardboxes_bin_a_location
+                | self.pallets_bin_b1_location
+                | self.pallets_bin_b2_location
+                | self.pallets_bin_c_location
+                | self.pallets_bin_a_location
             ).ids,
         )
 
@@ -223,4 +272,4 @@ class TestAbcLocation(SavepointCase):
         self.env["stock.location"].search(
             [("abc_storage", "in", ("a", "b"))]
         ).abc_storage = "b"
-        self.assertTrue(self.stock_location.get_storage_locations())
+        self.assertTrue(self.stock_location.get_storage_locations(self.product))


### PR DESCRIPTION
Invert the sorting for abc packs storage strategy to first apply the max_height which is a physical constraint, then apply the abc preference.

Add a pack putaway sequence to be able to favor some locations (e.g. level). For ordered children strategy, finalize by sorting by location name. For abc, random selection is applied at last as it was already.

Replaced multi-steps python sorting by an unique SQL quicksort query to quickly compute the result on large stock_location table. This is especially important for operations containing many moves requiring a putaway computation.

Improved READMEs

Removed alpha status

cc @lmignon 