### PR TITLE
[13.0->14.0][oca-port-pr-#130] shopfloor_batch_automatic_creation: Reactivate failing test

### DIFF
--- a/shopfloor_batch_automatic_creation/tests/test_batch_create.py
+++ b/shopfloor_batch_automatic_creation/tests/test_batch_create.py
@@ -1,5 +1,5 @@
-import os
-import unittest
+# Copyright 2020 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.addons.shopfloor.tests.common import CommonCase
 
@@ -64,9 +64,6 @@ class TestBatchCreate(CommonCase):
         # when we have users on pickings, we select only those for the batch
         self.assertEqual(batch.picking_ids, self.picking2 + self.picking3)
 
-    @unittest.skipIf(
-        os.getenv("TRAVIS"), "failing test only on travis, need to be investigated"
-    )
     def test_create_batch_max_weight(self):
         # each picking has 2 lines of 10 units, set weight of 1kg per unit,
         # we'll have a total weight of 20kg per picking


### PR DESCRIPTION
Port of #130 from 13.0 to 14.0.