### PR TITLE
[14.0] shopfloor_mobile_base: manifest & app info improvements

### DIFF
--- a/shopfloor_base/models/shopfloor_app.py
+++ b/shopfloor_base/models/shopfloor_app.py
@@ -102,7 +102,8 @@ class ShopfloorApp(models.Model):
     @api.depends("tech_name")
     def _compute_url(self):
         for rec in self:
-            rec.url = rec._base_url_path + rec.tech_name
+            full_url = rec._base_url_path + rec.tech_name
+            rec.url = full_url.rstrip("/") + "/"
             rec.api_docs_url = rec._base_api_docs_url_path + rec.tech_name
 
     @api.depends("tech_name")
@@ -292,7 +293,8 @@ class ShopfloorApp(models.Model):
             name=self.name,
             short_name=self.short_name,
             base_url=base_url,
-            manifest_url=self.url + "/manifest.json",
+            url=self.url,
+            manifest_url=self.url + "manifest.json",
             auth_type=self.auth_type,
             profile_required=self.profile_required,
             demo_mode=demo,

--- a/shopfloor_base/tests/test_shopfloor_app.py
+++ b/shopfloor_base/tests/test_shopfloor_app.py
@@ -37,11 +37,11 @@ class TestShopfloorApp(CommonCase):
         expected = [
             {
                 "api_route": "/shopfloor/api/test_app",
-                "url": "/shopfloor/app/test_app",
+                "url": "/shopfloor/app/test_app/",
             },
             {
                 "api_route": "/shopfloor/api/test_app_2",
-                "url": "/shopfloor/app/test_app_2",
+                "url": "/shopfloor/app/test_app_2/",
             },
         ]
         # fmt: on
@@ -113,6 +113,7 @@ class TestShopfloorApp(CommonCase):
         expected = {
             "auth_type": "user_endpoint",
             "base_url": "/shopfloor/api/test/",
+            "url": "/shopfloor/app/test/",
             "demo_mode": False,
             "manifest_url": "/shopfloor/app/test/manifest.json",
             "name": "Test",

--- a/shopfloor_mobile_base/controllers/main.py
+++ b/shopfloor_mobile_base/controllers/main.py
@@ -91,10 +91,18 @@ class ShopfloorMobileAppMixin(object):
         return all_icons
 
     def _get_manifest(self, shopfloor_app):
+        param = (
+            http.request.env["ir.config_parameter"]
+            .sudo()
+            .get_param("web.base.url", "")
+            .rstrip("/")
+        )
         return {
             "name": shopfloor_app.name,
             "short_name": shopfloor_app.short_name,
-            "start_url": shopfloor_app.url + "#",
+            "start_url": param + shopfloor_app.url,
+            "scope": param + shopfloor_app.url,
+            "id": shopfloor_app.url,
             "display": "fullscreen",
             "icons": self._get_app_icons(shopfloor_app),
         }


### PR DESCRIPTION
The motivation of this PR is to fix and finalize shopfloor.app installation as a PWA:

- The entire url of the app is exposed in shopfloor_app_info.
- In the manifest:
    - "start_url" now gives the entire url of the app, and not only the path.
    - "scope" is added to the manifest, and it matches start_url.
    -  "id" is added but only as a relative path (as it is only used to identify unique PWAs).