### PR TITLE
[14.0] Improve shopfloor line priority search

### DIFF
--- a/shopfloor/actions/move_line_search.py
+++ b/shopfloor/actions/move_line_search.py
@@ -104,7 +104,7 @@ class MoveLineSearch(Component):
 
     def counters_for_lines(self, lines):
         # Not using mapped/filtered to support simple lists and generators
-        priority_lines = [x for x in lines if x.picking_id.priority == "1"]
+        priority_lines = [x for x in lines if int(x.picking_id.priority or "0") > 0]
         return {
             "lines_count": len(lines),
             "picking_count": len({x.picking_id.id for x in lines}),


### PR DESCRIPTION
Yes in Odoo core since v14 there is only "0" and "1" priority, but for some
implementation this may change.
The fact that all priority higher than zero should be included seems
logical.

For reference here is the implementation on v13

https://github.com/OCA/wms/blob/9e5e9c97c85f905868221ad47c2d97577ffdfe76/shopfloor/actions/move_line_search.py#L105