### PR TITLE
[14.0] Add shopfloor_workstation_label_printer

### DIFF
--- a/setup/shopfloor_workstation_label_printer/odoo/addons/shopfloor_workstation_label_printer
+++ b/setup/shopfloor_workstation_label_printer/odoo/addons/shopfloor_workstation_label_printer
@@ -1,0 +1,1 @@
+../../../../shopfloor_workstation_label_printer

--- a/setup/shopfloor_workstation_label_printer/setup.py
+++ b/setup/shopfloor_workstation_label_printer/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopfloor_workstation_label_printer/__init__.py
+++ b/shopfloor_workstation_label_printer/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/shopfloor_workstation_label_printer/__manifest__.py
+++ b/shopfloor_workstation_label_printer/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Shopfloor Workstation Label Printer",
+    "summary": "Adds a label printer configuration to the user and shopfloor workstation.",
+    "version": "14.0.1.0.0",
+    "category": "Tools",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/wms",
+    "development_status": "Alpha",
+    "license": "AGPL-3",
+    "depends": ["base_report_to_printer", "shopfloor_workstation"],
+    "data": ["views/res_users.xml", "views/shopfloor_workstation.xml"],
+    "installable": True,
+}

--- a/shopfloor_workstation_label_printer/models/__init__.py
+++ b/shopfloor_workstation_label_printer/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_users
+from . import shopfloor_workstation

--- a/shopfloor_workstation_label_printer/models/res_users.py
+++ b/shopfloor_workstation_label_printer/models/res_users.py
@@ -1,0 +1,22 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import api, fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    default_label_printer_id = fields.Many2one(
+        comodel_name="printing.printer", string="Default Label Printer"
+    )
+
+    @api.model
+    def _register_hook(self):
+        super()._register_hook()
+        self.SELF_WRITEABLE_FIELDS.extend(["default_label_printer_id"])
+        self.SELF_READABLE_FIELDS.extend(["default_label_printer_id"])
+
+    def get_delivery_label_printer(self, delivery_type):
+        self.ensure_one()
+        return self.default_label_printer_id

--- a/shopfloor_workstation_label_printer/models/shopfloor_workstation.py
+++ b/shopfloor_workstation_label_printer/models/shopfloor_workstation.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import fields, models
+
+
+class ShopfloorWorkstation(models.Model):
+    _inherit = "shopfloor.workstation"
+
+    default_label_printer_id = fields.Many2one(
+        comodel_name="printing.printer", string="Default Label Printer"
+    )
+
+    def set_as_default_on_user(self, user):
+        super().set_as_default_on_user(user)
+        if self.default_label_printer_id:
+            user.default_label_printer_id = self.default_label_printer_id
+        return

--- a/shopfloor_workstation_label_printer/readme/CONTRIBUTORS.rst
+++ b/shopfloor_workstation_label_printer/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/shopfloor_workstation_label_printer/readme/DESCRIPTION.rst
+++ b/shopfloor_workstation_label_printer/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+With this module a default label printer can be linked to a shopfloor
+workstation profile and to an Odoo user profile.
+
+When the user select a workstation profile on the mobile application is
+default label printer will change on Odoo side.

--- a/shopfloor_workstation_label_printer/views/res_users.xml
+++ b/shopfloor_workstation_label_printer/views/res_users.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<odoo>
+  <record model="ir.ui.view" id="view_users_form">
+    <field name="name">res.users.form.shopfloor.workstation.delivery.printer</field>
+    <field name="model">res.users</field>
+    <field name="inherit_id" ref="base_report_to_printer.view_users_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//group[@name='printing']" position="inside">
+        <field name="default_label_printer_id" options="{'no_create': True}" />
+      </xpath>
+    </field>
+  </record>
+
+  <record model="ir.ui.view" id="view_users_form_simple_modif">
+    <field
+            name="name"
+        >res.users.form.simple.shopfloor.workstation.delivery.printer</field>
+    <field name="model">res.users</field>
+    <field
+            name="inherit_id"
+            ref="base_report_to_printer.view_users_form_simple_modif"
+        />
+    <field name="arch" type="xml">
+      <xpath expr="//group[@name='printing']" position="inside">
+        <field
+                    name="default_label_printer_id"
+                    readonly="0"
+                    options="{'no_create': True}"
+                />
+      </xpath>
+    </field>
+  </record>
+</odoo>

--- a/shopfloor_workstation_label_printer/views/shopfloor_workstation.xml
+++ b/shopfloor_workstation_label_printer/views/shopfloor_workstation.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<odoo>
+  <record model="ir.ui.view" id="shopfloor_workstation_form_view">
+    <field name="name">shopfloor.workstation.form.workstation.label.printer</field>
+    <field name="model">shopfloor.workstation</field>
+    <field
+            name="inherit_id"
+            ref="shopfloor_workstation.shopfloor_workstation_form_view"
+        />
+    <field name="arch" type="xml">
+      <field name="printing_printer_id" position="after">
+        <field name="default_label_printer_id" options="{'no_create': True}" />
+      </field>
+    </field>
+  </record>
+
+</odoo>


### PR DESCRIPTION
With this module a default label printer can be linked to a shopfloor
workstation profile and to an Odoo user profile.

When the user select a workstation profile on the mobile application is
default label printer will change on Odoo side.