### PR TITLE
[13.0][IMP] shopfloor: performance improvement

### DIFF
--- a/shopfloor/models/stock_package_level.py
+++ b/shopfloor/models/stock_package_level.py
@@ -1,11 +1,16 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import models
+from odoo import fields, models
 
 
 class StockPackageLevel(models.Model):
     _name = "stock.package_level"
     _inherit = ["stock.package_level", "shopfloor.priority.postpone.mixin"]
+
+    # we search package levels based on their package in some workflows
+    package_id = fields.Many2one(index=True)
+    # allow domain on picking_id.xxx without too much perf penalty
+    picking_id = fields.Many2one(auto_join=True)
 
     def explode_package(self):
         """Unlink but keep the moves.


### PR DESCRIPTION
On `stock.package_level`, add an index on `package_id` and automatically
join `stock_picking` records through `picking_id` to improve performance.

Single pack transfer scenario is performing search operations on these fields.

The same changes have been applied on `stock.move.line` in this commit: 30149ce6c