### PR TITLE
[14.0] Shopfloor mobile base - refactor auth

### DIFF
--- a/setup/shopfloor_mobile_base_auth_api_key/odoo/addons/shopfloor_mobile_base_auth_api_key
+++ b/setup/shopfloor_mobile_base_auth_api_key/odoo/addons/shopfloor_mobile_base_auth_api_key
@@ -1,0 +1,1 @@
+../../../../shopfloor_mobile_base_auth_api_key

--- a/setup/shopfloor_mobile_base_auth_api_key/setup.py
+++ b/setup/shopfloor_mobile_base_auth_api_key/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/shopfloor_mobile_base_auth_user/odoo/addons/shopfloor_mobile_base_auth_user
+++ b/setup/shopfloor_mobile_base_auth_user/odoo/addons/shopfloor_mobile_base_auth_user
@@ -1,0 +1,1 @@
+../../../../shopfloor_mobile_base_auth_user

--- a/setup/shopfloor_mobile_base_auth_user/setup.py
+++ b/setup/shopfloor_mobile_base_auth_user/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopfloor_example/services/partner_service.py
+++ b/shopfloor_example/services/partner_service.py
@@ -17,7 +17,6 @@ class PartnerExampleService(Component):
     @restapi.method(
         [(["/scan/<string:identifier>"], "GET")],
         output_param=restapi.CerberusValidator("scan"),
-        auth="api_key",
     )
     def scan(self, identifier):
         """Scan a partner ref and return its data."""
@@ -29,7 +28,6 @@ class PartnerExampleService(Component):
         [(["/partner_list"], "GET")],
         input_param=restapi.CerberusValidator("partner_list"),
         output_param=restapi.CerberusValidator("partner_list"),
-        auth="api_key",
     )
     def partner_list(self, **params):
         """Return list of available partners."""
@@ -42,7 +40,6 @@ class PartnerExampleService(Component):
     @restapi.method(
         [(["/detail/<int:partner_id>"], "GET")],
         output_param=restapi.CerberusValidator("detail"),
-        auth="api_key",
     )
     def detail(self, partner_id):
         """Retrieve full detail for partner ID."""

--- a/shopfloor_mobile/__manifest__.py
+++ b/shopfloor_mobile/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Shopfloor mobile",
     "summary": "Mobile frontend for WMS Shopfloor app",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.1.0",
     "development_status": "Alpha",
     "depends": ["shopfloor", "shopfloor_mobile_base"],
     "author": "Camptocamp, BCIM, Akretion, Odoo Community Association (OCA)",

--- a/shopfloor_mobile/migrations/14.0.1.1.0/post-migrate.py
+++ b/shopfloor_mobile/migrations/14.0.1.1.0/post-migrate.py
@@ -1,0 +1,29 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Auth have been decoupled and split to `shopfloor_mobile_base_auth_api_key`
+    # for api key support.
+    # Since this is the base auth everyone used so far,
+    # let's make sure we don't break existing installations if any.
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    module = env["ir.module.module"].search(
+        [
+            ("name", "=", "shopfloor_mobile_base_auth_api_key"),
+            ("state", "=", "uninstalled"),
+        ]
+    )
+    if module:
+        _logger.info("Install module shopfloor_mobile_base_auth_api_key")
+        module.write({"state": "to install"})
+    return

--- a/shopfloor_mobile_base/readme/CONTRIBUTORS.rst
+++ b/shopfloor_mobile_base/readme/CONTRIBUTORS.rst
@@ -1,6 +1,7 @@
 * Simone Orsi <simahawk@gmail.com>
 * Thierry Ducrest <thierry.ducrest@camptocamp.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Juan Miguel Sánchez Arce  <juan.sanchez@camptocamp.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
 

--- a/shopfloor_mobile_base/static/wms/src/components/screen.js
+++ b/shopfloor_mobile_base/static/wms/src/components/screen.js
@@ -40,7 +40,7 @@ Vue.component("Screen", {
         },
         screen_app_class() {
             return [
-                this.$root.authenticated ? "authenticated" : "anonymous",
+                this.$root.is_authenticated() ? "authenticated" : "anonymous",
                 this.$root.loading ? "loading" : "",
                 this.$root.demo_mode ? "demo_mode" : "",
                 "env-" + this.$root.app_info.running_env,
@@ -57,7 +57,7 @@ Vue.component("Screen", {
         },
         show_profile_not_ready() {
             return (
-                this.$root.authenticated &&
+                this.$root.is_authenticated() &&
                 this.$route.meta.requiresProfile &&
                 !this.$root.has_profile
             );
@@ -131,7 +131,7 @@ Vue.component("Screen", {
             <v-btn icon v-if="info.current_doc_identifier" @click="$router.push({'name': 'scan_anything', params: {identifier: info.current_doc_identifier}, query: {displayOnly: 1}})">
                 <btn-info-icon color="'#fff'" />
             </v-btn>
-            <app-bar-actions v-if="$root.authenticated"/>
+            <app-bar-actions v-if="$root.is_authenticated()"/>
         </v-app-bar>
         <v-main :class="screen_content_class">
 

--- a/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
+++ b/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
@@ -10,13 +10,11 @@ const messages_en = {
     screen: {
         login: {
             title: "Login",
-            api_key_placeholder: "YOUR_API_KEY_HERE",
-            api_key_label: "API key",
             action: {
                 login: "Login",
             },
             error: {
-                api_key_invalid: "Invalid API KEY",
+                login_invalid: "Invalid credentials",
             },
         },
         home: {

--- a/shopfloor_mobile_base/static/wms/src/loginpage.js
+++ b/shopfloor_mobile_base/static/wms/src/loginpage.js
@@ -13,6 +13,24 @@ export var LoginPage = Vue.component("login-page", {
             error: "",
         };
     },
+    beforeCreate: function () {
+        const self = this;
+        if (this.$root.is_authenticated()) {
+            self.$router.push({name: "home"});
+        }
+    },
+    mounted: function () {
+        const self = this;
+        this.$root.event_hub.$once("login:before", function () {
+            self.error = "";
+        });
+        this.$root.event_hub.$once("login:success", function () {
+            self.$router.push({name: "home"});
+        });
+        this.$root.event_hub.$once("login:failure", function () {
+            self._handle_invalid_login();
+        });
+    },
     computed: {
         screen_info: function () {
             return {
@@ -31,6 +49,9 @@ export var LoginPage = Vue.component("login-page", {
         login_form_component_name() {
             const name = "login-" + this.$root.app_info.auth_type;
             return name;
+        },
+        _handle_invalid_login() {
+            this.error = this.$t("screen.login.error.login_invalid");
         },
     },
     template: `

--- a/shopfloor_mobile_base/static/wms/src/loginpage.js
+++ b/shopfloor_mobile_base/static/wms/src/loginpage.js
@@ -6,10 +6,10 @@
  * @author Simone Orsi <simahawk@gmail.com>
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
+
 export var LoginPage = Vue.component("login-page", {
     data: function () {
         return {
-            apikey: "",
             error: "",
         };
     },
@@ -28,28 +28,9 @@ export var LoginPage = Vue.component("login-page", {
         },
     },
     methods: {
-        login: function (evt) {
-            evt.preventDefault();
-            // Call odoo application load => set the result in the local storage in json
-            this.error = "";
-            this.$root.apikey = this.apikey;
-            this.$root
-                ._loadConfig()
-                .catch((error) => {
-                    this._handle_invalid_key();
-                })
-                .then(() => {
-                    // TODO: shall we do this in $root._loadRoutes?
-                    if (this.$root.authenticated) {
-                        this.$router.push({name: "home"});
-                    } else {
-                        this._handle_invalid_key();
-                    }
-                });
-        },
-        _handle_invalid_key() {
-            this.error = this.$t("screen.login.error.api_key_invalid");
-            this.$root.apikey = "";
+        login_form_component_name() {
+            const name = "login-" + this.$root.app_info.auth_type;
+            return name;
         },
     },
     template: `
@@ -74,22 +55,9 @@ export var LoginPage = Vue.component("login-page", {
                 justify="center">
                 <v-col cols="12" sm="8" md="4">
                     <div class="login-wrapper">
-                        <v-form v-on:submit="login">
-                            <v-text-field
-                                name="apikey"
-                                v-model="apikey"
-                                :label="$t('screen.login.api_key_label')"
-                                :placeholder="$t('screen.login.api_key_placeholder')"
-                                autofocus
-                                autocomplete="off"></v-text-field>
-                            <div class="button-list button-vertical-list full">
-                                <v-row align="center">
-                                    <v-col class="text-center" cols="12">
-                                        <v-btn color="success" type="submit">{{ $t('screen.login.action.login') }}</v-btn>
-                                    </v-col>
-                                </v-row>
-                            </div>
-                        </v-form>
+                        <component
+                            :is="login_form_component_name()"
+                            />
                     </div>
                 </v-col>
             </v-row>

--- a/shopfloor_mobile_base/static/wms/src/loginpage.js
+++ b/shopfloor_mobile_base/static/wms/src/loginpage.js
@@ -51,7 +51,7 @@ export var LoginPage = Vue.component("login-page", {
             return name;
         },
         _handle_invalid_login() {
-            this.error = this.$t("screen.login.error.login_invalid");
+            this.error = this.$root.$t("screen.login.error.login_invalid");
         },
     },
     template: `

--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -219,6 +219,9 @@ new Vue({
             this.$router.push({name: "login"});
             this.trigger("logout:after");
         },
+        is_authenticated: function () {
+            return this.authenticated ? true : false;
+        },
         // Likely not needed anymore
         loadJS: function (url, script_id) {
             if (script_id && !document.getElementById(script_id)) {

--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -151,7 +151,7 @@ new Vue({
             const auth_type = this.app_info.auth_type;
             const auth_handler = auth_handler_registry.get(auth_type);
             if (_.isUndefined(auth_handler)) {
-                throw "Auth type '" + auth_type + " not supported";
+                throw new Error("Auth type '" + auth_type + "' not supported");
             }
             return auth_handler;
         },

--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -176,10 +176,8 @@ new Vue({
                     self.appconfig = result.data;
                     self.authenticated = true;
                     self.$storage.set("appconfig", self.appconfig);
-                    return result;
-                } else {
-                    return result;
                 }
+                return result;
             });
         },
         _clearConfig: function (reload = true) {

--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -46,7 +46,6 @@ const register_app_components = function (components) {
 register_app_components(process_registry.all());
 register_app_components(page_registry.all());
 
-config_registry.add("apikey", {default: "", reset_on_clear: true});
 config_registry.add("profile", {default: {}, reset_on_clear: true});
 config_registry.add("appmenu", {default: [], reset_on_clear: true});
 config_registry.add("authenticated", {default: false, reset_on_clear: true});

--- a/shopfloor_mobile_base/static/wms/src/router.js
+++ b/shopfloor_mobile_base/static/wms/src/router.js
@@ -57,7 +57,12 @@ const router = new VueRouter({
 });
 router.beforeEach(async (to, from, next) => {
     await Vue.nextTick();
-    if (!router.app.authenticated && to.meta.requiresAuth && !router.app.demo_mode) {
+    // debugger;
+    if (
+        !router.app.is_authenticated() &&
+        to.meta.requiresAuth &&
+        !router.app.demo_mode
+    ) {
         next("login");
     } else {
         if (router.app.global_state_key && to.name != from.name) {

--- a/shopfloor_mobile_base/static/wms/src/router.js
+++ b/shopfloor_mobile_base/static/wms/src/router.js
@@ -18,7 +18,11 @@ const routes = [
         name: "home",
         meta: {requiresAuth: true, requiresProfile: true},
     },
-    {path: "/login", component: LoginPage, name: "login"},
+    {
+        path: "/login",
+        component: LoginPage,
+        name: "login",
+    },
     {
         path: "/settings",
         component: SettingsControlPanel,

--- a/shopfloor_mobile_base/static/wms/src/router.js
+++ b/shopfloor_mobile_base/static/wms/src/router.js
@@ -61,7 +61,6 @@ const router = new VueRouter({
 });
 router.beforeEach(async (to, from, next) => {
     await Vue.nextTick();
-    // debugger;
     if (
         !router.app.is_authenticated() &&
         to.meta.requiresAuth &&

--- a/shopfloor_mobile_base/static/wms/src/services/auth_handler_registry.js
+++ b/shopfloor_mobile_base/static/wms/src/services/auth_handler_registry.js
@@ -11,6 +11,7 @@ export class AuthHandlerMixin {
     get_params() {
         return {};
     }
+    // TODO: document on_login and on_logout
 }
 
 /**

--- a/shopfloor_mobile_base_auth_api_key/README.rst
+++ b/shopfloor_mobile_base_auth_api_key/README.rst
@@ -1,0 +1,1 @@
+wait for the bot ;)

--- a/shopfloor_mobile_base_auth_api_key/__init__.py
+++ b/shopfloor_mobile_base_auth_api_key/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/shopfloor_mobile_base_auth_api_key/__manifest__.py
+++ b/shopfloor_mobile_base_auth_api_key/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Shopfloor Mobile Base auth via API key",
+    "summary": "Provides authentication via API key to Shopfloor base mobile app",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainer": ["simahawk"],
+    "license": "AGPL-3",
+    "depends": ["shopfloor_mobile_base", "auth_api_key"],
+    "data": ["templates/assets.xml"],
+}

--- a/shopfloor_mobile_base_auth_api_key/controllers/__init__.py
+++ b/shopfloor_mobile_base_auth_api_key/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/shopfloor_mobile_base_auth_api_key/controllers/main.py
+++ b/shopfloor_mobile_base_auth_api_key/controllers/main.py
@@ -1,0 +1,10 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.addons.shopfloor_base.controllers.main import ShopfloorController
+
+# Do not extend the existing controller to not cause this error:
+#
+# odoo.addons.base_rest.models.rest_service_registration:
+# Only one REST controller can be safely declared for root path /shopfloor/
+ShopfloorController._default_auth = "api_key"

--- a/shopfloor_mobile_base_auth_api_key/readme/CONTRIBUTORS.rst
+++ b/shopfloor_mobile_base_auth_api_key/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Simone Orsi <simone.orsi@camptocamp.com>
+* Juan Miguel Sánchez Arce  <juan.sanchez@camptocamp.com>

--- a/shopfloor_mobile_base_auth_api_key/readme/CREDITS.rst
+++ b/shopfloor_mobile_base_auth_api_key/readme/CREDITS.rst
@@ -1,0 +1,3 @@
+**Financial support**
+
+* Camptocamp R&D

--- a/shopfloor_mobile_base_auth_api_key/readme/DESCRIPTION.rst
+++ b/shopfloor_mobile_base_auth_api_key/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Provide Shopfloor mobile base authentication via API key.

--- a/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
+++ b/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
@@ -49,7 +49,7 @@ Vue.component("login-api_key", {
                 })
                 .then(() => {
                     // TODO: shall we do this in $root._loadRoutes?
-                    if (this.$root.authenticated) {
+                    if (this.$root.is_authenticated()) {
                         this.$router.push({name: "home"});
                     } else {
                         this._handle_invalid_key();

--- a/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
+++ b/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
@@ -3,6 +3,7 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
+import {translation_registry} from "/shopfloor_mobile_base/static/wms/src/services/translation_registry.js";
 import {
     AuthHandlerMixin,
     auth_handler_registry,
@@ -21,7 +22,17 @@ export class ApiKeyAuthHandler extends AuthHandlerMixin {
             },
         };
     }
+
+    // on_login($root, evt, data) {
+    // No need for a handler as we set the api_key inside the login method
+    // }
+
+    // on_logout($root) {
+    // No need for a handler as the reset_on_clear flag in the config_registry
+    // is going to flush the api_key on appdata cleanup
+    // }
 }
+
 auth_handler_registry.add(new ApiKeyAuthHandler("api_key"));
 
 /**
@@ -32,33 +43,13 @@ auth_handler_registry.add(new ApiKeyAuthHandler("api_key"));
 Vue.component("login-api_key", {
     data: function () {
         return {
-            error: "",
             apikey: "",
         };
     },
     methods: {
         login: function (evt) {
-            evt.preventDefault();
-            // Call odoo application load => set the result in the local storage in json
-            this.$parent.error = "";
             this.$root.apikey = this.apikey;
-            this.$root
-                ._loadConfig()
-                .catch((error) => {
-                    this._handle_invalid_key();
-                })
-                .then(() => {
-                    // TODO: shall we do this in $root._loadRoutes?
-                    if (this.$root.is_authenticated()) {
-                        this.$router.push({name: "home"});
-                    } else {
-                        this._handle_invalid_key();
-                    }
-                });
-        },
-        _handle_invalid_key() {
-            this.error = this.$t("screen.login.error.api_key_invalid");
-            this.$root.apikey = "";
+            this.$root.login(evt);
         },
     },
     template: `
@@ -81,8 +72,13 @@ Vue.component("login-api_key", {
     `,
 });
 
-// TODO: Add translation
-// login: {
-//     api_key_placeholder: "YOUR_API_KEY_HERE",
-//     api_key_label: "API key",
-// },
+translation_registry.add("en-US.screen.login.api_key_label", "API key");
+translation_registry.add("fr-FR.screen.login.api_key_label", "Clé API");
+translation_registry.add("de-DE.screen.login.api_key_label", "API-Schlüssel");
+
+translation_registry.add("en-US.screen.login.api_key_placeholder", "YOUR_API_KEY_HERE");
+translation_registry.add("fr-FR.screen.login.api_key_placeholder", "VOTRE_CLE_API_ICI");
+translation_registry.add(
+    "de-DE.screen.login.api_key_placeholder",
+    "DEIN_API-SCHLÜSSEL_HIER"
+);

--- a/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
+++ b/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js
@@ -1,0 +1,88 @@
+/**
+ * @author Simone Orsi <simone.orsi@camptocamp.com>
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ */
+
+import {
+    AuthHandlerMixin,
+    auth_handler_registry,
+} from "/shopfloor_mobile_base/static/wms/src/services/auth_handler_registry.js";
+import {config_registry} from "/shopfloor_mobile_base/static/wms/src/services/config_registry.js";
+
+//  Register apikey storage
+config_registry.add("apikey", {default: "", reset_on_clear: true});
+
+// Provide auth handle for Odoo calls
+export class ApiKeyAuthHandler extends AuthHandlerMixin {
+    get_params($root) {
+        return {
+            headers: {
+                "API-KEY": $root.apikey,
+            },
+        };
+    }
+}
+auth_handler_registry.add(new ApiKeyAuthHandler("api_key"));
+
+/**
+ * Handle loging via API key.
+ *
+ * Conventional name: `login-` + auth_type (from app config)
+ */
+Vue.component("login-api_key", {
+    data: function () {
+        return {
+            error: "",
+            apikey: "",
+        };
+    },
+    methods: {
+        login: function (evt) {
+            evt.preventDefault();
+            // Call odoo application load => set the result in the local storage in json
+            this.$parent.error = "";
+            this.$root.apikey = this.apikey;
+            this.$root
+                ._loadConfig()
+                .catch((error) => {
+                    this._handle_invalid_key();
+                })
+                .then(() => {
+                    // TODO: shall we do this in $root._loadRoutes?
+                    if (this.$root.authenticated) {
+                        this.$router.push({name: "home"});
+                    } else {
+                        this._handle_invalid_key();
+                    }
+                });
+        },
+        _handle_invalid_key() {
+            this.error = this.$t("screen.login.error.api_key_invalid");
+            this.$root.apikey = "";
+        },
+    },
+    template: `
+    <v-form v-on:submit="login">
+        <v-text-field
+            name="apikey"
+            v-model="apikey"
+            :label="$t('screen.login.api_key_label')"
+            :placeholder="$t('screen.login.api_key_placeholder')"
+            autofocus
+            autocomplete="off"></v-text-field>
+        <div class="button-list button-vertical-list full">
+            <v-row align="center">
+                <v-col class="text-center" cols="12">
+                    <v-btn color="success" type="submit">{{ $t('screen.login.action.login') }}</v-btn>
+                </v-col>
+            </v-row>
+        </div>
+    </v-form>
+    `,
+});
+
+// TODO: Add translation
+// login: {
+//     api_key_placeholder: "YOUR_API_KEY_HERE",
+//     api_key_label: "API key",
+// },

--- a/shopfloor_mobile_base_auth_api_key/templates/assets.xml
+++ b/shopfloor_mobile_base_auth_api_key/templates/assets.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+    @author Simone Orsi <simahawk@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <template
+        id="shopfloor_app_assets"
+        inherit_id="shopfloor_mobile_base.shopfloor_app_assets"
+    >
+        <script id="script_page_login" position="after">
+        <t t-set="mod_name" t-value="'shopfloor_mobile_base_auth_api_key'" />
+          <script
+                id="script_login_api_key"
+                t-attf-src="/shopfloor_mobile_base_auth_api_key/static/wms/src/login.js?v=#{get_version(mod_name)}"
+                type="module"
+            />
+        </script>
+    </template>
+</odoo>

--- a/shopfloor_mobile_base_auth_user/README.rst
+++ b/shopfloor_mobile_base_auth_user/README.rst
@@ -1,0 +1,1 @@
+wait for the bot ;)

--- a/shopfloor_mobile_base_auth_user/__init__.py
+++ b/shopfloor_mobile_base_auth_user/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/shopfloor_mobile_base_auth_user/__manifest__.py
+++ b/shopfloor_mobile_base_auth_user/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# @author Simone Orsi <simahawk@gmail.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Shopfloor Mobile Base auth via user auth",
+    "summary": "Provides authentication via standard user login",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainer": ["simahawk"],
+    "license": "AGPL-3",
+    "depends": ["shopfloor_mobile_base", "base_rest_auth_user_service"],
+    "data": ["templates/assets.xml"],
+}

--- a/shopfloor_mobile_base_auth_user/controllers/__init__.py
+++ b/shopfloor_mobile_base_auth_user/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import main

--- a/shopfloor_mobile_base_auth_user/controllers/main.py
+++ b/shopfloor_mobile_base_auth_user/controllers/main.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.addons.shopfloor_base.controllers.main import ShopfloorController
+from odoo.addons.shopfloor_mobile_base.controllers.main import (
+    ShopfloorMobileAppController,
+)
+
+# Do not extend the existing controller to not cause this error:
+#
+# odoo.addons.base_rest.models.rest_service_registration:
+# Only one REST controller can be safely declared for root path /shopfloor/
+ShopfloorController._default_auth = "user"
+
+
+class ShopfloorMobileAppControllerUser(ShopfloorMobileAppController):
+    def _get_main_template_values(self, demo=False, **kw):
+        values = super()._get_main_template_values(demo=demo, **kw)
+        values["auth_type"] = "user"
+        return values

--- a/shopfloor_mobile_base_auth_user/readme/CONTRIBUTORS.rst
+++ b/shopfloor_mobile_base_auth_user/readme/CONTRIBUTORS.rst
@@ -1,0 +1,2 @@
+* Simone Orsi <simone.orsi@camptocamp.com>
+* Juan Miguel Sánchez Arce  <juan.sanchez@camptocamp.com>

--- a/shopfloor_mobile_base_auth_user/readme/CREDITS.rst
+++ b/shopfloor_mobile_base_auth_user/readme/CREDITS.rst
@@ -1,0 +1,3 @@
+**Financial support**
+
+* Camptocamp R&D

--- a/shopfloor_mobile_base_auth_user/readme/DESCRIPTION.rst
+++ b/shopfloor_mobile_base_auth_user/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Provide Shopfloor mobile base authentication via standard auth.

--- a/shopfloor_mobile_base_auth_user/static/wms/src/login.js
+++ b/shopfloor_mobile_base_auth_user/static/wms/src/login.js
@@ -4,6 +4,7 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
+import {translation_registry} from "/shopfloor_mobile_base/static/wms/src/services/translation_registry.js";
 import {
     AuthHandlerMixin,
     auth_handler_registry,
@@ -27,7 +28,6 @@ export class UserAuthHandler extends AuthHandlerMixin {
     }
 
     on_login($root, evt, data) {
-        const self = this;
         evt.preventDefault();
         // Call odoo application load => set the result in the local storage in json
         const odoo = $root.getOdoo({base_url: "/session/"});
@@ -36,9 +36,6 @@ export class UserAuthHandler extends AuthHandlerMixin {
             .post("auth/login", data, true)
             .then(function (response) {
                 if (response.error) {
-                    // If there is a need to handle different login error messages
-                    // depending on the response, pass the error as an argument
-                    // to def.reject
                     return def.reject();
                 }
                 return def.resolve();
@@ -108,3 +105,11 @@ Vue.component("login-user", {
     </v-form>
     `,
 });
+
+translation_registry.add("en-US.screen.login.username", "Username");
+translation_registry.add("fr-FR.screen.login.username", "Nom d'utilisateur");
+translation_registry.add("de-DE.screen.login.username", "Benutzername");
+
+translation_registry.add("en-US.screen.login.password", "Password");
+translation_registry.add("fr-FR.screen.login.password", "Mot de passe");
+translation_registry.add("de-DE.screen.login.password", "Passwort");

--- a/shopfloor_mobile_base_auth_user/static/wms/src/login.js
+++ b/shopfloor_mobile_base_auth_user/static/wms/src/login.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+ * @author Simone Orsi <simone.orsi@camptocamp.com>
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ */
+
+import {
+    AuthHandlerMixin,
+    auth_handler_registry,
+} from "/shopfloor_mobile_base/static/wms/src/services/auth_handler_registry.js";
+
+// Provide auth handle for Odoo calls
+export class UserAuthHandler extends AuthHandlerMixin {
+    // Not sure we need anything if we get a cookie in the same browser
+    get_params($root) {
+        return {
+            /**
+             * NOTE: we don't have to provide any param because the auth
+             * comes from the cookie.
+             * In the future if we want to support cross domain
+             * we'll have to provide `credentials` same-origin|include
+             * to the fetch method.
+             * */
+
+            headers: {},
+        };
+    }
+
+    on_login($root, evt, data) {
+        const self = this;
+        evt.preventDefault();
+        // Call odoo application load => set the result in the local storage in json
+        const odoo = $root.getOdoo({base_url: "/session/"});
+        const def = $.Deferred();
+        return odoo
+            .post("auth/login", data, true)
+            .then(function (response) {
+                if (response.error) {
+                    // If there is a need to handle different login error messages
+                    // depending on the response, pass the error as an argument
+                    // to def.reject
+                    return def.reject();
+                }
+                return def.resolve();
+            })
+            .catch(function (error) {
+                return def.reject();
+            });
+    }
+
+    on_logout($root) {
+        const def = $.Deferred();
+        const odoo = $root.getOdoo({base_url: "/session/"});
+        return odoo
+            .post("auth/logout", null, true)
+            .then(function () {
+                return def.resolve();
+            })
+            .catch(function () {
+                return def.reject();
+            });
+    }
+}
+auth_handler_registry.add(new UserAuthHandler("user"));
+
+/**
+ * Handle loging via user.
+ *
+ * Conventional name: `login-` + auth_type (from app config)
+ */
+Vue.component("login-user", {
+    data: function () {
+        return {
+            username: "",
+            password: "",
+        };
+    },
+    methods: {
+        login: function (evt) {
+            const data = {login: this.username, password: this.password};
+            this.$root.login(evt, data);
+        },
+    },
+    template: `
+    <v-form v-on:submit="login">
+        <v-text-field
+            name="username"
+            v-model="username"
+            :label="$t('screen.login.username')"
+            :placeholder="$t('screen.login.username')"
+            autofocus
+            autocomplete="off"></v-text-field>
+        <v-text-field
+            name="password"
+            v-model="password"
+            type="password"
+            :label="$t('screen.login.password')"
+            :placeholder="$t('screen.login.password')"
+            autofocus
+            autocomplete="off"></v-text-field>
+        <div class="button-list button-vertical-list full">
+            <v-row align="center">
+                <v-col class="text-center" cols="12">
+                    <v-btn color="success" type="submit">{{ $t('screen.login.action.login') }}</v-btn>
+                </v-col>
+            </v-row>
+        </div>
+    </v-form>
+    `,
+});

--- a/shopfloor_mobile_base_auth_user/templates/assets.xml
+++ b/shopfloor_mobile_base_auth_user/templates/assets.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+    @author Simone Orsi <simahawk@gmail.com>
+    License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+    <template
+        id="shopfloor_app_assets"
+        inherit_id="shopfloor_mobile_base.shopfloor_app_assets"
+    >
+        <script id="script_page_login" position="after">
+        <t t-set="mod_name" t-value="'shopfloor_mobile_base_auth_user'" />
+          <script
+                id="script_login_user"
+                t-attf-src="/shopfloor_mobile_base_auth_user/static/wms/src/login.js?v=#{get_version(mod_name)}"
+                type="module"
+            />
+        </script>
+    </template>
+</odoo>


### PR DESCRIPTION
Auth is now pluggable. See atomic commits for details.

In short:
- auth is now pluggable on frontend thanks to the new auth registry
- 2 new modules for handling auth: `shopfloor_mobile_base_auth_user` + `shopfloor_mobile_base_auth_api_key`
- the base auth for shopfloor_base is still `api_key` which gets overriden by the 2 modules above (which are not compatible together as you can have only one type of auth at time)
- shopfloor_mobile_base installs `shopfloor_mobile_base_auth_api_key` to make sure current installations work as before

Support for multiple auth at the same time per different app will come with https://github.com/OCA/wms/pull/316.