### PR TITLE
[14.0][FIX] fixing .gitignore lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ build/
 develop-eggs/
 dist/
 eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
The line
lib/
in the file .gitignore
ignores all directories with the name lib
That is not useful because of the directory 
shopfloor_mobile_base/static/wms/src/lib