### PR TITLE
[13.0->14.0][oca-port-pr-#127] Shopfloor: use estimated package weight if weight is not set

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -309,11 +309,15 @@ class StockLocation(models.Model):
                 ("max_height_in_m", "=", 0),
                 ("max_height_in_m", ">=", quants.package_id.height_in_m),
             ]
-        if quants.package_id.pack_weight:
+        package_weight_kg = (
+            quants.package_id.pack_weight_in_kg
+            or quants.package_id.estimated_pack_weight_kg
+        )
+        if package_weight_kg:
             pertinent_loc_storagetype_domain += [
                 "|",
                 ("max_weight_in_kg", "=", 0),
-                ("max_weight_in_kg", ">=", quants.package_id.pack_weight_in_kg),
+                ("max_weight_in_kg", ">=", package_weight_kg),
             ]
         _logger.debug(
             "pertinent storage type domain: %s", pertinent_loc_storagetype_domain

--- a/stock_storage_type/models/stock_quant.py
+++ b/stock_storage_type/models/stock_quant.py
@@ -29,6 +29,10 @@ class StockQuant(models.Model):
                     % (pack_storage_type.name, location.name)
                 )
             allowed = False
+            package_weight_kg = (
+                quant.package_id.pack_weight_in_kg
+                or quant.package_id.estimated_pack_weight_kg
+            )
             package_quants = quant.package_id.mapped("quant_ids")
             package_products = package_quants.mapped("product_id")
             package_lots = package_quants.mapped("lot_id")
@@ -97,8 +101,7 @@ class StockQuant(models.Model):
                     continue
                 if (
                     loc_storage_type.max_weight_in_kg
-                    and quant.package_id.pack_weight_in_kg
-                    > loc_storage_type.max_weight_in_kg
+                    and package_weight_kg > loc_storage_type.max_weight_in_kg
                 ):
                     lst_fails.append(
                         _(
@@ -107,7 +110,7 @@ class StockQuant(models.Model):
                             % (
                                 loc_storage_type.name,
                                 loc_storage_type.max_weight_in_kg,
-                                quant.package_id.pack_weight_in_kg,
+                                package_weight_kg,
                             )
                         )
                     )


### PR DESCRIPTION
Port of #127 from 13.0 to 14.0.

Depends on:
- [x] https://github.com/OCA/stock-logistics-workflow/pull/875