### PR TITLE
[13.0] stock_storage_type: Fix putaway compution when a strategy is defined

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -112,6 +112,11 @@ class StockLocation(models.Model):
     leaf_location_ids = fields.Many2many(
         "stock.location",
         compute="_compute_leaf_location_ids",
+        help="technical field: all the leaves locations",
+    )
+    leaf_child_location_ids = fields.Many2many(
+        "stock.location",
+        compute="_compute_leaf_location_ids",
         help="technical field: all the leaves sub-locations",
     )
     max_height = fields.Float(
@@ -162,20 +167,23 @@ class StockLocation(models.Model):
                 for storage_type in rec.allowed_location_storage_type_ids
             )
 
-    @api.depends("child_ids.leaf_location_ids")
+    @api.depends("child_ids.leaf_location_ids", "child_ids.active")
     def _compute_leaf_location_ids(self):
+        """Compute all children leaf locations. Current location is excluded (not a child)"""
         query = """
             SELECT parent.id, ARRAY_AGG(sub.id) AS leaves
             FROM stock_location parent
             INNER JOIN stock_location sub
             ON sub.parent_path LIKE parent.parent_path || '%%'
             AND sub.id != parent.id
+            AND sub.active
             LEFT JOIN stock_location subsub
             ON subsub.location_id = sub.id
+            AND subsub.active
             WHERE
             -- exclude any location which has children so we keep only leaves
             subsub.id IS NULL
-            AND parent.id = %s
+            AND parent.id in %s
             GROUP BY parent.id;
         """
         self.env.cr.execute(query, (tuple(self.ids),))
@@ -183,11 +191,12 @@ class StockLocation(models.Model):
         for loc in self:
             leave_ids = rows.get(loc.id)
             if not leave_ids:
-                # if we have no sub-location, we are a leaf
                 loc.leaf_location_ids = loc
+                loc.leaf_child_location_ids = False
                 continue
             leaves = self.search([("id", "in", leave_ids)])
             loc.leaf_location_ids = leaves
+            loc.leaf_child_location_ids = leaves
 
     def _should_compute_will_contain_product_ids(self):
         return self.do_not_mix_products
@@ -367,7 +376,7 @@ class StockLocation(models.Model):
             locations = self
         else:
             products = products or self.env["product.product"]
-            locations = self._get_sorted_leaf_locations(products)
+            locations = self._get_sorted_leaf_child_locations(products)
         return locations
 
     def _get_sorted_leaf_locations_orderby(self, products):
@@ -390,16 +399,16 @@ class StockLocation(models.Model):
             ]
         return ", ".join(orderby), []
 
-    def _get_sorted_leaf_locations(self, products):
+    def _get_sorted_leaf_child_locations(self, products):
         """Return sorted leaf sub-locations
 
         The locations are candidate locations that will be evaluated one per
         one in order to find the first available location. They must be leaf
         locations where we can actually put goods.
         """
-        if not self.leaf_location_ids:
-            return self.leaf_location_ids
-        query = self._where_calc([("id", "in", self.leaf_location_ids.ids)])
+        if not self.leaf_child_location_ids:
+            return self.leaf_child_location_ids
+        query = self._where_calc([("id", "in", self.leaf_child_location_ids.ids)])
         from_clause, where_clause, where_params = query.get_sql()
         orderby_clause, orderby_params = self._get_sorted_leaf_locations_orderby(
             products

--- a/stock_storage_type/tests/test_storage_type.py
+++ b/stock_storage_type/tests/test_storage_type.py
@@ -112,7 +112,11 @@ class TestStorageType(SavepointCase):
         self.assertEqual(self.stock_location.leaf_location_ids, all_stock_leaves)
 
     def test_location_leaf_locations_on_leaf(self):
-        self.assertEqual(self.cardboxes_bin_3.leaf_location_ids, self.cardboxes_bin_3)
+        self.cardboxes_bin_4.active = False
+        self.assertEqual(
+            self.cardboxes_stock.leaf_location_ids,
+            self.cardboxes_bin_1 | self.cardboxes_bin_2 | self.cardboxes_bin_3,
+        )
 
     def test_location_max_height(self):
         self.pallets_location_storage_type.max_height = 2

--- a/stock_storage_type/tests/test_storage_type_putaway_strategy.py
+++ b/stock_storage_type/tests/test_storage_type_putaway_strategy.py
@@ -59,6 +59,23 @@ class TestPutawayStorageTypeStrategy(TestStorageTypeCommon):
             int_picking.move_line_ids.mapped("location_dest_id"),
             self.cardboxes_bin_1_location,
         )
+        # Archive all leaf locations. Ensure that the intermediate location is
+        # not returned as a valid leaf location and that the next location in
+        # the sequence (reserve) is selected
+        int_picking.do_unreserve()
+        cardboxes_stock = self.env.ref("stock_storage_type.stock_location_cardboxes")
+        cardboxes_stock.child_ids.write({"active": False})
+        int_picking.action_assign()
+        self.assertEqual(int_picking.location_dest_id, self.stock_location)
+        self.assertEqual(
+            int_picking.move_lines.mapped("location_dest_id"), self.stock_location
+        )
+        reserve_cardbox = self.env.ref(
+            "stock_storage_type.stock_location_cardboxes_reserve_bin_1"
+        )
+        self.assertEqual(
+            int_picking.move_line_ids.mapped("location_dest_id"), reserve_cardbox
+        )
 
     def test_storage_strategy_only_empty_ordered_locations_pallets(self):
         # Set pallets location type as only empty


### PR DESCRIPTION
When the strategy has to find a leaf sub-location (strategy = ordered children location), do not return the locations defined on a storage type putaway sequence (this is not a child location).

Example: sequence is defined to first look in WH/Stock/area1 and then in WH/Stock/area2. On area1 the strategy is to find a leaf sub-location under area1. If area1 has temporarily no sub-location, area1 should not be returned as a valid leaf location.

Also, when searching for a leaf location, exclude non-active locations

cc @jgrandguillaume @TDu @lmignon 