### PR TITLE
[13.0] stock_storage_type: add location smart buttons

### DIFF
--- a/stock_storage_type/models/stock_location_storage_type.py
+++ b/stock_storage_type/models/stock_location_storage_type.py
@@ -156,3 +156,8 @@ class StockLocationStorageType(models.Model):
                     ("location_will_contain_lot_ids", "=", False),
                 ]
         return location_domain
+
+    def button_show_locations(self):
+        action = self.env.ref("stock.action_location_form").read()[0]
+        action["domain"] = [("allowed_location_storage_type_ids", "in", self.ids)]
+        return action

--- a/stock_storage_type/models/stock_storage_location_sequence.py
+++ b/stock_storage_type/models/stock_storage_location_sequence.py
@@ -67,3 +67,15 @@ class StockStorageLocationSequence(models.Model):
                 % self.location_id.name
             )
         return msg
+
+    def button_show_locations(self):
+        action = self.env.ref("stock.action_location_form").read()[0]
+        action["domain"] = [
+            ("parent_path", "=ilike", "{}%".format(self.location_id.parent_path)),
+            (
+                "allowed_location_storage_type_ids",
+                "in",
+                self.package_storage_type_id.location_storage_type_ids.ids,
+            ),
+        ]
+        return action

--- a/stock_storage_type/views/stock_location_storage_type.xml
+++ b/stock_storage_type/views/stock_location_storage_type.xml
@@ -16,6 +16,15 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            string="Locations"
+                            class="oe_stat_button"
+                            icon="fa-th-list"
+                            name="button_show_locations"
+                            type="object"
+                        />
+                    </div>
                     <field name="active" invisible="1" />
                     <widget
                         name="web_ribbon"

--- a/stock_storage_type/views/stock_storage_location_sequence.xml
+++ b/stock_storage_type/views/stock_storage_location_sequence.xml
@@ -13,6 +13,11 @@
                 />
                 <field name="location_id" />
                 <field name="location_putaway_strategy" />
+                <button
+                    string="Show locations"
+                    name="button_show_locations"
+                    type="object"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
When you make your config or want to analyze a situation, it is practical to see the locations allowing a package storage type from the config.

cc @sebalix @jgrandguillaume @lmignon 