### PR TITLE
13.0 Fix failing branch in stock-logistics-warehouse for stock_vertical_lift_storage_type

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -385,6 +385,7 @@ class StockLocation(models.Model):
                 "CASE WHEN max_height > 0 THEN max_height ELSE 'Infinity' END",
                 "pack_putaway_sequence",
                 "name",
+                "id",
             ]
         return ", ".join(orderby), []
 


### PR DESCRIPTION
Ensuring order when tray cells have all the same name