### PR TITLE
[14.0][FIX] Fix reception_screen next pack button

### DIFF
--- a/stock_reception_screen/models/stock_reception_screen.py
+++ b/stock_reception_screen/models/stock_reception_screen.py
@@ -506,7 +506,7 @@ class StockReceptionScreen(models.Model):
         new_move_vals = move._split(qty)
         if new_move_vals:
             new_move = self.env["stock.move"].create(new_move_vals)
-            new_move._action_confirm()
+            new_move = new_move._action_confirm(merge=False)
             return new_move
         return move
 


### PR DESCRIPTION
When receiving a move in multiple step (packages), the reception screen
moves back to the main screen. When it should offer to enter the next
pack. This is the normal workflow in v13.

Without this change for picking with a single move the new stock move
is assigned to a new picking and the current picking in the reception
screen is done.