### PR TITLE
[14.0] shopfloor_mobile_base: persistent language in app

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -48,6 +48,7 @@ register_app_components(page_registry.all());
 config_registry.add("profile", {default: {}, reset_on_clear: true});
 config_registry.add("appmenu", {default: [], reset_on_clear: true});
 config_registry.add("authenticated", {default: false, reset_on_clear: true});
+config_registry.add("current_language", {default: "", reset_on_clear: false});
 
 new Vue({
     i18n,
@@ -81,6 +82,19 @@ new Vue({
         });
         document.addEventListener("fetchEnd", function () {
             self.loading = false;
+        });
+    },
+    beforeMount: function () {
+        const lang_id = this.current_language;
+        if (lang_id) {
+            // If a specific language is stored as app language,
+            // use it as locale instead of the default one
+            this.switch_language(lang_id);
+        }
+        event_hub.$on("language:selected", (lang_id) => {
+            // When the user updates the language in the app,
+            // store it so that it is used in the future
+            this.switch_language(lang_id);
         });
     },
     mounted: function () {
@@ -295,6 +309,11 @@ new Vue({
                 // Register them wisely.
                 extra_nav: extra_nav,
             };
+        },
+        switch_language: function (lang_id) {
+            this.$i18n.locale = lang_id;
+            this.$set(this, "current_language", lang_id);
+            event_hub.$emit("language:updated", lang_id);
         },
         /*
         Trigger and event on the event hub.

--- a/shopfloor_mobile_base/static/wms/src/settings/language.js
+++ b/shopfloor_mobile_base/static/wms/src/settings/language.js
@@ -4,6 +4,7 @@
  * @author Simone Orsi <simahawk@gmail.com>
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
+import event_hub from "../services/event_hub.js";
 import {page_registry} from "../services/page_registry.js";
 
 export var Language = {
@@ -27,8 +28,7 @@ export var Language = {
     methods: {
         on_select: function (selected) {
             const self = this;
-            this.$i18n.locale = selected.id;
-            // This.$root.trigger("language:selected", selected, true);
+            event_hub.$emit("language:selected", selected.id);
             self.$root.$router.push("/");
         },
     },


### PR DESCRIPTION
This PR stores the language that the users select in the app and makes it persistent through login/login & page refresh.
If no language has been selected by the user yet, it still reverts to the default language.