### PR TITLE
[14.0] shopfloor: add options on cluster and zone picking

### DIFF
--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -16,13 +16,19 @@
         <field name="key">zone_picking</field>
         <field name="options_edit">
 {
-    "pick_pack_same_time": true
+    "pick_pack_same_time": true,
+    "multiple_move_single_pack": true
 }
         </field>
     </record>
     <record id="scenario_cluster_picking" model="shopfloor.scenario">
         <field name="name">Cluster Picking</field>
         <field name="key">cluster_picking</field>
+        <field name="options_edit">
+{
+    "multiple_move_single_pack": true
+}
+        </field>
     </record>
     <record id="scenario_checkout" model="shopfloor.scenario">
         <field name="name">Checkout</field>

--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -17,6 +17,7 @@
         <field name="options_edit">
 {
     "pick_pack_same_time": true,
+    "unload_package_at_destination": true,
     "multiple_move_single_pack": true
 }
         </field>
@@ -26,6 +27,7 @@
         <field name="key">cluster_picking</field>
         <field name="options_edit">
 {
+    "unload_package_at_destination": true,
     "multiple_move_single_pack": true
 }
         </field>

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -11,6 +11,11 @@ If you tick this box, while picking goods from a location
 * in both cases, if the picking has no carrier the operation fails.",
 """
 
+MULTIPLE_MOVE_SINGLE_PACK_HELP = """
+When picking a move,
+allow to set a destination package that was already used for the other lines.
+"""
+
 
 class ShopfloorMenu(models.Model):
     _inherit = "shopfloor.menu"
@@ -74,6 +79,14 @@ class ShopfloorMenu(models.Model):
     pick_pack_same_time_is_possible = fields.Boolean(
         compute="_compute_pick_pack_same_time_is_possible"
     )
+    multiple_move_single_pack_is_possible = fields.Boolean(
+        compute="_compute_multiple_move_single_pack_is_possible"
+    )
+    multiple_move_single_pack = fields.Boolean(
+        string="Collect multiple moves on a same destination package",
+        default=False,
+        help=MULTIPLE_MOVE_SINGLE_PACK_HELP,
+    )
 
     allow_force_reservation = fields.Boolean(
         string="Force stock reservation",
@@ -115,6 +128,13 @@ class ShopfloorMenu(models.Model):
         for menu in self:
             menu.pick_pack_same_time_is_possible = menu.scenario_id.has_option(
                 "pick_pack_same_time"
+            )
+
+    @api.depends("scenario_id")
+    def _compute_multiple_move_single_pack_is_possible(self):
+        for menu in self:
+            menu.multiple_move_single_pack_is_possible = menu.scenario_id.has_option(
+                "multiple_move_single_pack"
             )
 
     @api.onchange("unreserve_other_moves_is_possible")

--- a/shopfloor/models/stock_quant_package.py
+++ b/shopfloor/models/stock_quant_package.py
@@ -15,6 +15,7 @@ class StockQuantPackage(models.Model):
     planned_move_line_ids = fields.One2many(
         comodel_name="stock.move.line",
         inverse_name="result_package_id",
+        domain=[("state", "not in", ("done", "cancel"))],
         readonly=True,
         help="Technical field. Move lines for which destination is this package.",
     )

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -975,6 +975,8 @@ class ClusterPicking(Component):
             picking_lines = picking.mapped("move_line_ids")
             if all(line.shopfloor_unloaded for line in picking_lines):
                 picking._action_done()
+        if self.work.menu.unload_package_at_destination:
+            lines.result_package_id = False
 
     def _unload_end(self, batch, completion_info_popup=None):
         """Try to close the batch if all transfers are done.

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -607,12 +607,14 @@ class ClusterPicking(Component):
             )
 
         # the scanned package can contain only move lines of the same picking
-        if bin_package.quant_ids or any(
+        different_picking = any(
             ml.picking_id != move_line.picking_id
             for ml in bin_package.planned_move_line_ids.filtered(
                 lambda x: x.state not in ("done", "cancel")
             )
-        ):
+        )
+        multi_pick_allowed = self.work.menu.multiple_move_single_pack
+        if not multi_pick_allowed and (bin_package.quant_ids or different_picking):
             return self._response_for_scan_destination(
                 move_line,
                 message={

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1162,6 +1162,8 @@ class ZonePicking(Component):
         self._lock_lines(lines)
         lines.location_dest_id = location
         lines.package_level_id.location_dest_id = location
+        if self.work.menu.unload_package_at_destination:
+            lines.result_package_id = False
 
     def unload_split(self):
         """Indicates that now the buffer must be treated line per line

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -661,14 +661,8 @@ class ZonePicking(Component):
         return not bool(package.quant_ids)
 
     def _is_package_already_used(self, package):
-        return bool(
-            self.env["stock.move.line"].search_count(
-                [
-                    ("state", "not in", ("done", "cancel")),
-                    ("result_package_id", "=", package.id),
-                ]
-            )
-        )
+        # Deprecated, use planned_move_line_ids instead
+        return bool(package.planned_move_line_ids)
 
     def _move_line_compare_qty(self, move_line, qty):
         rounding = move_line.product_uom_id.rounding
@@ -694,7 +688,8 @@ class ZonePicking(Component):
                 message=self.msg_store.package_not_empty(package),
             )
             return (package_changed, response)
-        if self._is_package_already_used(package):
+        multiple_move_allowed = self.work.menu.multiple_move_single_pack
+        if package.planned_move_line_ids and not multiple_move_allowed:
             response = self._response_for_set_line_destination(
                 move_line,
                 message=self.msg_store.package_already_used(package),

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -597,6 +597,52 @@ class ClusterPickingUnloadScanDestinationCase(ClusterPickingUnloadingCommonCase)
             data=data,
         )
 
+    def test_scan_destination_unload_package_enabled(self):
+        """Endpoint /unload_scan_destination is called, unload_package_at_destination
+        is enabled, lines.result_package_id should be False"""
+        dest_location = self.bin1_lines[0].location_dest_id
+        # Default behavior, result_package_id is kept when package in unloaded
+        self.service.dispatch(
+            "unload_scan_destination",
+            params={
+                "picking_batch_id": self.batch.id,
+                "package_id": self.bin1.id,
+                "barcode": dest_location.barcode,
+                "confirmation": True,
+            },
+        )
+        self.assertRecordValues(
+            self.bin1_lines,
+            [
+                {
+                    "result_package_id": self.bin1.id,
+                }
+            ],
+        )
+        # Now, if `unload_package_at_destination` is enabled, result_package_id
+        # should be set to False
+        self.menu.sudo().write({"unload_package_at_destination": True})
+        self.service.dispatch(
+            "unload_scan_destination",
+            params={
+                "picking_batch_id": self.batch.id,
+                "package_id": self.bin2.id,
+                "barcode": dest_location.barcode,
+                "confirmation": True,
+            },
+        )
+        self.assertRecordValues(
+            self.bin2_lines,
+            [
+                {
+                    "result_package_id": False,
+                },
+                {
+                    "result_package_id": False,
+                },
+            ],
+        )
+
     def test_unload_scan_destination_one_line_of_picking_only(self):
         """Endpoint /unload_scan_destination is called, only one line of picking"""
         # For this test, we assume the move in bin1 is already done.

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -55,6 +55,19 @@
                   <field name="allow_prepackaged_product" />
               </group>
               <group
+                    name="unload_at_destination"
+                    attrs="{'invisible': [('unload_package_at_destination_is_possible', '=', False)]}"
+                >
+                  <field
+                        name="unload_package_at_destination_is_possible"
+                        invisible="1"
+                    />
+                  <field
+                        name="unload_package_at_destination"
+                        attrs="{'readonly': [('pick_pack_same_time', '=', True)]}"
+                    />
+              </group>
+              <group
                     name="multiple_move_single_pack"
                     attrs="{'invisible': [('multiple_move_single_pack_is_possible', '=', False)]}"
                 >

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -54,6 +54,16 @@
                   <field name="prepackaged_product_is_possible" invisible="1" />
                   <field name="allow_prepackaged_product" />
               </group>
+              <group
+                    name="multiple_move_single_pack"
+                    attrs="{'invisible': [('multiple_move_single_pack_is_possible', '=', False)]}"
+                >
+                  <field name="multiple_move_single_pack_is_possible" invisible="1" />
+                  <field
+                        name="multiple_move_single_pack"
+                        attrs="{'readonly': [('pick_pack_same_time', '=', True)]}"
+                    />
+              </group>
             </group>
         </field>
     </record>


### PR DESCRIPTION
Based on https://github.com/OCA/wms/pull/398 to avoid conflicts.

Add a two options:
- `Unload package at destination`, which allows to unload goods as bulk products in the destination location.
- `Collect multiple moves on a same destination package`, which allows to set a destination package that was already used for the other move lines.

Also add some constrains, because `Collect multiple moves on a same destination package` should be only be enabled when `Unload package at destination` is enabled, and `Unload package at destination` cannot be enabled when `Pick and pack at the same time` is.