### PR TITLE
[13.0] shopfloor: refactor the packaging quantity picker - fixup!

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -211,8 +211,11 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
             },
         },
     },
+    created: function() {
+        // Propagate the newly initialized quantity to the parent component
+        this.$root.trigger("qty_edit", this.qty_done);
+    },
     updated: function() {
-        // Put in updated to prevent triggerring when the component is initialized
         this.$root.trigger("qty_edit", this.qty_done);
     },
     computed: {


### PR DESCRIPTION
When the component is initialized, the shown quantity must be propagated to the root component otherwise it doesn't know the validated quantity.

In the location content transfer, the first line works properly but when the second line is displayed, while the quantity is shown properly, the quantity of the previous line was send in the endpoint call. On refresh, the quantity was also lost.

cc @lmignon @simahawk @sebalix 

Already fixed the V14.0 migration PR