### PR TITLE
[13.0] Shopfloor: Control the display of the virtual keyboard (Gboard) + SECURITY FIX

### DIFF
--- a/shopfloor_mobile_base/README.rst
+++ b/shopfloor_mobile_base/README.rst
@@ -199,6 +199,7 @@ Contributors
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Design
 ~~~~~~

--- a/shopfloor_mobile_base/readme/CONTRIBUTORS.rst
+++ b/shopfloor_mobile_base/readme/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Design
 ~~~~~~

--- a/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
+++ b/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
@@ -4,6 +4,8 @@
  * @author Raphaël Reverdy <raphael.reverdy@akretion.com>
  * Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
  * @author Simone Orsi <simahawk@gmail.com>
+ * Copyright 2021 BCIM (http://www.bcim.be)
+ * @author Jacques-Etienne Baudoux <je@bcim.be>
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
@@ -18,14 +20,21 @@ Vue.component("searchbar", {
             type: Boolean,
             default: true,
         },
-        // Allow searchbar to steal focus on screen reload
-        reload_steal_focus: {
+        forcefocus: {
             type: Boolean,
-            default: true,
+            default: false,
         },
         autocomplete: {
             type: String,
             default: "off",
+        },
+        input_type: {
+            type: String,
+            default: "text",
+        },
+        input_inputmode: {
+            type: String,
+            default: "text",
         },
         input_placeholder: String,
         input_data_type: String,
@@ -35,9 +44,18 @@ Vue.component("searchbar", {
         },
     },
     mounted: function() {
-        this.$root.event_hub.$on("screen:reload", this.on_screen_reload);
+        // As the inputMode is set to none when inserted in the DOM, we need to force the focus
+        if (this.autofocus) this.$refs.searchbar.focus();
     },
     methods: {
+        show_virtual_keyboard: function(elem) {
+            elem.inputMode = this.input_inputmode;
+            elem.classList.add("searchbar-keyboard");
+        },
+        hide_virtual_keyboard: function(elem) {
+            elem.inputMode = "none";
+            elem.classList.remove("searchbar-keyboard");
+        },
         search: function(e) {
             e.preventDefault();
             // Talk to parent
@@ -49,12 +67,21 @@ Vue.component("searchbar", {
         },
         reset: function() {
             this.entered = "";
+            this.hide_virtual_keyboard(this.$refs.searchbar);
         },
-        on_screen_reload: function(evt) {
-            if (this.reload_steal_focus)
-                $(this.$el)
-                    .find(":input[name=searchbar]")
-                    .focus();
+        onclick: function(e) {
+            if (e.target.inputMode == "none") {
+                this.show_virtual_keyboard(e.target);
+            } else {
+                this.hide_virtual_keyboard(e.target);
+            }
+        },
+        onfocus: function(e) {
+            e.target.classList.add("searchbar-scan");
+        },
+        onblur: function(e) {
+            if (this.forcefocus) return e.target.click();
+            e.target.classList.remove("searchbar-scan");
         },
     },
 
@@ -65,13 +92,21 @@ Vue.component("searchbar", {
       ref="form"
       class="searchform"
       >
-    <v-text-field
-      name="searchbar"
-      required v-model="entered"
-      :placeholder="input_placeholder"
-      :autofocus="autofocus ? 'autofocus' : null"
-      :autocomplete="autocomplete"
-      />
+    <div class="v-input v-text-field">
+      <input
+        ref="searchbar"
+        required v-model="entered"
+        :type="input_type"
+        :inputmode="autofocus ? 'none' : input_inputmode"
+        :placeholder="input_placeholder"
+        :autofocus="autofocus ? 'autofocus' : null"
+        :autocomplete="autocomplete"
+        @focus="onfocus"
+        @blur="onblur"
+        @click="onclick"
+        class="searchbar"
+        />
+      </div>
   </v-form>
   `,
 });

--- a/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
+++ b/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
@@ -36,6 +36,7 @@ Vue.component("searchbar", {
             type: String,
             default: "text",
         },
+        input_label: String,
         input_placeholder: String,
         input_data_type: String,
         reset_on_submit: {
@@ -89,10 +90,10 @@ Vue.component("searchbar", {
   <v-form
       v-on:submit="search"
       :data-type="input_data_type"
-      ref="form"
       class="searchform"
       >
-    <div class="v-input v-text-field">
+    <div class="searchbar v-input v-text-field">
+      <label class="v-label" v-if="input_label">{{ input_label }}</label>
       <input
         ref="searchbar"
         required v-model="entered"
@@ -104,7 +105,6 @@ Vue.component("searchbar", {
         @focus="onfocus"
         @blur="onblur"
         @click="onclick"
-        class="searchbar"
         />
       </div>
   </v-form>

--- a/shopfloor_mobile_base/static/wms/src/css/main.css
+++ b/shopfloor_mobile_base/static/wms/src/css/main.css
@@ -470,8 +470,24 @@ main.v-content > .v-content__wrap > .header .container {
     position: absolute;
 }
 
+/* login */
+.login-wrapper .searchbar input {
+    padding: 50px 10px;
+    text-align: center;
+    font-size: 2rem !important;
+}
+
 /* searchbar */
-.v-text-field input.searchbar {
+.searchbar {
+    position: relative;
+}
+.searchbar label.v-label {
+    top: -20px;
+    left: 0px;
+    right: auto;
+    position: absolute;
+}
+.searchbar input {
     margin-bottom: 8px;
     padding: 5px;
     line-height: 1.5;
@@ -486,13 +502,13 @@ main.v-content > .v-content__wrap > .header .container {
         background-color: #fa9696;
     }
 }
-.v-text-field input.searchbar-keyboard {
+.searchbar input.searchbar-keyboard {
     caret-color: auto !important;
 }
-.v-text-field input.searchbar-keyboard:focus::placeholder {
+.searchbar input.searchbar-keyboard:focus::placeholder {
     color: transparent;
 }
-.v-text-field input.searchbar-scan {
+.searchbar input.searchbar-scan {
     caret-color: transparent;
     /*border-radius: 10%;*/
     animation-name: scanning;

--- a/shopfloor_mobile_base/static/wms/src/css/main.css
+++ b/shopfloor_mobile_base/static/wms/src/css/main.css
@@ -469,3 +469,36 @@ main.v-content > .v-content__wrap > .header .container {
     */
     position: absolute;
 }
+
+/* searchbar */
+.v-text-field input.searchbar {
+    margin-bottom: 8px;
+    padding: 5px;
+    line-height: 1.5;
+}
+@keyframes scanning {
+    0%,
+    40%,
+    100% {
+        background-color: #ffe0e0;
+    }
+    20% {
+        background-color: #fa9696;
+    }
+}
+.v-text-field input.searchbar-keyboard {
+    caret-color: auto !important;
+}
+.v-text-field input.searchbar-keyboard:focus::placeholder {
+    color: transparent;
+}
+.v-text-field input.searchbar-scan {
+    caret-color: transparent;
+    /*border-radius: 10%;*/
+    animation-name: scanning;
+    animation-duration: 3s;
+    animation-timing-function: ease-out;
+    animation-delay: 0;
+    animation-direction: normal;
+    animation-iteration-count: infinite;
+}

--- a/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
+++ b/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
@@ -10,13 +10,13 @@ const messages_en = {
     screen: {
         login: {
             title: "Login",
-            api_key_placeholder: "YOUR_API_KEY_HERE",
+            api_key_placeholder: "Scan your badge",
             api_key_label: "API key",
             action: {
                 login: "Login",
             },
             error: {
-                api_key_invalid: "Invalid API KEY",
+                api_key_invalid: "Login failed. Invalid API key",
             },
         },
         home: {

--- a/shopfloor_mobile_base/static/wms/src/loginpage.js
+++ b/shopfloor_mobile_base/static/wms/src/loginpage.js
@@ -28,11 +28,10 @@ export var LoginPage = Vue.component("login-page", {
         },
     },
     methods: {
-        login: function(evt) {
-            evt.preventDefault();
+        login: function(apikey) {
             // Call odoo application load => set the result in the local storage in json
             this.error = "";
-            this.$root.apikey = this.apikey;
+            this.$root.apikey = apikey.text;
             this.$root
                 ._loadConfig()
                 .catch(error => {
@@ -69,28 +68,14 @@ export var LoginPage = Vue.component("login-page", {
                     </v-alert>
                 </v-col>
             </v-row>
-            <v-row
-                align="center"
-                justify="center">
-                <v-col cols="12" sm="8" md="4">
-                    <div class="login-wrapper">
-                        <v-form v-on:submit="login">
-                            <v-text-field
-                                name="apikey"
-                                v-model="apikey"
-                                :label="$t('screen.login.api_key_label')"
-                                :placeholder="$t('screen.login.api_key_placeholder')"
-                                autofocus
-                                autocomplete="off"></v-text-field>
-                            <div class="button-list button-vertical-list full">
-                                <v-row align="center">
-                                    <v-col class="text-center" cols="12">
-                                        <v-btn color="success" type="submit">{{ $t('screen.login.action.login') }}</v-btn>
-                                    </v-col>
-                                </v-row>
-                            </div>
-                        </v-form>
-                    </div>
+            <v-row class="login-wrapper">
+                <v-col class="text-center" cols="12">
+                <searchbar
+                    v-on:found="login"
+                    :input_label="$t('screen.login.api_key_label')"
+                    :input_placeholder="$t('screen.login.api_key_placeholder')"
+                    forcefocus
+                    input_type="password"/>
                 </v-col>
             </v-row>
             <div class="button-list button-vertical-list full">


### PR DESCRIPTION
## Manage virtual keyboard
On an android device having no physical keyboard, the virtual keyboard (Gboard) is always displayed by default when an input field has focus which is what we have on each screen when something must be scanned. This is quite annoying as it hides most of the screen info on small mobile devices.

This change hides by default the virtual keyboard while keeping focus to collect the scanned input. The field shows a glowing light red to indicate that it is ready to collect a scanned input.
When clicking on the input field already having the focus, this will toggle the virtual keyboard and a cursor in the input field. You can still scan the input. If the input field lost the focus and you click on it, it will only acquire the focus for scanning and show back the glowing light red to indicate is it back ready to collect data.

## Login Security fix
Set input type="password" for the login input field to prevent Gboard to automatically add the api key in the location dictionary suggestions

@simahawk @lmignon @sebalix @hparfr 