### PR TITLE
[13.0][FIX] s_r_screen: subcontracting fix with components tracked by lot

### DIFF
--- a/stock_reception_screen_mrp_subcontracting/models/__init__.py
+++ b/stock_reception_screen_mrp_subcontracting/models/__init__.py
@@ -1,2 +1,3 @@
 from . import stock_reception_screen
 from . import stock_move_line
+from . import stock_move

--- a/stock_reception_screen_mrp_subcontracting/models/stock_move.py
+++ b/stock_reception_screen_mrp_subcontracting/models/stock_move.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _check_overprocessed_subcontract_qty(self):
+        # Disable the check if finished move lines have been removed by the
+        # `_action_done_picking` method of the reception screen (resetting the
+        # 'qty_produced' computed field of the production order to 0). Indeed,
+        # these move lines are automatically recreated by the 'mrp_subcontracting'
+        # module in the picking 'action_done()' override by duplicating received
+        # move lines, so the production order will get its 'qty_produced' correct
+        # afterwards anyway.
+        # We know that we come from a validation of the reception screen thanks
+        # to the 'subcontracting_skip_unlink' context key defined in
+        # '_action_done_picking' method of the reception screen.
+        if self.env.context.get("subcontracting_skip_unlink"):
+            return False
+        return super()._check_overprocessed_subcontract_qty()

--- a/stock_reception_screen_mrp_subcontracting/tests/test_reception_screen.py
+++ b/stock_reception_screen_mrp_subcontracting/tests/test_reception_screen.py
@@ -10,6 +10,10 @@ class TestReceptionScreenMrpSubcontracting(Common):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls._prepare_reception_screen()
+
+    @classmethod
+    def _prepare_reception_screen(cls):
         # product.product_delivery_02 has a subcontracted BoM defined with
         # 'mrp_subcontracting' installed
         cls.picking = cls._create_picking_in(partner=cls.env.ref("base.res_partner_12"))
@@ -18,7 +22,106 @@ class TestReceptionScreenMrpSubcontracting(Common):
         cls.picking.action_reception_screen_open()
         cls.screen = cls.picking.reception_screen_id
 
+    def _record_components_for_picking(self, picking):
+        for move in picking.move_lines:
+            if not move.is_subcontract:
+                continue
+            context = dict(
+                default_production_id=move.move_orig_ids.production_id.id,
+                default_subcontract_move_id=move.id,
+            )
+            wiz_model = self.env["mrp.product.produce"].with_context(context)
+            wiz = wiz_model.create({})
+            for line in wiz.move_raw_ids.move_line_ids:
+                line.qty_done = line.product_uom_qty
+            wiz.do_produce()
+
     def test_reception_screen_with_subcontracted_products(self):
+        """Receive subcontracted goods."""
+        # Select the product to receive
+        self.assertEqual(self.screen.current_step, "select_product")
+        move = fields.first(self.screen.picking_filtered_move_lines)
+        move.action_select_product()
+        # Receive 2/4 qties (corresponding to the product packaging qty)
+        self.assertEqual(self.screen.current_step, "set_quantity")
+        self.screen.current_move_line_qty_done = 2
+        self.assertEqual(self.screen.current_move_line_qty_status, "lt")
+        # Check package data (automatically filled normally)
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "select_packaging")
+        self.assertEqual(self.screen.product_packaging_id, self.product_2_packaging)
+        self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
+        self.assertEqual(self.screen.package_height, self.product_2_packaging.height)
+        # Check that a destination location is defined by default
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
+        self.screen.button_save_step()
+        self.assertEqual(
+            self.screen.current_move_line_location_dest_id,
+            self.screen.current_move_line_location_dest_stored_id,
+        )
+        # Set a package
+        self.assertEqual(self.screen.current_step, "set_package")
+        self.screen.current_move_line_package = "PID-TEST-1"
+        self.assertEqual(self.screen.current_move_line_package_stored, "PID-TEST-1")
+        move_line = self.screen.current_move_line_id
+        self.assertFalse(move_line.result_package_id)
+        self.assertEqual(len(self.picking.move_lines), 1)
+        self.screen.button_save_step()
+        self.assertEqual(move_line.result_package_id.name, "PID-TEST-1")
+        # The first 2 qties should be validated, creating a 2nd move to process
+        self.assertEqual(len(self.picking.move_lines), 2)
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_quantity")
+        self.screen.current_move_line_qty_done = 2
+        self.assertEqual(self.screen.current_move_line_qty_status, "eq")
+        self.screen.button_save_step()
+        # Check package data (automatically filled as before)
+        self.assertEqual(self.screen.current_step, "select_packaging")
+        self.assertEqual(self.screen.product_packaging_id, self.product_2_packaging)
+        self.assertEqual(self.screen.package_storage_type_id, self.storage_type_pallet)
+        self.assertEqual(self.screen.package_height, self.product_2_packaging.height)
+        self.screen.button_save_step()
+        # Set location
+        self.assertEqual(self.screen.current_step, "set_location")
+        self.screen.current_move_line_location_dest_stored_id = self.location_dest
+        # Set a package
+        self.screen.button_save_step()
+        self.assertEqual(self.screen.current_step, "set_package")
+        self.screen.current_move_line_package = "PID-TEST-2"
+        self.assertEqual(self.screen.current_move_line_package_stored, "PID-TEST-2")
+        move_line = self.screen.current_move_line_id
+        self.assertFalse(move_line.result_package_id)
+        self.screen.button_save_step()  # Reception done
+        self.assertEqual(move_line.result_package_id.name, "PID-TEST-2")
+        # Check that the manufacturing order is now done
+        production = self.picking.move_lines.move_orig_ids.production_id
+        self.assertEqual(production.state, "done")
+        self.assertEqual(production.move_finished_ids.product_uom_qty, 4)
+        self.assertEqual(production.move_finished_ids.quantity_done, 4)
+        self.assertEqual(production.move_finished_ids.state, "done")
+        for ml in production.finished_move_line_ids:
+            self.assertEqual(ml.qty_done, 2)
+
+    def test_reception_screen_with_subcontracted_products_with_tracked_components(self):
+        """Receive subcontracted goods having components tracked by lots."""
+        # Update the existing BoM to have a component tracked by lot
+        bom_line = self.product_2.bom_ids.bom_line_ids
+        component = bom_line.product_id.copy({"type": "product", "tracking": "lot"})
+        bom_line.product_id = component
+        component_lot = self.env["stock.production.lot"].create(
+            {"product_id": component.id, "company_id": self.picking.company_id.id}
+        )
+        production = self.picking.move_lines.move_orig_ids.production_id
+        self.env["stock.quant"]._update_available_quantity(
+            component, production.move_raw_ids.location_id, 4, lot_id=component_lot
+        )
+        # Prepare a new reception
+        self.picking.action_cancel()
+        self._prepare_reception_screen()
+        # Record components (mandatory)
+        self._record_components_for_picking(self.picking)
         # Select the product to receive
         self.assertEqual(self.screen.current_step, "select_product")
         move = fields.first(self.screen.picking_filtered_move_lines)


### PR DESCRIPTION
When receiving goods with the reception screen we are able to process
a partial quantity, splitting the current move and validating it on its
own. By convenience, the stock.move.line related to the finished moves
(in the production order) are removed and recreated (by duplicating move
lines received) when the reception is validated.

This last part has been rewritten in 'stock_reception_screen_mrp_subcontracting'
module to satisfy a technical need for the reception screen, but this was
causing an issue when receiving subcontracted goods with components
tracked by lots.
The fix here is to disable the blocking check which compares the produced
qty of the production order (which is 0 because all produced move lines have
been removed) to the qty received on the move when the reception is
validated by the reception screen.

Ref. 2670