### PR TITLE
sf_mobile_base_auth_user: fix demo data load

### DIFF
--- a/shopfloor_mobile_base_auth_user/__manifest__.py
+++ b/shopfloor_mobile_base_auth_user/__manifest__.py
@@ -13,8 +13,10 @@
     "maintainer": ["simahawk"],
     "license": "AGPL-3",
     "depends": ["shopfloor_mobile_base", "base_rest_auth_user_service"],
-    "data": [
+    "demo": [
         "demo/shopfloor_app_demo.xml",
+    ],
+    "data": [
         "templates/assets.xml",
     ],
 }


### PR DESCRIPTION
It finished in `data` by error.