### PR TITLE
[FIX] s_a_to_promise_release: compatibility with 'stock_picking_batch'

### DIFF
--- a/stock_available_to_promise_release/views/stock_picking_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_views.xml
@@ -5,8 +5,10 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form" />
         <field name="arch" type="xml">
+            <sheet position="inside">
+              <field name="need_release" invisible="1" />
+            </sheet>
             <button name="action_confirm" position="after">
-                <field name="need_release" invisible="1" />
                 <field name="release_ready" invisible="1" />
                 <button
                     name="release_available_to_promise"


### PR DESCRIPTION
If the standard module `stock_picking_batch` is installed, all the
header of the picking form is replaced by a new one, removing the
`need_release` invisible field which is required by other fields
on the picking form.

Putting this field outside of the header fixes this situation.