### PR TITLE
[13.0] shopfloor: support barcode that do not send end of line + trim value

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
+++ b/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
@@ -13,6 +13,7 @@ Vue.component("searchbar", {
     data: function() {
         return {
             entered: "",
+            debounceWait: this.autosearch,
         };
     },
     props: {
@@ -43,10 +44,61 @@ Vue.component("searchbar", {
             type: Boolean,
             default: true,
         },
+        // remove leading/trailing spaces from input before searching
+        autotrim: {
+            type: Boolean,
+            default: true,
+        },
+        // on scanned input without end of line, the search will run after 50ms. Set to 0 to disable
+        autosearch: {
+            type: Number,
+            default: 50,
+        },
+        // on manually typed input, the search will run after time. Set to 1500 (ms) as time for typing. By default, disabled, enter must be pressed
+        autosearch_typing: {
+            type: Number,
+            default: 0,
+        },
     },
     mounted: function() {
         // As the inputMode is set to none when inserted in the DOM, we need to force the focus
         if (this.autofocus) this.$refs.searchbar.focus();
+    },
+    computed: {
+        // defined as computed property to put a new instance in cache each
+        // time the reactive debounceWait is modified
+        debouncedSearch() {
+            return _.debounce(function(e) {
+                if (
+                    this.entered.length == 1 &&
+                    this.debounceWait != this.autosearch_typing
+                ) {
+                    this.debounceWait = this.autosearch_typing;
+                    if (!this.debounceWait) return;
+                    return this.debouncedSearch();
+                }
+                if (!this.debounceWait) return;
+                return this.search();
+            }, this.debounceWait);
+        },
+    },
+    watch: {
+        entered: function(val) {
+            if (this.autotrim) {
+                let trimmed = val.trim();
+                if (trimmed !== val) {
+                    this.entered = trimmed;
+                    return;
+                }
+            }
+            if (!this.autosearch) return;
+            if (val.length == 0) {
+                this.debouncedSearch.cancel();
+                this.debounceWait = this.autosearch;
+                return;
+            }
+            return this.debouncedSearch();
+        },
     },
     methods: {
         show_virtual_keyboard: function(elem) {
@@ -57,13 +109,20 @@ Vue.component("searchbar", {
             elem.inputMode = "none";
             elem.classList.remove("searchbar-keyboard");
         },
-        search: function(e) {
-            e.preventDefault();
+        search: function() {
             // Talk to parent
+            if (!this.entered) return;
             this.$emit("found", {
                 text: this.entered,
-                type: e.target.dataset.type,
+                type: this.input_data_type,
             });
+            if (this.debounceWait === this.autosearch && this.reset_on_submit)
+                this.reset();
+        },
+        on_submit: function(e) {
+            e.preventDefault();
+            this.debouncedSearch.cancel();
+            this.search();
             if (this.reset_on_submit) this.reset();
         },
         reset: function() {
@@ -88,8 +147,7 @@ Vue.component("searchbar", {
 
     template: `
   <v-form
-      v-on:submit="search"
-      :data-type="input_data_type"
+      v-on:submit="on_submit"
       class="searchform"
       >
     <div class="searchbar v-input v-text-field">


### PR DESCRIPTION
When using multiple apps on the barcode, sometimes you cannot reconfigure the barcode to append an end of line to the scanned value.
The searchbar will auto detects if the code is scanned or manually typed. By default, the search will automatically execute when scanned and no more input is fed. The end of line can still be send. By default, when typing, you have to press enter to submit the input.

Also trim spaces from the input value

cc @simahawk @lmignon @sebalix @jgrandguillaume 