### PR TITLE
13.0: s_s_available_to_promise_release: Sale report product line availability

### DIFF
--- a/sale_stock_available_to_promise_release/README.rst
+++ b/sale_stock_available_to_promise_release/README.rst
@@ -60,6 +60,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_stock_available_to_promise_release/__manifest__.py
+++ b/sale_stock_available_to_promise_release/__manifest__.py
@@ -10,6 +10,7 @@
     "category": "Stock Management",
     "depends": ["sale_stock", "stock_available_to_promise_release", "delivery"],
     "data": [
+        "reports/sale_order.xml",
         "views/stock_move_views.xml",
         "views/stock_picking_views.xml",
         "views/product_product_views.xml",

--- a/sale_stock_available_to_promise_release/i18n/ca.po
+++ b/sale_stock_available_to_promise_release/i18n/ca.po
@@ -6,6 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-02 13:13+0000\n"
 "PO-Revision-Date: 2021-06-04 10:48+0000\n"
 "Last-Translator: jabelchi <jabelchi@gmail.com>\n"
 "Language-Team: none\n"
@@ -15,6 +16,21 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.3.2\n"
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__availability_status
+msgid "Availability Status"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "Available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__available_qty
+msgid "Available Qty"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_move__carrier_id
@@ -36,6 +52,16 @@ msgid "Delivery Method"
 msgstr "Mètode de lliurament"
 
 #. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__expected_availability_date
+msgid "Expected Availability Date"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__full
+msgid "Fully Available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Further Shipment"
 msgstr "Enviament addicional"
@@ -52,9 +78,40 @@ msgid "Moves Need Release"
 msgstr "Moviments que cal alliberar"
 
 #. module: sale_stock_available_to_promise_release
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "No"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__no
+msgid "Not available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__mto
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "On order"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__partial
+msgid "Partially Available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_procurement_group
 msgid "Procurement Group"
 msgstr "Agrupament de compres"
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model,name:sale_stock_available_to_promise_release.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__restock
+msgid "Restock ordered"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_sale_order
@@ -85,3 +142,8 @@ msgstr "Transferència"
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Weight"
 msgstr "Pes"
+
+#. module: sale_stock_available_to_promise_release
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "Yes"
+msgstr ""

--- a/sale_stock_available_to_promise_release/i18n/de.po
+++ b/sale_stock_available_to_promise_release/i18n/de.po
@@ -4,18 +4,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-02 13:13+0000\n"
-"PO-Revision-Date: 2021-02-07 02:44+0000\n"
-"Last-Translator: Ignacio Buioli <ibuioli@gmail.com>\n"
-"Language-Team: none\n"
-"Language: es_AR\n"
+"PO-Revision-Date: 2021-07-02 08:11+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: \n"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__availability_status
@@ -25,7 +24,7 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
 msgid "Available"
-msgstr ""
+msgstr "Verfügbar"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__available_qty
@@ -36,7 +35,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_move__carrier_id
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_picking_release_search
 msgid "Carrier"
-msgstr "Transportista"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_procurement_group__date_expected
@@ -44,12 +43,12 @@ msgstr "Transportista"
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_picking__sale_date_expected
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Delivery Date"
-msgstr "Fecha de Entrega"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Delivery Method"
-msgstr "Método de Entrega"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__expected_availability_date
@@ -64,18 +63,18 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Further Shipment"
-msgstr "Envío Adicional"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Late Shipment"
-msgstr "Último Envío"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order__move_need_release_count
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_order_form
 msgid "Moves Need Release"
-msgstr "Movimientos Necesitan Liberarse"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
@@ -91,7 +90,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__mto
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
 msgid "On order"
-msgstr ""
+msgstr "Auf Auftrag"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__partial
@@ -101,12 +100,12 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_procurement_group
 msgid "Procurement Group"
-msgstr "Grupo de Adquisiciones"
+msgstr "Beschaffungsgruppe"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_product_product
 msgid "Product"
-msgstr ""
+msgstr "Produkt"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__restock
@@ -116,32 +115,32 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de Ventas"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Línea de Pedido de Ventas"
+msgstr "Auftragsposition"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_stock_move
 msgid "Stock Move"
-msgstr "Movimiento de Inventario"
+msgstr "Lagerbuchung"
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Today Shipment"
-msgstr "Envío de Hoy"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_stock_picking
 msgid "Transfer"
-msgstr "Transferencia"
+msgstr "Lieferung vornehmen"
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Weight"
-msgstr "Altura"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document

--- a/sale_stock_available_to_promise_release/i18n/fr_CH.po
+++ b/sale_stock_available_to_promise_release/i18n/fr_CH.po
@@ -4,18 +4,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-02 13:13+0000\n"
-"PO-Revision-Date: 2021-02-07 02:44+0000\n"
-"Last-Translator: Ignacio Buioli <ibuioli@gmail.com>\n"
-"Language-Team: none\n"
-"Language: es_AR\n"
+"PO-Revision-Date: 2021-07-02 07:18+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: \n"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__availability_status
@@ -25,7 +24,7 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
 msgid "Available"
-msgstr ""
+msgstr "Disponible"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__available_qty
@@ -36,7 +35,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_move__carrier_id
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_picking_release_search
 msgid "Carrier"
-msgstr "Transportista"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_procurement_group__date_expected
@@ -44,12 +43,12 @@ msgstr "Transportista"
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_picking__sale_date_expected
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Delivery Date"
-msgstr "Fecha de Entrega"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Delivery Method"
-msgstr "Método de Entrega"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__expected_availability_date
@@ -64,18 +63,18 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Further Shipment"
-msgstr "Envío Adicional"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Late Shipment"
-msgstr "Último Envío"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order__move_need_release_count
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_order_form
 msgid "Moves Need Release"
-msgstr "Movimientos Necesitan Liberarse"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
@@ -91,7 +90,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__mto
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
 msgid "On order"
-msgstr ""
+msgstr "À la demande"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__partial
@@ -101,12 +100,12 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_procurement_group
 msgid "Procurement Group"
-msgstr "Grupo de Adquisiciones"
+msgstr "Groupe d'approvisionnement"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_product_product
 msgid "Product"
-msgstr ""
+msgstr "Article"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__restock
@@ -116,32 +115,32 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de Ventas"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Línea de Pedido de Ventas"
+msgstr "Ligne de bons de commande"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_stock_move
 msgid "Stock Move"
-msgstr "Movimiento de Inventario"
+msgstr "Mouvement de stock"
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Today Shipment"
-msgstr "Envío de Hoy"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_stock_picking
 msgid "Transfer"
-msgstr "Transferencia"
+msgstr "Transfert"
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Weight"
-msgstr "Altura"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document

--- a/sale_stock_available_to_promise_release/i18n/it.po
+++ b/sale_stock_available_to_promise_release/i18n/it.po
@@ -4,18 +4,17 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-02 13:13+0000\n"
-"PO-Revision-Date: 2021-02-07 02:44+0000\n"
-"Last-Translator: Ignacio Buioli <ibuioli@gmail.com>\n"
-"Language-Team: none\n"
-"Language: es_AR\n"
+"PO-Revision-Date: 2021-07-02 07:19+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.3.2\n"
+"Plural-Forms: \n"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__availability_status
@@ -25,7 +24,7 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
 msgid "Available"
-msgstr ""
+msgstr "A disposizione"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__available_qty
@@ -36,7 +35,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_move__carrier_id
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_picking_release_search
 msgid "Carrier"
-msgstr "Transportista"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_procurement_group__date_expected
@@ -44,12 +43,12 @@ msgstr "Transportista"
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_picking__sale_date_expected
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Delivery Date"
-msgstr "Fecha de Entrega"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Delivery Method"
-msgstr "Método de Entrega"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__expected_availability_date
@@ -64,18 +63,18 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Further Shipment"
-msgstr "Envío Adicional"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Late Shipment"
-msgstr "Último Envío"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order__move_need_release_count
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_order_form
 msgid "Moves Need Release"
-msgstr "Movimientos Necesitan Liberarse"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
@@ -91,7 +90,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__mto
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
 msgid "On order"
-msgstr ""
+msgstr "Su ordine"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__partial
@@ -101,12 +100,12 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_procurement_group
 msgid "Procurement Group"
-msgstr "Grupo de Adquisiciones"
+msgstr "Gruppo di Approvvigionamento"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_product_product
 msgid "Product"
-msgstr ""
+msgstr "Prodotto"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__restock
@@ -116,32 +115,32 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_sale_order
 msgid "Sales Order"
-msgstr "Pedido de Ventas"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_sale_order_line
 msgid "Sales Order Line"
-msgstr "Línea de Pedido de Ventas"
+msgstr "Riga ordine di vendita"
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_stock_move
 msgid "Stock Move"
-msgstr "Movimiento de Inventario"
+msgstr "Movimento Magazzino"
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Today Shipment"
-msgstr "Envío de Hoy"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_stock_picking
 msgid "Transfer"
-msgstr "Transferencia"
+msgstr "Trasferisci"
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Weight"
-msgstr "Altura"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document

--- a/sale_stock_available_to_promise_release/i18n/sale_stock_available_to_promise_release.pot
+++ b/sale_stock_available_to_promise_release/i18n/sale_stock_available_to_promise_release.pot
@@ -4,14 +4,31 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server 13.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-02 13:13+0000\n"
+"PO-Revision-Date: 2021-07-02 13:13+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__availability_status
+msgid "Availability Status"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "Available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__available_qty
+msgid "Available Qty"
+msgstr ""
 
 #. module: sale_stock_available_to_promise_release
 #: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_stock_move__carrier_id
@@ -33,6 +50,16 @@ msgid "Delivery Method"
 msgstr ""
 
 #. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields,field_description:sale_stock_available_to_promise_release.field_sale_order_line__expected_availability_date
+msgid "Expected Availability Date"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__full
+msgid "Fully Available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_search
 msgid "Further Shipment"
 msgstr ""
@@ -49,8 +76,39 @@ msgid "Moves Need Release"
 msgstr ""
 
 #. module: sale_stock_available_to_promise_release
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "No"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__no
+msgid "Not available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__mto
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "On order"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__partial
+msgid "Partially Available"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
 #: model:ir.model,name:sale_stock_available_to_promise_release.model_procurement_group
 msgid "Procurement Group"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model,name:sale_stock_available_to_promise_release.model_product_product
+msgid "Product"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model:ir.model.fields.selection,name:sale_stock_available_to_promise_release.selection__sale_order_line__availability_status__restock
+msgid "Restock ordered"
 msgstr ""
 
 #. module: sale_stock_available_to_promise_release
@@ -81,4 +139,9 @@ msgstr ""
 #. module: sale_stock_available_to_promise_release
 #: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.view_move_release_tree
 msgid "Weight"
+msgstr ""
+
+#. module: sale_stock_available_to_promise_release
+#: model_terms:ir.ui.view,arch_db:sale_stock_available_to_promise_release.report_saleorder_document
+msgid "Yes"
 msgstr ""

--- a/sale_stock_available_to_promise_release/models/__init__.py
+++ b/sale_stock_available_to_promise_release/models/__init__.py
@@ -3,3 +3,4 @@ from . import sale_order_line
 from . import stock_move
 from . import stock_picking
 from . import procurement_group
+from . import product_product

--- a/sale_stock_available_to_promise_release/models/product_product.py
+++ b/sale_stock_available_to_promise_release/models/product_product.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _get_next_replenishment_date(self):
+        self.ensure_one()
+        move_line = self.env["stock.move"].search(
+            [
+                ("product_id", "=", self.id),
+                ("state", "not in", ["done", "cancel"]),
+                ("picking_type_id.code", "=", "incoming"),
+            ],
+            limit=1,
+            order="date_expected asc",
+        )
+        return move_line and move_line.date_expected or False

--- a/sale_stock_available_to_promise_release/models/sale_order_line.py
+++ b/sale_stock_available_to_promise_release/models/sale_order_line.py
@@ -1,13 +1,67 @@
 # Copyright 2019 Camptocamp (https://www.camptocamp.com)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo import models
+from odoo import api, fields, models
+from odoo.tools import float_compare, float_is_zero
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    def _prepare_procurement_values(self, group_id=False):
-        values = super()._prepare_procurement_values(group_id)
-        values["date_priority"] = self.order_id.date_order
-        return values
+    availability_status = fields.Selection(
+        selection=[
+            ("mto", "On order"),
+            ("full", "Fully Available"),
+            ("partial", "Partially Available"),
+            ("restock", "Restock ordered"),
+            ("no", "Not available"),
+        ],
+        compute="_compute_availability_status",
+    )
+    expected_availability_date = fields.Datetime(compute="_compute_availability_status")
+    available_qty = fields.Float(
+        digits="Product Unit of Measure", compute="_compute_availability_status"
+    )
+
+    @api.depends(
+        "move_ids.ordered_available_to_promise_uom_qty",
+        "product_id.route_ids",
+        "product_uom_qty",
+    )
+    def _compute_availability_status(self):
+        for record in self:
+            # Fallback values
+            availability_status = "no"
+            expected_availability_date = False
+            available_qty = sum(
+                record.mapped("move_ids.ordered_available_to_promise_uom_qty")
+            )
+            # required values
+            product = record.product_id
+            rounding = product.uom_id.rounding
+            mto_route = self.env.ref("stock.route_warehouse0_mto")
+            # MTO product
+            if mto_route in product.route_ids:
+                availability_status = "mto"
+            # Fully available
+            elif (
+                float_compare(
+                    available_qty, record.product_uom_qty, precision_rounding=rounding
+                )
+                >= 0
+            ):
+                availability_status = "full"
+                available_qty = record.product_uom_qty
+            # Partially available
+            elif float_compare(available_qty, 0, precision_rounding=rounding) == 1:
+                availability_status = "partial"
+            # No stock
+            elif float_is_zero(available_qty, precision_rounding=rounding):
+                product_replenishment_date = product._get_next_replenishment_date()
+                # Replenishment ordered
+                if product_replenishment_date:
+                    availability_status = "restock"
+                    expected_availability_date = product_replenishment_date
+            record.availability_status = availability_status
+            record.expected_availability_date = expected_availability_date
+            record.available_qty = available_qty

--- a/sale_stock_available_to_promise_release/readme/CONTRIBUTORS.rst
+++ b/sale_stock_available_to_promise_release/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Matthieu Méquignon <matthieu.mequignon@camptocamp.com>

--- a/sale_stock_available_to_promise_release/reports/sale_order.xml
+++ b/sale_stock_available_to_promise_release/reports/sale_order.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 Camptocamp SA
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <template
+        id="report_saleorder_document"
+        inherit_id="sale.report_saleorder_document"
+    >
+      <xpath expr="//th[@name='th_description']" position="after">
+        <th
+                t-if="doc.state != 'draft'"
+                name="th_is_available"
+                class="text-right nowrap"
+            >Available</th>
+      </xpath>
+
+      <xpath expr="//td[@name='td_name']" position="after">
+          <td
+                t-if="doc.state != 'draft'"
+                name="td_is_available"
+                class="nowrap text-right"
+            >
+              <span
+                    t-if="line.availability_status == 'mto'"
+                    name="availability_status_mto"
+                >On order</span>
+              <span
+                    t-elif="line.availability_status == 'full'"
+                    name="availability_status_full"
+                >Yes</span>
+              <t
+                    t-elif="line.availability_status == 'partial'"
+                    name="availablility_status_partial"
+                >
+                <span t-field="line.available_qty" />
+                <span t-field="line.product_uom" />
+              </t>
+              <span
+                    t-elif="line.availability_status == 'restock'"
+                    name="availability_status_restock"
+                    t-field="line.expected_availability_date"
+                    t-options="{'date_only': 'True'}"
+                />
+              <span
+                    t-elif="line.availability_status == 'no'"
+                    name="availability_status_no"
+                >No</span>
+          </td>
+      </xpath>
+    </template>
+
+</odoo>

--- a/sale_stock_available_to_promise_release/static/description/index.html
+++ b/sale_stock_available_to_promise_release/static/description/index.html
@@ -408,6 +408,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#id4">Contributors</a></h2>
 <ul class="simple">
 <li>Guewen Baconnier &lt;<a class="reference external" href="mailto:guewen.baconnier&#64;camptocamp.com">guewen.baconnier&#64;camptocamp.com</a>&gt;</li>
+<li>Matthieu Méquignon &lt;<a class="reference external" href="mailto:matthieu.mequignon&#64;camptocamp.com">matthieu.mequignon&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/sale_stock_available_to_promise_release/tests/__init__.py
+++ b/sale_stock_available_to_promise_release/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_line_availability_status

--- a/sale_stock_available_to_promise_release/tests/test_sale_line_availability_status.py
+++ b/sale_stock_available_to_promise_release/tests/test_sale_line_availability_status.py
@@ -1,0 +1,122 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from odoo.tests.common import SavepointCase
+
+
+class TestSaleLineAvailablilityStatus(SavepointCase):
+    at_install = False
+    post_install = True
+
+    @classmethod
+    def setUpClassProduct(cls):
+        cls.mto_route = cls.env.ref("stock.route_warehouse0_mto")
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Storable Product",
+                "uom_id": cls.uom_unit.id,
+                "type": "product",
+            }
+        )
+
+    @classmethod
+    def setUpClassSale(cls):
+        customer = cls.env["res.partner"].create(
+            {"name": "Partner who loves storable products"}
+        )
+        cls.sale = cls.env["sale.order"].create({"partner_id": customer.id})
+        cls.line = cls.env["sale.order.line"].create(
+            {
+                "order_id": cls.sale.id,
+                "product_id": cls.product.id,
+                "product_uom_qty": 100,
+                "product_uom": cls.uom_unit.id,
+            }
+        )
+
+    @classmethod
+    def setUpClassStock(cls):
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.suppliers_location = cls.env.ref("stock.stock_location_suppliers")
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestSaleLineAvailablilityStatus, cls).setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.setUpClassProduct()
+        cls.setUpClassSale()
+        cls.setUpClassStock()
+
+    def _set_stock(self, product, qty):
+        self.env["stock.quant"]._update_available_quantity(
+            product, self.stock_location, qty
+        )
+
+    @freeze_time("2021-07-03 12:00:00")
+    def _create_replenishment_picking(self, product, qty):
+        picking_type_in = self.env.ref("stock.picking_type_in")
+        return self.env["stock.picking"].create(
+            {
+                "name": "A picking full of moves",
+                "picking_type_id": picking_type_in.id,
+                "location_id": self.suppliers_location.id,
+                "location_dest_id": self.stock_location.id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": product.id,
+                            "name": "A move full of storable products",
+                            "picking_type_id": picking_type_in.id,
+                            "location_id": self.suppliers_location.id,
+                            "location_dest_id": self.stock_location.id,
+                            "product_uom_qty": qty,
+                            "product_uom": self.uom_unit.id,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_available_mto(self):
+        # No matter the ordered qty, if mto route is defined on the product,
+        # availability_status = "mto"
+        self.sale.action_confirm()
+        self.assertNotEqual(self.line.availability_status, "mto")
+        self.product.route_ids = [(4, self.mto_route.id, 0)]
+        self.assertEqual(self.line.availability_status, "mto")
+
+    def test_available_full(self):
+        self._set_stock(self.product, 100)
+        self.sale.action_confirm()
+        self.assertEqual(self.line.availability_status, "full")
+
+    def test_available_partial(self):
+        self._set_stock(self.product, 50)
+        self.sale.action_confirm()
+        self.assertEqual(self.line.availability_status, "partial")
+        self.assertEqual(self.line.available_qty, 50.0)
+
+    @freeze_time("2021-07-01 12:00:00")
+    def test_availabile_restock(self):
+        replenishment_picking = self._create_replenishment_picking(self.product, 100)
+        self.sale.action_confirm()
+        self.assertEqual(self.line.availability_status, "restock")
+        replenishment_picking.action_confirm()
+        self.assertNotEqual(self.line.availability_status, "full")
+        self.assertEqual(
+            self.line.expected_availability_date, datetime(2021, 7, 3, 12, 0, 0)
+        )
+
+    def test_not_available(self):
+        self.sale.action_confirm()
+        self.assertEqual(
+            self.line.with_context(not_available=True).availability_status, "no"
+        )

--- a/sale_stock_available_to_promise_release/views/sale_order_views.xml
+++ b/sale_stock_available_to_promise_release/views/sale_order_views.xml
@@ -25,6 +25,12 @@
                     />
                 </button>
             </xpath>
+            <xpath
+                expr="//page[@name='order_lines']//field[@name='price_unit']"
+                position="before"
+            >
+                <field name="availability_status" optional="hide" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Displays the line availability on sale report.
- "On order" if product's route is MTO
- "Yes" if product is fully available
- A qty if product is partially available
- A date if no stock and there's an active replenishment
- "No" otherwise