### PR TITLE
[14.0] shopfloor: Cluster picking / Location content transfer - Fix error messages in case of wrong thing scanned

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -1,8 +1,12 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
 from odoo import _
 
 from odoo.addons.component.core import Component
+
+_logger = logging.getLogger(__name__)
 
 
 class MessageAction(Component):
@@ -200,10 +204,23 @@ class MessageAction(Component):
         }
 
     def wrong_product(self):
+        # Method to drop in v15
+        _logger.warning("`wrong_product` is deprecated, use `wrong_record` instead")
         return {
             "message_type": "error",
-            "body": _("Wrong product."),
+            "body": self._wrong_record_msg("product.product"),
         }
+
+    def _wrong_record_msg(self, model_name):
+        return {
+            "product.product": _("Wrong product."),
+            "stock.production.lot": _("Wrong lot."),
+            "stock.location": _("Wrong location."),
+            "stock.quant.package": _("Wrong pack."),
+        }.get(model_name, _("Wrong."))
+
+    def wrong_record(self, record):
+        return {"message_type": "error", "body": self._wrong_record_msg(record._name)}
 
     def no_lot_for_barcode(self, barcode):
         return {
@@ -218,9 +235,11 @@ class MessageAction(Component):
         }
 
     def wrong_lot(self):
+        # Method to drop in v15
+        _logger.warning("`wrong_product` is deprecated, use `wrong_record` instead")
         return {
             "message_type": "error",
-            "body": _("Wrong lot."),
+            "body": self._wrong_record_msg("stock.production.lot"),
         }
 
     def several_lots_in_location(self, location):

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -236,7 +236,7 @@ class MessageAction(Component):
 
     def wrong_lot(self):
         # Method to drop in v15
-        _logger.warning("`wrong_product` is deprecated, use `wrong_record` instead")
+        _logger.warning("`wrong_log` is deprecated, use `wrong_record` instead")
         return {
             "message_type": "error",
             "body": self._wrong_record_msg("stock.production.lot"),
@@ -466,7 +466,7 @@ class MessageAction(Component):
 
     def location_empty(self, location):
         return {
-            "message_type": "info",
+            "message_type": "error",
             "body": _("Location {} empty").format(location.name),
         }
 

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1,5 +1,5 @@
 # Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
-# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020-2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, fields
 from odoo.osv import expression

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -464,6 +464,12 @@ class ClusterPicking(Component):
         if location and move_line.location_id == location:
             return self._scan_line_by_location(picking, move_line, location)
 
+        # Nothing matches what is expected from the move line.
+        for rec in (package, product, lot, location):
+            if rec:
+                return self._response_for_start_line(
+                    move_line, message=self.msg_store.wrong_record(rec)
+                )
         return self._response_for_start_line(
             move_line, message=self.msg_store.barcode_not_found()
         )

--- a/shopfloor/tests/test_cluster_picking_scan_line.py
+++ b/shopfloor/tests/test_cluster_picking_scan_line.py
@@ -328,6 +328,74 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         line.qty_done = line.product_uom_qty
         self._scan_line_ok(new_move.move_line_ids[0], line.location_id.barcode)
 
+    def test_scan_line_error_wrong_package(self):
+        """Wrong package scanned"""
+        self._simulate_batch_selected(self.batch, in_package=True)
+        pack = self.env["stock.quant.package"].sudo().create({})
+        self._scan_line_error(
+            self.batch.picking_ids.move_line_ids,
+            pack.name,
+            {"message_type": "error", "body": "Wrong pack."},
+        )
+
+    def test_scan_line_error_wrong_product(self):
+        """Wrong product scanned"""
+        self._simulate_batch_selected(self.batch, in_package=True)
+        product = (
+            self.env["product.product"]
+            .sudo()
+            .create(
+                {
+                    "name": "Wrong",
+                    "barcode": "WRONGPRODUCT",
+                }
+            )
+        )
+        self._scan_line_error(
+            self.batch.picking_ids.move_line_ids,
+            product.barcode,
+            {"message_type": "error", "body": "Wrong product."},
+        )
+
+    def test_scan_line_error_wrong_lot(self):
+        """Wrong product scanned"""
+        self._simulate_batch_selected(self.batch, in_package=True)
+        lot = (
+            self.env["stock.production.lot"]
+            .sudo()
+            .create(
+                {
+                    "name": "WRONGLOT",
+                    "product_id": self.batch.picking_ids.move_line_ids[0].product_id.id,
+                    "company_id": self.env.company.id,
+                }
+            )
+        )
+        self._scan_line_error(
+            self.batch.picking_ids.move_line_ids,
+            lot.name,
+            {"message_type": "error", "body": "Wrong lot."},
+        )
+
+    def test_scan_line_error_wrong_location(self):
+        """Wrong product scanned"""
+        self._simulate_batch_selected(self.batch, in_package=True)
+        location = (
+            self.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "name": "Wrong",
+                    "barcode": "WRONGLOCATION",
+                }
+            )
+        )
+        self._scan_line_error(
+            self.batch.picking_ids.move_line_ids,
+            location.barcode,
+            {"message_type": "error", "body": "Wrong location."},
+        )
+
     def test_scan_line_error_not_found(self):
         """Nothing found for the barcode"""
         self._simulate_batch_selected(self.batch, in_package=True)

--- a/shopfloor/tests/test_location_content_transfer_start.py
+++ b/shopfloor/tests/test_location_content_transfer_start.py
@@ -172,7 +172,7 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
             response,
             message={
                 "message_type": "error",
-                "body": "This location content can't be moved using this menu.",
+                "body": "You cannot move this using this menu.",
             },
         )
 
@@ -245,7 +245,7 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
         )
         self.assert_response_start(
             response,
-            message=self.service.msg_store.no_pack_in_location(self.content_loc),
+            message=self.service.msg_store.location_empty(self.content_loc),
         )
 
     def test_scan_location_wrong_picking_type_allow_unreserve_error(self):

--- a/shopfloor_manual_product_transfer/services/manual_product_transfer.py
+++ b/shopfloor_manual_product_transfer/services/manual_product_transfer.py
@@ -463,7 +463,11 @@ class ManualProductTransfer(Component):
             # Barcode is a lot but doesn't match the processed one
             if lot != scanned_lot:
                 return self._response_for_confirm_quantity(
-                    location, product, quantity, lot, message=self.msg_store.wrong_lot()
+                    location,
+                    product,
+                    quantity,
+                    lot,
+                    message=self.msg_store.wrong_record(scanned_lot),
                 )
             return
         # Search by product
@@ -480,7 +484,11 @@ class ManualProductTransfer(Component):
         # Barcode is a product but doesn't match the processed one
         if product != scanned_product:
             return self._response_for_confirm_quantity(
-                location, product, quantity, lot, message=self.msg_store.wrong_product()
+                location,
+                product,
+                quantity,
+                lot,
+                message=self.msg_store.wrong_record(scanned_product),
             )
 
     # FIXME copy pasted from location content transfer, put it elsewhere?


### PR DESCRIPTION
If you don't scan the right package/product/lot/location, raise the correct error to the operator that he scanned the wrong package/product/lot/location instead of raising a "Barcode not found"

In location content transfer, initial step where you have to scan a location:
* add a check that the location is valid for the menu's picking types
* raise a "Location empty" error message if the location is empty instead of a "no pack found in location" (the pack error is for single_pack_transfer)

I changed the "Location empty" from info to error. I checked the scenario using this message and seems to me to always be an error and not an info.

cc @sebalix @simahawk @lmignon @Lmarion-source