### PR TITLE
Add default shopfloor profile on res users

### DIFF
--- a/shopfloor_base/__manifest__.py
+++ b/shopfloor_base/__manifest__.py
@@ -21,10 +21,12 @@
         "endpoint_route_handler",
     ],
     "data": [
+        "data/config_parameter.xml",
         "data/module_category_data.xml",
         "security/groups.xml",
         "security/ir.model.access.csv",
         "views/shopfloor_app.xml",
+        "views/res_users.xml",
         "views/shopfloor_menu.xml",
         "views/shopfloor_scenario_views.xml",
         "views/shopfloor_profile_views.xml",

--- a/shopfloor_base/data/config_parameter.xml
+++ b/shopfloor_base/data/config_parameter.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record
+            id="shopfloor_user_default_profile"
+            model="ir.config_parameter"
+            forcecreate="True"
+        >
+            <field name="key">shopfloor.default.profile</field>
+            <field name="value">False</field>
+        </record>
+    </data>
+</odoo>

--- a/shopfloor_base/models/__init__.py
+++ b/shopfloor_base/models/__init__.py
@@ -1,4 +1,5 @@
 from . import shopfloor_app
+from . import res_users
 from . import shopfloor_menu
 from . import shopfloor_profile
 from . import shopfloor_scenario

--- a/shopfloor_base/models/res_users.py
+++ b/shopfloor_base/models/res_users.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Akretion (http://www.akretion.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+from odoo import fields, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    shopfloor_default_profile_id = fields.Many2one(
+        comodel_name="shopfloor.profile", string="Shopfloor default profile"
+    )

--- a/shopfloor_base/services/profile.py
+++ b/shopfloor_base/services/profile.py
@@ -53,6 +53,16 @@ class ShopfloorProfile(Component):
             "name": record.name,
         }
 
+    def set_default_profile(self, profile_id):
+        if (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("shopfloor.default.profile")
+            and self.env.user.shopfloor_default_profile_id.id != profile_id
+        ):
+            self.env.user.shopfloor_default_profile_id = profile_id
+        return self._response(data={"result": True})
+
 
 class ShopfloorProfileValidator(Component):
     """Validators for the Profile endpoints"""
@@ -65,6 +75,9 @@ class ShopfloorProfileValidator(Component):
         return {
             "name_fragment": {"type": "string", "nullable": True, "required": False}
         }
+
+    def set_default_profile(self):
+        return {"profile_id": {"type": "integer", "coerce": to_int, "required": True}}
 
 
 class ShopfloorProfileValidatorResponse(Component):
@@ -82,6 +95,13 @@ class ShopfloorProfileValidatorResponse(Component):
                     "type": "list",
                     "schema": {"type": "dict", "schema": self._record_schema},
                 },
+            }
+        )
+
+    def set_default_profile(self):
+        return self._response_schema(
+            {
+                "result": {"required": True, "type": "boolean"},
             }
         )
 

--- a/shopfloor_base/services/user.py
+++ b/shopfloor_base/services/user.py
@@ -27,7 +27,12 @@ class ShopfloorUser(Component):
 
     @property
     def _user_info_parser(self):
-        return ["id", "name", ("lang", self._user_lang_parser)]
+        return [
+            "id",
+            "name",
+            ("lang", self._user_lang_parser),
+            ("shopfloor_default_profile_id:default_profile", ["id", "name"]),
+        ]
 
     def _user_lang_parser(self, rec, fname):
         if not rec[fname]:
@@ -83,8 +88,15 @@ class ShopfloorUserValidatorResponse(Component):
         )
 
     def _user_info_schema(self):
+        profile_return_validator = self.component("profile.validator.response")
         return {
             "id": {"coerce": to_int, "required": True, "type": "integer"},
             "name": {"type": "string", "nullable": False, "required": True},
             "lang": {"type": "string", "nullable": False, "required": False},
+            "default_profile": {
+                "type": "dict",
+                "nullable": True,
+                "required": False,
+                "schema": profile_return_validator._record_schema,
+            },
         }

--- a/shopfloor_base/tests/test_user_config_service.py
+++ b/shopfloor_base/tests/test_user_config_service.py
@@ -26,6 +26,29 @@ class AppCase(CommonCase):
                     "id": self.env.user.id,
                     "name": self.env.user.name,
                     "lang": self.env.user.lang.replace("_", "-"),
+                    "default_profile": None,
+                },
+            },
+        )
+
+    def test_default_profile(self):
+        response = self.service.dispatch("user_config")
+        profiles = self.env["shopfloor.profile"].search([])
+        default_profile = profiles[0]
+        self.env.user.shopfloor_default_profile_id = default_profile
+        self.assert_response(
+            response,
+            data={
+                "profiles": [
+                    {"id": profile.id, "name": profile.name} for profile in profiles
+                ],
+                "user_info": {
+                    "id": self.env.user.id,
+                    "name": self.env.user.name,
+                    "default_profile": {
+                        "id": default_profile.id,
+                        "name": default_profile.name,
+                    },
                 },
             },
         )

--- a/shopfloor_base/views/res_users.xml
+++ b/shopfloor_base/views/res_users.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_users_view_form_preferences" model="ir.ui.view">
+        <field name="name">res.users.preferences.form.inherit</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form_simple_modif" />
+        <field name="arch" type="xml">
+            <group name="signature" position="after">
+                <group name="shopfloor">
+                    <field
+                        name="shopfloor_default_profile_id"
+                        groups="shopfloor_base.group_shopfloor_manager"
+                    />
+                </group>
+            </group>
+        </field>
+    </record>
+
+    <record id="res_users_view_simple_form" model="ir.ui.view">
+        <field name="name">res.users.simple.form.inherit</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_simple_form" />
+        <field name="arch" type="xml">
+            <group name="phone_numbers" position="after">
+                <group name="shopfloor">
+                    <field
+                        name="shopfloor_default_profile_id"
+                        groups="shopfloor_base.group_shopfloor_manager"
+                    />
+                </group>
+            </group>
+        </field>
+    </record>
+
+    <record id="res_users_view_form" model="ir.ui.view">
+        <field name="name">res.users.form.inherit</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_form" />
+        <field name="arch" type="xml">
+            <group name="messaging" position="after">
+                <group
+                    name="shopfloor"
+                    string="Shopfloor"
+                    groups="shopfloor_base.group_shopfloor_manager"
+                >
+                    <field
+                        name="shopfloor_default_profile_id"
+                        groups="shopfloor_base.group_shopfloor_manager"
+                    />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>

--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -118,6 +118,8 @@ new Vue({
         });
         event_hub.$on("profile:selected", function (profile) {
             self.profile = profile;
+            const odoo = self.getOdoo({usage: "profile"});
+            odoo.call("set_default_profile", {profile_id: profile.id});
             self.loadMenu(true);
         });
         event_hub.$emit("app:mounted", self, false);
@@ -136,6 +138,14 @@ new Vue({
             },
         },
         has_profile: function () {
+            if (_.isEmpty(this.profile) && this.authenticated) {
+                this.profile = this.appconfig
+                    ? this.appconfig.user_info
+                        ? this.appconfig.user_info.default_profile || {}
+                        : {}
+                    : {};
+            }
+            console.log(this.profile);
             return !_.isEmpty(this.profile);
         },
         profiles: function () {


### PR DESCRIPTION
Hello,

This PR adds a default profile mechanism for shopfloor.

It adds a field on res_users to store the default profile.
And select it automaticaly if filled.

There is a config parameter to select automaticaly the last profile as default.

It allows 3 ways of working :
- no automation : ir.config.parameter to False and don't set default profile manualy on user. The user will have to select his profile every time he logged in (it is currently working like this)
- force default profile : ir.config.parameter to False and set a profile manualy on user : the user will have the same profile by default at the login
- force last selected profile : ir.config.parameter to True : the user will have the last selected profile automaticaly at the login