### PR TITLE
[13.0] shopfloor: fix computation of contained packagings

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -1,6 +1,7 @@
 /**
  * Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
  * @author Simone Orsi <simahawk@gmail.com>
+ * Copyright 2021 Jacques-Etienne Baudoux (BCIM)
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
@@ -194,14 +195,23 @@ export var PackagingQtyPickerMixin = {
          */
         contained_packaging: function() {
             const self = this;
-            let res = {};
+            let res = {},
+                qty_per_pkg,
+                remaining,
+                elected_next_pkg;
             const packaging = this.sorted_packaging;
             _.forEach(packaging, function(pkg, i) {
-                if (packaging[i + 1]) {
-                    const next_pkg = packaging[i + 1];
+                const next_pkgs = packaging.slice(i + 1);
+                remaining = undefined;
+                _.every(next_pkgs, function(next_pkg) {
+                    [qty_per_pkg, remaining] = self._qty_by_pkg(next_pkg.qty, pkg.qty);
+                    elected_next_pkg = next_pkg;
+                    return remaining;
+                });
+                if (remaining === 0) {
                     res[pkg.id] = {
-                        pkg: next_pkg,
-                        qty: self._qty_by_pkg(next_pkg.qty, pkg.qty)[0],
+                        pkg: elected_next_pkg,
+                        qty: qty_per_pkg,
                     };
                 }
             });


### PR DESCRIPTION
If a packaging is not a multiple of the next packaging, the displayed info was wrong.
In this example, a vendor pallet has 54 TU and a stored pallet has 42 TU.
The vendor pallet was computed as 1 Pallet which is wrong.
The new implementation looks to further packagings until it finds a multiple.

## Before
![QtyByPkg-before](https://user-images.githubusercontent.com/7802725/147684229-0d9b5eab-49b1-4ed5-9193-6fc2b05e60c1.png)

## After
![QtyByPkg-after](https://user-images.githubusercontent.com/7802725/147684237-ff003aa4-3626-4a0f-b1ea-1e4fd1a3a52d.png)

cc @simahawk @sebalix @lmignon @jgrandguillaume 