### PR TITLE
shopfloor*: fix datetime handling

### DIFF
--- a/shopfloor/actions/data_detail.py
+++ b/shopfloor/actions/data_detail.py
@@ -99,7 +99,9 @@ class DataDetailAction(Component):
         suppliers = self.env["product.supplierinfo"].search(
             [("product_id", "=", record.id)]
         )
-        data["suppliers"] = suppliers.jsonify(self._product_supplierinfo_parser)
+        data["suppliers"] = self._jsonify(
+            suppliers, self._product_supplierinfo_parser, multi=True
+        )
         return data
 
     def products_detail(self, record, **kw):

--- a/shopfloor_base/actions/data.py
+++ b/shopfloor_base/actions/data.py
@@ -17,7 +17,8 @@ class DataAction(Component):
     _usage = "data"
 
     def _jsonify(self, recordset, parser, multi=False, **kw):
-        res = recordset.jsonify(parser)
+        # TODO: drop this ctx flag for v15 as `jsonifier` makes it default
+        res = recordset.with_context(jsonifier__date_user_tz=False).jsonify(parser)
         if not multi:
             return res[0] if res else None
         return res

--- a/shopfloor_base/services/menu.py
+++ b/shopfloor_base/services/menu.py
@@ -57,7 +57,10 @@ class ShopfloorMenu(Component):
         )
 
     def _convert_one_record(self, record):
-        values = record.jsonify(self._one_record_parser(record), one=True)
+        # TODO: drop this ctx flag for v15 as `jsonifier` makes it default
+        values = record.with_context(jsonifier__date_user_tz=False).jsonify(
+            self._one_record_parser(record), one=True
+        )
         return values
 
     def _one_record_parser(self, record):

--- a/shopfloor_mobile_base/static/wms/src/utils.js
+++ b/shopfloor_mobile_base/static/wms/src/utils.js
@@ -7,7 +7,19 @@
 import {utils_registry} from "./services/utils_registry.js";
 
 export class DisplayUtils {
-    format_date_display(date_string, options = {}) {
+    _ensure_UTC_datetime(date_string) {
+        if (!date_string.endsWith("Z")) {
+            const _value = date_string.replace(" ", "T") + "Z";
+            if (!_.isNaN(Date.parse(_value))) {
+                return _value;
+            }
+        }
+        return date_string;
+    }
+    format_date_display(date_string, options = {}, utc = true) {
+        if (utc) {
+            date_string = this._ensure_UTC_datetime(date_string);
+        }
         _.defaults(options, {
             locale: navigator ? navigator.language : "en-US",
             format: {


### PR DESCRIPTION
Datetime should always be UTC
to allow the frontend to handle them in the same way
no matter how they are serialized.

Requires https://github.com/OCA/server-tools/pull/2332