### PR TITLE
[14.0][FIX] shopfloor: fetch lot related to current product(s)

### DIFF
--- a/shopfloor/actions/search.py
+++ b/shopfloor/actions/search.py
@@ -46,11 +46,17 @@ class SearchAction(Component):
             product = packaging.product_id
         return product
 
-    def lot_from_scan(self, barcode):
+    def lot_from_scan(self, barcode, products=None, limit=1):
         model = self.env["stock.production.lot"]
         if not barcode:
             return model.browse()
-        return model.search([("name", "=", barcode)], limit=1)
+        domain = [
+            ("company_id", "=", self.env.company.id),
+            ("name", "=", barcode),
+        ]
+        if products:
+            domain.append(("product_id", "in", products.ids))
+        return model.search(domain, limit=limit)
 
     def generic_packaging_from_scan(self, barcode):
         model = self.env["product.packaging"]

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -367,7 +367,7 @@ class Checkout(Component):
         if product:
             return self._select_lines_from_product(picking, selection_lines, product)
 
-        lot = search.lot_from_scan(barcode)
+        lot = search.lot_from_scan(barcode, products=picking.move_lines.product_id)
         if lot:
             return self._select_lines_from_lot(picking, selection_lines, lot)
 
@@ -731,7 +731,7 @@ class Checkout(Component):
             product_lines = selected_lines.filtered(lambda l: l.product_id == product)
             return self._switch_line_qty_done(picking, selected_lines, product_lines)
 
-        lot = search.lot_from_scan(barcode)
+        lot = search.lot_from_scan(barcode, products=selected_lines.product_id)
         if lot:
             lot_lines = selected_lines.filtered(lambda l: l.lot_id == lot)
             return self._switch_line_qty_done(picking, selected_lines, lot_lines)

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -456,7 +456,7 @@ class ClusterPicking(Component):
         if product and move_line.product_id == product:
             return self._scan_line_by_product(picking, move_line, product)
 
-        lot = search.lot_from_scan(barcode)
+        lot = search.lot_from_scan(barcode, products=move_line.product_id)
         if lot and move_line.lot_id == lot:
             return self._scan_line_by_lot(picking, move_line, lot)
 
@@ -885,7 +885,7 @@ class ClusterPicking(Component):
         response_ok_func = self._response_for_scan_destination
         response_error_func = self._response_for_change_pack_lot
         change_package_lot = self._actions_for("change.package.lot")
-        lot = search.lot_from_scan(barcode)
+        lot = search.lot_from_scan(barcode, products=move_line.product_id)
         if lot:
             response = change_package_lot.change_lot(
                 move_line, lot, response_ok_func, response_error_func

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -549,7 +549,7 @@ class LocationContentTransfer(Component):
             else:
                 return self._response_for_scan_destination(location, package_level)
 
-        lot = search.lot_from_scan(barcode)
+        lot = search.lot_from_scan(barcode, products=package_move_lines.product_id)
         if lot and lot in package_move_lines.mapped("lot_id"):
             if lot in other_move_lines.mapped("lot_id"):
                 return self._response_for_start_single(
@@ -603,7 +603,7 @@ class LocationContentTransfer(Component):
             else:
                 return self._response_for_scan_destination(location, move_line)
 
-        lot = search.lot_from_scan(barcode)
+        lot = search.lot_from_scan(barcode, products=move_line.product_id)
         if lot and lot == move_line.lot_id:
             return self._response_for_scan_destination(location, move_line)
 

--- a/shopfloor_delivery_shipment/services/delivery_shipment.py
+++ b/shopfloor_delivery_shipment/services/delivery_shipment.py
@@ -113,13 +113,20 @@ class DeliveryShipment(Component):
                     shipment_advice, message=message
                 )
         search = self._actions_for("search")
+        # Look for an operation
         scanned_picking = search.picking_from_scan(barcode)
         if scanned_picking:
             return self._scan_picking(shipment_advice, scanned_picking)
+        # Look for a package
         scanned_package = search.package_from_scan(barcode)
         if scanned_package:
             return self._scan_package(shipment_advice, scanned_package)
-        scanned_lot = search.lot_from_scan(barcode)
+        # Look for a lot (restricted to the relevant products as a lot number
+        # can be shared by different products)
+        move_lines = self.env["stock.move.line"].search(
+            self._find_move_lines_domain(shipment_advice)
+        )
+        scanned_lot = search.lot_from_scan(barcode, products=move_lines.product_id)
         if scanned_lot:
             return self._scan_lot(shipment_advice, scanned_lot)
         scanned_product = search.product_from_scan(barcode)

--- a/shopfloor_manual_product_transfer/services/manual_product_transfer.py
+++ b/shopfloor_manual_product_transfer/services/manual_product_transfer.py
@@ -248,8 +248,9 @@ class ManualProductTransfer(Component):
                     message=self.msg_store.recovered_previous_session(),
                 )
         # Search by lot
-        lot = search.lot_from_scan(barcode)
-        if lot:
+        lots = search.lot_from_scan(barcode, limit=None)
+        lot = None
+        for lot in lots:
             product = lot.product_id
             existing_move_lines = self._find_user_move_lines(
                 location, lot.product_id, lot=lot
@@ -449,7 +450,7 @@ class ManualProductTransfer(Component):
         search = self._actions_for("search")
         # Check if the lot matches if any
         if lot:
-            scanned_lot = search.lot_from_scan(barcode)
+            scanned_lot = search.lot_from_scan(barcode, products=product)
             # Barcode is not a lot
             if not scanned_lot:
                 return self._response_for_confirm_quantity(


### PR DESCRIPTION
In Odoo a lot number can be shared by multiple lots as soon as the product is different.
This has to be taken into account by Shopfloor each time we scan a lot number by restricting the search to relevant products, or it could result unexpected result (a "Barcode not found" for instance).

**TODO:**
- [x] fix the delivery shipment scenario

Ref. 3261