### PR TITLE
[14.0][FIX] delivery_carrier_preference: fix dependency

### DIFF
--- a/delivery_carrier_preference/__manifest__.py
+++ b/delivery_carrier_preference/__manifest__.py
@@ -13,7 +13,7 @@
     "depends": [
         "delivery",
         "product_total_weight_from_packaging",
-        "stock_available_to_promise_release",
+        "sale_stock_available_to_promise_release",
         "stock_picking_group_by_partner_by_carrier",
     ],
     "data": [

--- a/delivery_carrier_preference/views/stock_move.xml
+++ b/delivery_carrier_preference/views/stock_move.xml
@@ -15,7 +15,7 @@
         <field name="model">stock.move</field>
         <field
             name="inherit_id"
-            ref="stock_available_to_promise_release.view_move_release_tree"
+            ref="sale_stock_available_to_promise_release.view_move_release_tree"
         />
         <field name="arch" type="xml">
             <field name="ordered_available_to_promise_uom_qty" position="after">


### PR DESCRIPTION
`weight` field isn't added on stock move tree view by `stock_available_to_promise_release` but by `sale_stock_available_to_promise_release`.

As we also depend on `delivery` which already depends on `sale`, it is not an issue to depend on `sale_stock_available_to_promise_release`.