### PR TITLE
[14.0] shopfloor_mobile_base: add event on drawer transition

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/screen.js
+++ b/shopfloor_mobile_base/static/wms/src/components/screen.js
@@ -4,6 +4,8 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
+import event_hub from "../services/event_hub.js";
+
 /* eslint-disable strict */
 Vue.component("Screen", {
     props: {
@@ -76,9 +78,11 @@ Vue.component("Screen", {
         this.$watch(
             "drawer",
             (value) => {
-                if (value)
+                if (value) {
                     // Refresh menu items and their counters when the drawer is expanded
                     this.$root.loadMenu(true);
+                }
+                this._on_drawer_transition();
             },
             {immediate: true}
         );
@@ -97,6 +101,21 @@ Vue.component("Screen", {
             },
             {immediate: true}
         );
+    },
+    methods: {
+        _on_drawer_transition: function () {
+            if (this.drawer) {
+                document.body.classList.add("with-open-drawer");
+                document.body.classList.remove("with-closed-drawer");
+            } else {
+                document.body.classList.add("with-closed-drawer");
+                document.body.classList.remove("with-open-drawer");
+            }
+            event_hub.$emit("app:drawer_transition", {
+                root: this.$root,
+                drawer_opened: this.drawer,
+            });
+        },
     },
     template: `
     <v-app :class="screen_app_class">

--- a/shopfloor_mobile_base/templates/assets.xml
+++ b/shopfloor_mobile_base/templates/assets.xml
@@ -138,6 +138,7 @@
         <script
             id="script_component_screen"
             t-attf-src="/shopfloor_mobile_base/static/wms/src/components/screen.js?v=#{app_info.version}"
+            type="module"
         />
         <script
             id="script_component_misc"


### PR DESCRIPTION
The motivation for this PR is to have a way to identify whether the navigation drawer is open or closed in the app, and to apply any logic on transition.

To do so:
- A dynamic class is added to the body.
- An event is triggered.