### PR TITLE
[14.0]Fix shopfloor edit picking carrier form

### DIFF
--- a/shopfloor/services/forms/picking_form.py
+++ b/shopfloor/services/forms/picking_form.py
@@ -46,7 +46,10 @@ class ShopfloorPickingFormValidator(Component):
     _usage = "form_edit_stock_picking.validator"
 
     def get(self):
-        return {}
+        return {
+            "id": {"type": "integer", "rename": "_id"},
+            "_id": {"type": "integer"},
+        }
 
     def update(self):
         return {

--- a/shopfloor_mobile_base/static/wms/src/scenario/form.js
+++ b/shopfloor_mobile_base/static/wms/src/scenario/form.js
@@ -72,7 +72,7 @@ const Form = {
                 });
         },
         _getFormData: function (record_id) {
-            this.odoo.call(record_id, {}, "GET").then(this._load_form_data);
+            this.odoo.get(record_id + "/get").then(this._load_form_data);
         },
         _load_form_data: function (result) {
             this.odoo_data = result.data || {};


### PR DESCRIPTION
There is an issue with the get url on the form although there is two url
options one with `/get` at the end and one without. Only the former works.
The one not working returns a 405.
This is why the call is changed in the js file.

Another problem for both url is their route are recorded with <int:id>
instead of <int:_id> wich is the default for a get route to work with
the `base_rest` module.
The workaround for this is to add a validator for the `id` parameter.