### PR TITLE
[14.0][FIX] s_a_t_p_release: fix computation of 'previous_promised_qty'

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -114,7 +114,7 @@ class StockMove(models.Model):
         horizon_date = self._promise_reservation_horizon_date()
         if horizon_date:
             sql += (
-                " AND (m.need_release IS true AND m.date_deadline <= %(horizon)s "
+                " AND (m.need_release IS true AND m.date <= %(horizon)s "
                 "      OR m.need_release IS false)"
             )
             params["horizon"] = horizon_date

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -95,10 +95,7 @@ class PromiseReleaseCommonCase(common.SavepointCase):
             )
         pickings = cls._pickings_in_group(group)
         pickings.mapped("move_lines").write(
-            {
-                "date_priority": date or fields.Datetime.now(),
-                "date_deadline": date or fields.Datetime.now(),
-            }
+            {"date_priority": date or fields.Datetime.now()}
         )
         return pickings
 

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -255,7 +255,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.env.company.stock_reservation_horizon = 1
         with freeze_time("2019-09-03"):
             # set expected date for picking moves far in the future
-            picking.move_lines.write({"date_deadline": "2019-09-10"})
+            picking.move_lines.write({"date": "2019-09-10"})
             # its quantity won't be counted in previously reserved
             # and we get 3 more on the next one
             # promised qty is 0 because the picking is excluded by its date
@@ -267,8 +267,8 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             )
 
             # do the same for picking 2
-            picking2_orig_date_expected = picking2.move_lines.date_deadline
-            picking2.move_lines.write({"date_deadline": "2019-09-10"})
+            picking2_orig_date_expected = picking2.move_lines.date
+            picking2.move_lines.write({"date": "2019-09-10"})
             # since we modified date_expected, force recomputation of the field
             self.env["stock.move"].invalidate_cache(
                 fnames=["previous_promised_qty", "ordered_available_to_promise_uom_qty"]
@@ -284,8 +284,8 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                 picking4.move_lines.ordered_available_to_promise_uom_qty, 0
             )
 
-            picking3_orig_date_expected = picking3.move_lines.date_deadline
-            picking3.move_lines.write({"date_deadline": "2019-09-10"})
+            picking3_orig_date_expected = picking3.move_lines.date
+            picking3.move_lines.write({"date": "2019-09-10"})
             # since we modified date_expected, force recomputation of the field
             self.env["stock.move"].invalidate_cache(
                 fnames=["previous_promised_qty", "ordered_available_to_promise_uom_qty"]
@@ -306,10 +306,10 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
 
             # set a higher priority for picking 5
             # (restoring previous date_expected values for other pickings before)
-            picking2.move_lines.date_deadline = picking2_orig_date_expected
-            picking3.move_lines.date_deadline = picking3_orig_date_expected
+            picking2.move_lines.date = picking2_orig_date_expected
+            picking3.move_lines.date = picking3_orig_date_expected
             picking5.move_lines.write(
-                {"date_deadline": "2019-09-01", "date_priority": "2019-09-01"}
+                {"date": "2019-09-01", "date_priority": "2019-09-01"}
             )
             # Put 23 in stock. Available:
             #  5 for the released move.

--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -44,7 +44,7 @@
         <field name="inherit_id" ref="stock.view_move_form" />
         <field eval="900" name="priority" />
         <field name="arch" type="xml">
-            <field name="date_deadline" position="attributes">
+            <field name="date" position="attributes">
                 <attribute name="string">Shipment date</attribute>
             </field>
             <group name="main_grp_col2" position="inside">


### PR DESCRIPTION
In 13.0 the field used on 'stock.move' was `date_expected` which has been merged into `date` field in 14.0:
https://github.com/odoo/odoo/commit/57f805f71e9357870dfc2498c5ef72ebd8ab7273
This piece of code has been updated during the 14.0 migration to use `date_deadline` by mistake.

Ref. 3446