### PR TITLE
[14.0] shopfloor: Fix extract move lines

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, models
 from odoo.tools.float_utils import float_compare
@@ -24,29 +25,27 @@ class StockMove(models.Model):
         `move_lines` and `move.move_line_ids` which will be put in a new move.
         """
         self.ensure_one()
+        other_move_lines = self.move_line_ids - move_lines
         if intersection:
-            other_move_lines = self.move_line_ids & move_lines
+            to_move = self.move_line_ids & move_lines
         else:
-            other_move_lines = self.move_line_ids - move_lines
+            to_move = other_move_lines
         if other_move_lines or self.state == "partially_available":
             if intersection:
-                # TODO @sebalix: please check if we can abandon the flag.
-                # Thi behavior can be achieved by passing all move lines
-                # as done at zone_picking.py:1293
-                qty_to_split = sum(other_move_lines.mapped("product_uom_qty"))
+                qty_to_split = sum(to_move.mapped("product_uom_qty"))
             else:
                 qty_to_split = self.product_uom_qty - sum(
                     move_lines.mapped("product_uom_qty")
                 )
-            backorder_move_vals = self._split(qty_to_split)
-            backorder_move = self.create(backorder_move_vals)
-            backorder_move._action_confirm(merge=False)
-            backorder_move.move_line_ids = other_move_lines
-            backorder_move._recompute_state()
-            backorder_move._action_assign()
+            split_move_vals = self._split(qty_to_split)
+            split_move = self.create(split_move_vals)
+            split_move._action_confirm(merge=False)
+            split_move.move_line_ids = to_move
+            split_move._recompute_state()
+            split_move._action_assign()
             self._recompute_state()
-            return backorder_move
-        return False
+            return split_move
+        return self.browse()
 
     def split_unavailable_qty(self):
         """Put unavailable qty of a partially available move in their own
@@ -56,6 +55,31 @@ class StockMove(models.Model):
         for partial_move in partial_moves:
             partial_move.split_other_move_lines(partial_move.move_line_ids)
         return partial_moves
+
+    def _extract_in_split_order(self):
+        """Extract moves in a new picking"""
+        picking = self.picking_id
+        picking.ensure_one()
+        new_picking = picking.copy(
+            {
+                "name": "/",
+                "move_lines": [],
+                "move_line_ids": [],
+                "backorder_id": picking.id,
+            }
+        )
+        message = _(
+            'The split order <a href="#" '
+            'data-oe-model="stock.picking" '
+            'data-oe-id="%d">%s</a> has been created.'
+        ) % (new_picking.id, new_picking.name)
+        picking.message_post(body=message)
+        self.picking_id = new_picking.id
+        self.package_level_id.picking_id = new_picking.id
+        self.move_line_ids.picking_id = new_picking.id
+        self.move_line_ids.package_level_id.picking_id = new_picking.id
+        self._action_assign()
+        return new_picking
 
     def extract_and_action_done(self):
         """Extract the moves in a separate transfer and validate them.
@@ -78,30 +102,7 @@ class StockMove(models.Model):
             # a new transfer to validate. All remaining moves stay in the
             # current transfer.
             else:
-                new_picking = picking.copy(
-                    {
-                        "name": "/",
-                        "move_lines": [],
-                        "move_line_ids": [],
-                        "backorder_id": picking.id,
-                    }
-                )
-                new_picking.message_post(
-                    body=_(
-                        "Created from backorder "
-                        "<a href=# data-oe-model=stock.picking data-oe-id=%d>%s</a>."
-                    )
-                    % (picking.id, picking.name)
-                )
-                moves_todo.write({"picking_id": new_picking.id})
-                moves_todo.package_level_id.write({"picking_id": new_picking.id})
-                moves_todo.move_line_ids.write({"picking_id": new_picking.id})
-                moves_todo.move_line_ids.package_level_id.write(
-                    {"picking_id": new_picking.id}
-                )
-                # NOTE: at this stage all the operations should be assigned already
-                # hence the new picking must be assigned already.
-                # DO NOT CALL `new_picking.action_assign` or you'll wipe qty_done.
+                new_picking = moves_todo._extract_in_split_order()
                 assert new_picking.state == "assigned"
             new_picking._action_done()
         return True

--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -1,8 +1,13 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
 from odoo import _, exceptions, fields, models
 from odoo.exceptions import UserError
 from odoo.tools.float_utils import float_compare
+
+_logger = logging.getLogger(__name__)
 
 
 class StockMoveLine(models.Model):
@@ -20,6 +25,28 @@ class StockMoveLine(models.Model):
 
     # allow domain on picking_id.xxx without too much perf penalty
     picking_id = fields.Many2one(auto_join=True)
+
+    def _extract_in_split_order(self):
+        """Have pickings fully reserved with only those move lines.
+
+        If the condition is not met, extract the move lines in a new picking.
+        """
+        for picking in self.picking_id:
+            moves_to_extract = new_move = picking.move_lines.browse()
+            need_split = False
+            for move in picking.move_lines:
+                move_lines = move.move_line_ids & self
+                if not move_lines:
+                    # The picking contains moves not related to given move lines
+                    need_split = True
+                    continue
+                new_move = move.split_other_move_lines(move_lines, intersection=True)
+                if new_move:
+                    # The move contains other move lines or is partially available
+                    need_split = True
+                moves_to_extract += new_move or move
+            if need_split:
+                moves_to_extract._extract_in_split_order()
 
     def _split_pickings_from_source_location(self):
         """Ensure that the related pickings will have the same source location.
@@ -49,9 +76,12 @@ class StockMoveLine(models.Model):
                     - move line with source location LOC2
                     - move line with source location LOC2
 
-        Return the new picking (in case a split has been made), or the current
-        related pickings.
+        Return the pickings containing the given move lines.
         """
+        _logger.warning(
+            "`_split_pickings_from_source_location` is deprecated "
+            "and replaced by `_extract_in_split_order`"
+        )
         location_src_to_process = self.location_id
         if location_src_to_process and len(location_src_to_process) != 1:
             raise UserError(
@@ -60,51 +90,15 @@ class StockMoveLine(models.Model):
         pickings = self.picking_id
         move_lines_to_process_ids = []
         for picking in pickings:
-            location_src = picking.mapped("move_line_ids.location_id")
+            location_src = picking.move_line_ids.location_id
             if len(location_src) == 1:
                 continue
+            (picking.move_line_ids & self)._extract_in_split_order()
             # Get the related move lines among the picking and split them
             move_lines_to_process_ids.extend(
                 set(picking.move_line_ids.ids) & set(self.ids)
             )
-        # Put all move lines related to the source location in a separate picking
-        move_lines_to_process = self.browse(move_lines_to_process_ids)
-        new_move_ids = []
-        for move_line in move_lines_to_process:
-            new_move = move_line.move_id.split_other_move_lines(
-                move_line, intersection=True
-            )
-            if new_move:
-                new_move._recompute_state()
-                new_move_ids.append(new_move.id)
-        # If we have new moves, create the backorder picking
-        # NOTE: code copy/pasted & adapted from OCA module 'stock_split_picking'
-        new_moves = self.env["stock.move"].browse(new_move_ids)
-        if new_moves:
-            picking = pickings[0]
-            new_picking = picking.copy(
-                {
-                    "name": "/",
-                    "move_lines": [],
-                    "move_line_ids": [],
-                    "backorder_id": picking.id,
-                }
-            )
-            message = _(
-                'The backorder <a href="#" '
-                'data-oe-model="stock.picking" '
-                'data-oe-id="%d">%s</a> has been created.'
-            ) % (new_picking.id, new_picking.name)
-            for pick in pickings:
-                pick.message_post(body=message)
-            new_moves.write({"picking_id": new_picking.id})
-            new_moves.mapped("move_line_ids").write({"picking_id": new_picking.id})
-            new_moves.move_line_ids.package_level_id.write(
-                {"picking_id": new_picking.id}
-            )
-            new_moves._action_assign()
-            pickings = new_picking
-        return pickings
+        return self.picking_id
 
     def _split_qty_to_be_done(self, qty_done, split_partial=True, **split_default_vals):
         """Check qty to be done for current move line. Split it if needed.

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -319,36 +319,21 @@ class LocationContentTransfer(Component):
                 return self._response_for_start(
                     message=self.msg_store.cannot_move_something_in_picking_type()
                 )
-        # If there are different source locations, we put the move lines we are
-        # interested in in a separate picking.
-        # This is required as we can only deal within this scenario with pickings
-        # that share the same source location.
-        pickings = move_lines._split_pickings_from_source_location()
-        # Ensure we process move lines related to transfers having only one source
-        # location among all their move lines.
-        # We need to put the unreserved qty into separate moves as a new move
-        # line could be created in the middle of the process.
-        new_picking_ids = []
-        for picking in pickings:
-            #   -> put move lines to process in their own move/transfer
-            new_picking_id = picking.split_assigned_move_lines(move_lines)
-            new_picking_ids.append(new_picking_id)
-        if new_picking_ids != pickings.ids:
-            pickings = pickings.browse(new_picking_ids)
 
-        # If the following criteria are met:
-        #   - no move lines have been found
-        #   - the menu is configured to allow the creation of moves
-        #   - the menu is bind to one picking type
-        #   - scanned location is a valid source for one the menu's picking types
-        # then prepare new stock moves to move goods from the scanned location.
-        menu = self.work.menu
-        if (
-            not move_lines
-            and menu.allow_move_create
-            and len(self.picking_types) == 1
-            and self.is_src_location_valid(location)
-        ):
+        if move_lines:
+            # If there are different source locations, we put the move lines we are
+            # interested in in a separate picking.
+            # This is required as we can only deal within this scenario with pickings
+            # that share the same source location.
+            # We also need to put the unreserved qty into separate moves as a new move
+            # line could be created in the middle of the process.
+            move_lines._extract_in_split_order()
+        elif not self.is_allow_move_create():
+            savepoint.rollback()
+            return self._response_for_start(
+                message=self.msg_store.location_empty(location)
+            )
+        else:
             new_moves = self._create_moves_from_location(location)
             if not new_moves:
                 savepoint.rollback()
@@ -362,7 +347,6 @@ class LocationContentTransfer(Component):
                 return self._response_for_start(
                     message=self.msg_store.new_move_lines_not_assigned()
                 )
-            pickings = new_moves.mapped("picking_id")
             move_lines = new_moves.move_line_ids
             for move_line in move_lines:
                 if not self.is_dest_location_valid(
@@ -386,23 +370,16 @@ class LocationContentTransfer(Component):
                 message=self.msg_store.no_putaway_destination_available()
             )
 
-        if not pickings:
-            savepoint.rollback()
-            return self._response_for_start(
-                message=self.msg_store.location_empty(location)
-            )
-
         for line in move_lines:
             line.qty_done = line.product_uom_qty
             line.shopfloor_user_id = self.env.uid
-
-        pickings.user_id = self.env.uid
+        move_lines.picking_id.user_id = self.env.uid
 
         unreserved_moves._action_assign()
 
         savepoint.release()
 
-        return self._router_single_or_all_destination(pickings)
+        return self._router_single_or_all_destination(move_lines.picking_id)
 
     def _find_transfer_move_lines_domain(self, location):
         return [
@@ -729,22 +706,11 @@ class LocationContentTransfer(Component):
 
         self._lock_lines(move_line)
 
-        if quantity < move_line.product_uom_qty:
-            # Update the current move line quantity and
-            # put the scanned qty (the move line) in its own move
-            # (by splitting the current one)
-            move_line.product_uom_qty = move_line.qty_done = quantity
-            current_move = move_line.move_id
-            new_move_vals = current_move._split(quantity)
-            new_move = self.env["stock.move"].create(new_move_vals)
-            new_move._action_confirm(merge=False)
-            new_move.move_line_ids = move_line
-            # Ensure that the remaining qty to process is reserved as before
-            (new_move | current_move)._recompute_state()
-            (new_move | current_move)._action_assign()
-            for remaining_move_line in current_move.move_line_ids:
-                remaining_move_line.qty_done = remaining_move_line.product_uom_qty
-        move_line.move_id.split_other_move_lines(move_line)
+        move_line.qty_done = quantity
+        remaining_move_line = move_line._split_partial_quantity()
+        move_line._extract_in_split_order({"user_id": self.env.uid})
+        remaining_move_line.qty_done = remaining_move_line.product_uom_qty
+
         self._write_destination_on_lines(move_line, scanned_location)
         stock = self._actions_for("stock")
         stock.validate_moves(move_line.move_id)

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -91,3 +91,11 @@ class BaseShopfloorProcess(AbstractComponent):
         The location is valid but not the expected one: ask for confirmation
         """
         return not location.is_sublocation_of(location_dest_id)
+
+    def is_allow_move_create(self):
+        """Check a new operation can be created
+
+        The menu is configured to allow the creation of moves
+        The menu is bind to one picking type
+        """
+        return self.work.menu.allow_move_create and len(self.picking_types) == 1

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -137,7 +137,7 @@ class SinglePackTransfer(Component):
             lambda pl: pl.state not in ("cancel", "done", "draft")
         )
         message = self.msg_store.no_pending_operation_for_pack(package)
-        if not package_level and self.work.menu.allow_move_create:
+        if not package_level and self.is_allow_move_create():
             package_level = self._create_package_level(package)
             if not self.is_dest_location_valid(
                 package_level.move_line_ids.move_id, package_level.location_dest_id

--- a/shopfloor/tests/test_location_content_transfer_base.py
+++ b/shopfloor/tests/test_location_content_transfer_base.py
@@ -61,9 +61,10 @@ class LocationContentTransferCommonCase(CommonCase):
         # this code is repeated from the implementation, not great, but we
         # mostly want to ensure the selection of pickings is right, and the
         # data methods have their own tests
-        lines = pickings.move_line_ids.filtered(lambda line: not line.package_level_id)
+        move_lines = pickings.move_line_ids
+        lines = move_lines.filtered(lambda line: not line.package_level_id)
         package_levels = pickings.package_level_ids
-        location = pickings.mapped("move_line_ids.location_id")
+        location = move_lines.location_id
         self.assert_response(
             response,
             next_state=state,

--- a/shopfloor/tests/test_location_content_transfer_mix.py
+++ b/shopfloor/tests/test_location_content_transfer_mix.py
@@ -236,12 +236,12 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
         """Test the following scenario:
 
         1) Operator-1 processes the first pallet with the "zone picking" scenario
-           to move the goods to PACK-1:
+           to move the goods to PACK-1 and unload in destination location1:
 
             move1 PICK -> PACK-1 'done'
 
         2) Operator-1 processes the second pallet with the "zone picking" scenario
-           to move the goods to PACK-2:
+           to move the goods to PACK-2 and unload in destination location2:
 
             move1 PICK -> PACK-2 'done'
 

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -843,11 +843,12 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         self.assertEqual(move_line.product_uom_qty, 0)
         self.assertEqual(move_line.qty_done, 6)
         self.assertEqual(move_line.state, "done")
+        # the move has been split
+        self.assertNotEqual(move_line.move_id, move)
 
         # Check the move handling the remaining qty
-        remaining_move = picking_b.move_lines - move
-        self.assertEqual(remaining_move.state, "assigned")
-        remaining_move_line = remaining_move.move_line_ids
-        self.assertEqual(remaining_move_line.move_id.product_uom_qty, 4)
-        self.assertEqual(remaining_move_line.product_uom_qty, 4)
-        self.assertEqual(remaining_move_line.qty_done, 4)
+        self.assertEqual(move.state, "assigned")
+        move_line = move.move_line_ids
+        self.assertEqual(move_line.move_id.product_uom_qty, 4)
+        self.assertEqual(move_line.product_uom_qty, 4)
+        self.assertEqual(move_line.qty_done, 4)

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -466,11 +466,10 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         self.another_package = self.env["stock.quant.package"].create(
             {"name": "ANOTHER_PACKAGE"}
         )
-        self.assertEqual(
-            self.picking5.move_line_ids.location_dest_id, self.packing_location
-        )
+        move_lines = self.picking5.move_line_ids
+        self.assertEqual(move_lines.location_dest_id, self.packing_location)
         for move_line, package_dest in zip(
-            self.picking5.move_line_ids, self.free_package | self.another_package
+            move_lines, self.free_package | self.another_package
         ):
             self.service.dispatch(
                 "set_destination",
@@ -490,7 +489,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             response,
             self.zone_location,
             self.picking_type,
-            self.picking5.move_line_ids,
+            move_lines,
         )
 
     def test_list_move_lines_empty_location(self):

--- a/shopfloor/tests/test_zone_picking_unload_all.py
+++ b/shopfloor/tests/test_zone_picking_unload_all.py
@@ -205,15 +205,15 @@ class ZonePickingUnloadAllCase(ZonePickingCommonCase):
         )
         # check data
         #   picking validated
-        picking_validated = self.picking6
-        self.assertEqual(picking_validated.state, "done")
-        self.assertEqual(picking_validated.move_line_ids, move_line_g | move_line_h)
         self.assertEqual(move_line_g.state, "done")
+        self.assertEqual(move_line_g.picking_id.state, "done")
         self.assertEqual(move_line_g.qty_done, 6)
         self.assertEqual(move_line_h.state, "done")
+        self.assertEqual(move_line_h.picking_id.state, "done")
         self.assertEqual(move_line_h.qty_done, 3)
         #   current picking (backorder)
-        backorder = self.picking6.backorder_ids
+        backorder = (move_line_g | move_line_h).picking_id.backorder_id
+        self.assertEqual(backorder, self.picking6)
         self.assertEqual(backorder.state, "confirmed")
         self.assertEqual(backorder.move_lines.product_id, self.product_h)
         self.assertEqual(backorder.move_lines.product_uom_qty, 3)

--- a/shopfloor/tests/test_zone_picking_unload_buffer_lines.py
+++ b/shopfloor/tests/test_zone_picking_unload_buffer_lines.py
@@ -96,7 +96,7 @@ class ZonePickingUnloadBufferLinesCase(ZonePickingCommonCase):
             dest_package = self.env["stock.quant.package"].create(
                 {"name": f"TEST PKG 1 {i}"}
             )
-            self.service._set_move_line_as_done(
+            self.service._actions_for("stock").mark_move_line_as_picked(
                 line,
                 line.product_uom_qty,
                 dest_package,

--- a/shopfloor/tests/test_zone_picking_unload_set_destination.py
+++ b/shopfloor/tests/test_zone_picking_unload_set_destination.py
@@ -302,11 +302,12 @@ class ZonePickingUnloadSetDestinationCase(ZonePickingCommonCase):
         )
         # check data
         # move line has been moved to a new picking
-        # move line has been validated in the current picking
-        self.assertEqual(move_line.move_id.picking_id, self.picking_z)
-        # the new picking (backorder) contains a new line w/ the rest of the qty
+        # move line has been validated in the new picking
+        self.assertNotEqual(move_line.move_id.picking_id, self.picking_z)
+        backorder = move_line.move_id.picking_id.backorder_id
+        self.assertEqual(backorder, self.picking_z)
+        # the backorder contains a new line w/ the rest of the qty
         # that couldn't be processed
-        backorder = self.picking_z.backorder_ids[0]
         self.assertEqual(backorder.move_lines[0].product_uom_qty, 8)
         self.assertEqual(backorder.state, "confirmed")
         # the line has been processed


### PR DESCRIPTION
The location content transfer and zone picking are now aligned in the way lines are processed. Everything that you start to process is extracted in a split order and the user is set on it. This eases the tracking of what is being processed.

Refactor to reduce method complexity introduced by https://github.com/OCA/wms/pull/399

While reviewing the code, it appeared in the location content transfer that some pickings were lost when some gets their move lines extracted causing to move only split moves and not the other pickings having also content on the location.
I changed the tests in start in order to have the failing use case covered. The tests were already processing 2 different pickings. Now the second picking has stock on 2 different source locations. This causes a split on the second picking only.

In the zone picking, I added the extraction of processed lines / qty in a split order like in the location content transfer.
This solves a bug processing partial quantities. The last processed line was moving all quantity to its destination causing an automatic stock correction. 
This solves a bug when lines are reserved on multiple locations. It was only possible to process one of the lines.
When a line is put on a destination package, you can now find back in odoo the processed picking as it has the user set on it.
As the extraction in a split order is done at the beginning of the process, this has an impact on how you process backorder if you use the module `stock_picking_backorder_strategy` to automatically cancel backorders. A new glue module is required to cancel the initial order after extraction.