### PR TITLE
[IMP] delivery_carrier_preference: access rights for stock user

### DIFF
--- a/delivery_carrier_preference/security/ir.model.access.csv
+++ b/delivery_carrier_preference/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_delivery_carrier_preference,delivery.carrier.preference,model_delivery_carrier_preference,sales_team.group_sale_salesman,1,0,0,0
 access_delivery_carrier_preference_sales_manager,delivery.carrier.preference,model_delivery_carrier_preference,sales_team.group_sale_manager,1,1,1,1
+access_delivery_carrier_preference_stock_user,"delivery.carrier.preference",model_delivery_carrier_preference,stock.group_stock_user,1,0,0,0
+access_delivery_carrier_preference_stock_manager,"delivery.carrier.preference",model_delivery_carrier_preference,stock.group_stock_manager,1,1,1,1


### PR DESCRIPTION
The same way access rights are defined on shipping methods in standard `delivery` addon:
https://github.com/odoo/odoo/blob/14.0/addons/delivery/security/ir.model.access.csv