### PR TITLE
[14.0][FIX] shopfloor_mobile: fix translations

### DIFF
--- a/shopfloor_mobile/static/wms/src/i18n/add_translations_to_registry.js
+++ b/shopfloor_mobile/static/wms/src/i18n/add_translations_to_registry.js
@@ -1,4 +1,4 @@
 import {translation_registry} from "/shopfloor_mobile_base/static/wms/src/services/translation_registry.js";
 
-translation_registry.load("fr-FR", "/shopfloor_mobile/static/src/js/i18n/fr.json");
-translation_registry.load("en-US", "/shopfloor_mobile/static/src/js/i18n/en.json");
+translation_registry.load("fr-FR", "/shopfloor_mobile/static/wms/src/i18n/fr.json");
+translation_registry.load("en-US", "/shopfloor_mobile/static/wms/src/i18n/en.json");


### PR DESCRIPTION
There are some rendering issues regarding translations, seems the JSON files weren't loaded correctly (404 errors when loading the app):
**Before:**
![image](https://user-images.githubusercontent.com/5315285/154274573-1f99a61f-5824-46e8-a2e3-f57f41eba619.png)
![image](https://user-images.githubusercontent.com/5315285/154274618-f062eaa8-82c6-44ad-aacb-dd75c3ef937e.png)

**After:**
![image](https://user-images.githubusercontent.com/5315285/154275246-7f26d53d-759c-45e9-ba55-a5fa11bfd804.png)

Ref. 3292