### PR TITLE
[14.0][WIP] stock_dynamic_routing & release: merge moves

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2019-2022 Camptocamp (https://www.camptocamp.com)
+# Copyright 2020-2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 import logging
@@ -377,10 +378,10 @@ class StockMove(models.Model):
             pickings.write({"priority": max(priorities)})
 
     def _after_release_assign_moves(self):
-        moves = self
+        moves = self.exists()
         while moves:
             moves._action_assign()
-            moves = moves.mapped("move_orig_ids")
+            moves = moves.exists().mapped("move_orig_ids")
 
     def _release_split(self, remaining_qty):
         """Split move and create a new picking for it.

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -1,8 +1,12 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2020-2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import logging
 
 from odoo import _, api, exceptions, fields, models
 from odoo.tools.float_utils import float_compare
+
+_logger = logging.getLogger(__name__)
 
 
 class StockPicking(models.Model):
@@ -149,17 +153,16 @@ class StockPicking(models.Model):
         to the released one.
         """
         self._after_release_set_printed()
-        self._after_release_set_expected_date()
 
     def _after_release_set_printed(self):
         self.filtered(lambda p: not p.printed).printed = True
 
     def _after_release_set_expected_date(self):
-        prep_time = self.env.company.stock_release_max_prep_time
-        new_expected_date = fields.Datetime.add(
-            fields.Datetime.now(), minutes=prep_time
+        # TODO: Method to drop in v15
+        _logger.warning("`_after_release_set_expected_date` is deprecated")
+        self.scheduled_date = self.move_lines._release_get_deadline(
+            fields.Datetime.now()
         )
-        self.scheduled_date = new_expected_date
 
     def action_open_move_need_release(self):
         self.ensure_one()

--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -259,6 +259,10 @@ class StockMove(models.Model):
 
             if move.picking_id.picking_type_id == routing_rule.picking_type_id:
                 # already correct
+                if routing_rule.group_id and move.group_id != routing_rule.group_id:
+                    move.group_id = routing_rule.group_id
+                    move._assign_picking()
+                    move = move._merge_moves()
                 move_ids_to_assign_nonrelocated.append(move.id)
                 continue
 
@@ -270,6 +274,8 @@ class StockMove(models.Model):
                 __applying_routing_rule=True
             ).location_id = routing_rule.location_src_id
             move.picking_type_id = routing_rule.picking_type_id
+            if routing_rule.group_id and move.group_id != routing_rule.group_id:
+                move.group_id = routing_rule.group_id
             dest_location = move.location_dest_id
             rule_location = routing_rule.location_dest_id
             if rule_location.is_sublocation_of(dest_location):

--- a/stock_dynamic_routing/models/stock_routing_rule.py
+++ b/stock_dynamic_routing/models/stock_routing_rule.py
@@ -1,4 +1,5 @@
 # Copyright 2019-2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import _, api, exceptions, fields, models
@@ -38,12 +39,21 @@ class StockRoutingRule(models.Model):
         required=True,
         help="Operation type that will be applied on the move.",
     )
+    group_id = fields.Many2one(
+        comodel_name="procurement.group",
+        string="Fixed Procurement Group",
+        help="Procurement group that will be applied on the move. This allows "
+        "you to merge moves initialy coming from different procurement group. "
+        "For instance, have 1 pick for multiple customer shippings.",
+    )
     location_src_id = fields.Many2one(
         comodel_name="stock.location",
+        string="Source Location",
         compute="_compute_location_src_id",
     )
     location_dest_id = fields.Many2one(
         comodel_name="stock.location",
+        string="Destination Location",
         compute="_compute_location_dest_id",
     )
     rule_domain = fields.Char(

--- a/stock_dynamic_routing/views/stock_routing_views.xml
+++ b/stock_dynamic_routing/views/stock_routing_views.xml
@@ -33,7 +33,7 @@
                                 <field name="sequence" widget="handle" />
                                 <field name="method" />
                                 <field name="picking_type_id" />
-                                <field name="location_src_id" />
+                                <field name="group_id" />
                                 <field name="location_dest_id" />
                                 <field name="rule_domain" />
                             </tree>
@@ -47,6 +47,7 @@
                                     />
                                     <field name="location_src_id" />
                                     <field name="location_dest_id" />
+                                    <field name="group_id" />
                                     <field
                                         name="rule_domain"
                                         widget="domain"

--- a/stock_dynamic_routing_checkout_sync/tests/test_routing_sync.py
+++ b/stock_dynamic_routing_checkout_sync/tests/test_routing_sync.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo.addons.stock_checkout_sync.tests.common import CheckoutSyncCommonCase
@@ -139,11 +140,11 @@ class TestRoutingPullWithSync(CheckoutSyncCommonCase):
         self.assert_src_pack_post_bay1(self.pack_move1.move_line_ids)
         # no move lines on these waiting moves:
         self.assert_src_pack_post(self.pack_move2)
-        self.assert_src_pack_post(self.pack_move3)
-
         self.assert_picking_type_pack_post(self.pack_move1.picking_id)
         self.assert_picking_type_pack_post(self.pack_move2.picking_id)
-        self.assert_picking_type_pack_post(self.pack_move3.picking_id)
+        # pack_move3 has been merged into pack_move2
+        self.assertFalse(self.pack_move3.exists())
+        self.assertEqual(self.pack_move2.product_uom_qty, 4)
 
     def test_pack_sync_split(self):
         self.pack_type.checkout_sync = True
@@ -193,7 +194,7 @@ class TestRoutingPullWithSync(CheckoutSyncCommonCase):
         self.assert_dest_pack_post_bay1(self.pick_move1)
         self.assert_dest_pack_post_bay1(self.pick_move1.move_line_ids)
         self.assert_dest_pack_post_bay1(pick_move_split)
-        self.assert_dest_pack_post_bay1(self.pick_move1)
+        self.assert_dest_pack_post_bay1(self.pick_move2)
         self.assert_dest_pack_post_bay1(self.pick_move2.move_line_ids)
         self.assert_dest_pack_post_bay1(self.pick_move3)
         self.assert_dest_pack_post_bay1(self.pick_move3.move_line_ids)
@@ -204,8 +205,8 @@ class TestRoutingPullWithSync(CheckoutSyncCommonCase):
         # no move lines on these waiting moves:
         self.assert_src_pack_post(waiting_pack)
         self.assert_src_pack_post(self.pack_move2)
-        self.assert_src_pack_post(self.pack_move3)
-
         self.assert_picking_type_pack_post(self.pack_move1.picking_id)
         self.assert_picking_type_pack_post(self.pack_move2.picking_id)
-        self.assert_picking_type_pack_post(self.pack_move3.picking_id)
+        # pack_move3 has been merged into pack_move2
+        self.assertFalse(self.pack_move3.exists())
+        self.assertEqual(self.pack_move2.product_uom_qty, 4)

--- a/stock_move_source_relocate/models/stock_move.py
+++ b/stock_move_source_relocate/models/stock_move.py
@@ -14,7 +14,7 @@ class StockMove(models.Model):
         )
         super()._action_assign()
         # could not be (entirely) reserved
-        unconfirmed_moves = unconfirmed_moves.filtered(
+        unconfirmed_moves = unconfirmed_moves.exists().filtered(
             lambda m: m.state in ["confirmed", "partially_available"]
         )
         unconfirmed_moves._apply_source_relocate()


### PR DESCRIPTION
## Merging pulled moves
In standard, when _action_confirm is called, moves can be merged.
With the dynamic routing, if a move is re-assigned to another picking, we should also try to merge it with another one.
A side effect is that the initial move is deleted when merged, so we need to ensure the move still exists in any further call after action_assign.

## Force new procurement group
Allow to alter the procurement group of a pulled move.

### Use case
10 SO for a same product. Routing configured in 2 steps. Set a fixed procurement group on the rerouted pick move.
This will create a single pick transfer for all the SO's shipments. The pick will contain a single move line with the total quantity to pick.

## Fix the scheduled date and deadline
When releasing a move:
*  on the released move:
    * the deadline remains the one coming from the SO
    * the scheduled date is set to now + the max prep time
* on the pulled moves:
    * the deadline is set to now + the max prep time <= CHANGED: before it was the deadline of the SO. Required for the merging to occur as the deadline is part of the merge key
    * the scheduled date is set to now + max prep time (it cannot be now otherwise it will immediately be counted as a late picking)

cc @jgrandguillaume 
