### PR TITLE
[14.0][FIX] shopfloor_mobile_base: Ensure the right menu id is initialized …

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
@@ -35,6 +35,11 @@ export var ScenarioBaseMixin = {
         this.menu_item_id = this._get_menu_item_id();
     },
     beforeRouteUpdate(to, from, next) {
+        // force the menu id to the one from the menu since at this stage
+        // the new route is not yet applied but a call to odoo could
+        // be done when entering into the init state and this call must be
+        // done with the right menu_item_id
+        this.menu_item_id = to.params.menu_id;
         // Load initial state
         this._state_load(to.params.state);
         next();


### PR DESCRIPTION
…when state is loaded

The init state is called by the  bedoreRouteUpdate method of the router. At this stage, the new route is not yet set into the contexte and therefore, the menu item id is still the one from the previous route. To ensure that the new menu id is properly set before the init state is entered, we force the menu id to the one of the new route. Call to odoo into the enter method of the init state will be made with the right menu id into the request headers

fixes #359