### PR TITLE
[FIX] shopfloor: single pack transfer, handle backorders

### DIFF
--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -43,3 +43,20 @@ class StockAction(Component):
             moves.move_orig_ids.filtered(lambda m: m.state not in ("cancel", "done"))
         )
         return moves == assigned_moves and not has_ancestors
+
+    def put_package_level_in_move(self, package_level):
+        """Ensure to put the package level in its own move.
+
+        In standard the moves linked to a package level could also be linked to
+        other unrelated move lines. This method ensures that the package level
+        will be attached to a move with only the relevant lines.
+        This is useful to process a single package, having its own move makes
+        this process easy.
+        """
+        package_move_lines = package_level.move_line_ids
+        package_moves = package_move_lines.move_id
+        for package_move in package_moves:
+            # Check if there is no other lines linked to the move others than
+            # the lines related to the package itself. In such case we have to
+            # split the move to process only the lines related to the package.
+            package_move.split_other_move_lines(package_move_lines)

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -660,13 +660,9 @@ class LocationContentTransfer(Component):
             )
         package_move_lines = package_level.move_line_ids
         self._lock_lines(package_move_lines)
-        for package_move in package_moves:
-            # Check if there is no other lines linked to the move others than
-            # the lines related to the package itself. In such case we have to
-            # split the move to process only the lines related to the package.
-            package_move.split_other_move_lines(package_move_lines)
-        self._write_destination_on_lines(package_level.move_line_ids, scanned_location)
         stock = self._actions_for("stock")
+        stock.put_package_level_in_move(package_level)
+        self._write_destination_on_lines(package_level.move_line_ids, scanned_location)
         stock.validate_moves(package_moves)
         move_lines = self._find_transfer_move_lines(location)
         message = self.msg_store.location_content_transfer_item_complete(

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -256,7 +256,14 @@ class SinglePackTransfer(Component):
         # on the move lines
         package_level.location_dest_id = scanned_location
         stock = self._actions_for("stock")
-        stock.validate_moves(package_level.move_line_ids.move_id)
+        package_moves = package_level.move_line_ids.move_id
+        package_move_lines = package_level.move_line_ids
+        for package_move in package_moves:
+            # Check if there is no other lines linked to the move others than
+            # the lines related to the package itself. In such case we have to
+            # split the move to process only the lines related to the package.
+            package_move.split_other_move_lines(package_move_lines)
+        stock.validate_moves(package_moves)
 
     def cancel(self, package_level_id):
         package_level = self.env["stock.package_level"].browse(package_level_id)

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -256,14 +256,8 @@ class SinglePackTransfer(Component):
         # on the move lines
         package_level.location_dest_id = scanned_location
         stock = self._actions_for("stock")
-        package_moves = package_level.move_line_ids.move_id
-        package_move_lines = package_level.move_line_ids
-        for package_move in package_moves:
-            # Check if there is no other lines linked to the move others than
-            # the lines related to the package itself. In such case we have to
-            # split the move to process only the lines related to the package.
-            package_move.split_other_move_lines(package_move_lines)
-        stock.validate_moves(package_moves)
+        stock.put_package_level_in_move(package_level)
+        stock.validate_moves(package_level.move_line_ids.move_id)
 
     def cancel(self, package_level_id):
         package_level = self.env["stock.package_level"].browse(package_level_id)


### PR DESCRIPTION
When processing a package with the single pack transfer scenario which
belongs to a transfer having several other packages, the remaining ones
are not put in a backorder and as such can not be processed anymore.

This commit ensure to put the processed package/package level in its own
move which will be validated in its own transfer, keeping the remaining
packages to process in the current transfer.

Ref. 2400