### PR TITLE
[14.0][FIX] stock_picking_consolidation_priority: fix related to v14 core change

### DIFF
--- a/stock_picking_consolidation_priority/models/stock_move.py
+++ b/stock_picking_consolidation_priority/models/stock_move.py
@@ -121,4 +121,4 @@ class StockMove(models.Model):
                 [[("id", "in", move_ids)], self._consolidate_priority_domain()]
             )
         )
-        moves.write(self._consolidate_priority_values())
+        moves.picking_id.write(self._consolidate_priority_values())

--- a/stock_picking_consolidation_priority/tests/test_consolidation_priority.py
+++ b/stock_picking_consolidation_priority/tests/test_consolidation_priority.py
@@ -298,6 +298,16 @@ class TestConsolidationPriority(SavepointCase):
                 ),
             ),
         )
+        changed_pickings = changed_moves.picking_id
+        unchanged_pickings = unchanged_moves.picking_id
+        changed_ok = all(
+            picking.priority == expected_priority for picking in changed_pickings
+        )
+        unchanged_ok = all(
+            picking.priority == PROCUREMENT_PRIORITIES[0][0]
+            for picking in unchanged_pickings
+        )
+        self.assertTrue(changed_ok and unchanged_ok)
 
     def assert_default_priority(self):
         self.assert_priority(


### PR DESCRIPTION
Following this v14 core change:

* https://github.com/odoo/odoo/commit/e40553723b893bcd2244e9b9fcc5c1a7e1bf27d3

The priority field on stock.move is now a computed and it is the one on
the picking that is stored to the db.