### PR TITLE
[13.0] shopfloor - single pack transfer: when pack is empty, raise same error as in zone picking

### DIFF
--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -50,9 +50,9 @@ class SinglePackTransfer(Component):
         data["confirmation_required"] = confirmation_required
         return self._response(next_state="scan_location", data=data, message=message,)
 
-    def start(self, barcode, confirmation=False):
+    def _scan_source(self, barcode, confirmation=False):
+        """Search a package"""
         search = self._actions_for("search")
-        picking_types = self.picking_types
         location = search.location_from_scan(barcode)
 
         package = self.env["stock.quant.package"]
@@ -61,31 +61,32 @@ class SinglePackTransfer(Component):
                 [("location_id", "=", location.id)]
             )
             if not package:
-                return self._response_for_start(
-                    message=self.msg_store.no_pack_in_location(location)
-                )
+                return (self.msg_store.no_pack_in_location(location), None)
             if len(package) > 1:
-                return self._response_for_start(
-                    message=self.msg_store.several_packs_in_location(location)
-                )
+                return (self.msg_store.several_packs_in_location(location), None)
 
         if not package:
             package = search.package_from_scan(barcode)
 
         if not package:
-            return self._response_for_start(
-                self.msg_store.package_not_found_for_barcode(barcode)
+            return (self.msg_store.package_not_found_for_barcode(barcode), None)
+        if not package.location_id:
+            return (self.msg_store.package_has_no_product_to_take(barcode), None)
+        if not self.is_src_location_valid(package.location_id):
+            return (
+                self.msg_store.package_not_allowed_in_src_location(
+                    barcode, self.picking_types
+                ),
+                None,
             )
 
-        if not package.location_id or not self.is_src_location_valid(
-            package.location_id
-        ):
-            return self._response_for_start(
-                message=self.msg_store.package_not_allowed_in_src_location(
-                    barcode, picking_types
-                )
-            )
+        return (None, package)
 
+    def start(self, barcode, confirmation=False):
+        picking_types = self.picking_types
+        message, package = self._scan_source(barcode, confirmation)
+        if message:
+            return self._response_for_start(message=message)
         package_level = self.env["stock.package_level"].search(
             [
                 ("package_id", "=", package.id),

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -220,6 +220,27 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
             },
         )
 
+    def test_start_pack_empty(self):
+        """Test /start when the scanned pack is empty
+
+        The pre-conditions:
+
+        * Nothing
+
+        Expected result:
+
+        * Return a message
+        """
+        pack_empty = self.env["stock.quant.package"].create({})
+        pack_code = pack_empty.name
+        params = {"barcode": pack_code}
+        response = self.service.dispatch("start", params=params)
+        self.assert_response(
+            response,
+            next_state="start",
+            message=self.service.msg_store.package_has_no_product_to_take(pack_code),
+        )
+
     def test_start_pack_from_location(self):
         """Test /start, finding the pack from location's barcode
 


### PR DESCRIPTION
Raise an error "Package has no product to take" when scanning an empty pack

@sebalix I had not seen you recently already fixed the internal error. What you think about raising this message instead of package not allowed ?