### PR TITLE
[14.0][FIX] shopfloor_mobile: Display location as TODO as long as the artic…

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/batch_picking_line_detail.js
+++ b/shopfloor_mobile/static/wms/src/components/batch_picking_line_detail.js
@@ -38,7 +38,7 @@ export var batch_picking_line = Vue.component("batch-picking-line-detail", {
     :key="'batch-picking-line-detail-1'"
     :record="line"
     :options="{main: true, key_title: 'location_src.name', title_action_field: {action_val_path: 'location_src.barcode'}}"
-    :card_color="utils.colors.color_for('screen_step_done')"
+    :card_color="utils.colors.color_for(articleScanned ? 'screen_step_done': 'screen_step_todo')"
     />
   <item-detail-card
     :key="'batch-picking-line-detail-2'"


### PR DESCRIPTION
…le is not scanned

Before this change, the location into the screen displayed at the start of a line processing was always marked as done. With this change, the location is marked as done only when the location \ product \ lot has been scanned.