### PR TITLE
[14.0] shopfloor_mobile: demo data

### DIFF
--- a/shopfloor_mobile/readme/ROADMAP.rst
+++ b/shopfloor_mobile/readme/ROADMAP.rst
@@ -27,3 +27,11 @@
   This part is also related to "Refactor states definition".
 
 * Go through `_.forEach` and similar calls to replace them w/ vanilla JS (eg: `.map()`)
+* Demo data management
+
+  In order to make sure that demo data is loaded before the application is loaded,
+  we should make demo data a dependency for the whole application.
+  To achieve this, we could support a new metadata key in process_registry which accepts the path to the demo data file.
+  Before the app is initialized, we can check if demo mode is enabled & we have demo data to load,
+  in which case we import those modules.
+  Once this is implemented, we can remove the demo data assets.

--- a/shopfloor_mobile_base/static/wms/src/services/odoo.js
+++ b/shopfloor_mobile_base/static/wms/src/services/odoo.js
@@ -131,17 +131,6 @@ export class OdooMocked extends OdooMixin {
         this._set_demo_data();
         console.log("CALL:", path, this.usage);
         console.dir("CALL data:", data);
-        // Provide your own mock by enpoint
-        let mocked_handler = "mocked_" + path;
-        if (!_.isUndefined(this[mocked_handler])) {
-            return this[mocked_handler].call(this, data);
-        }
-        // Provide your own mock by service and endpoint
-        mocked_handler = "mocked_" + this.usage + "_" + path;
-        if (!_.isUndefined(this[mocked_handler])) {
-            // Provide your own mock by enpoint and specific process
-            return this[mocked_handler].call(this, data);
-        }
         let result = null;
         const barcode = data
             ? data.barcode || data.identifier || data.location_barcode
@@ -173,6 +162,19 @@ export class OdooMocked extends OdooMixin {
         if (_.has(result, "ok")) {
             // Pick the case were you have good or bad result
             result = result.ok;
+        }
+        if (!result) {
+            // Provide your own mock by enpoint
+            let mocked_handler = "mocked_" + path;
+            if (!_.isUndefined(this[mocked_handler])) {
+                result = this[mocked_handler].call(this, data);
+            }
+            // Provide your own mock by service and endpoint
+            mocked_handler = "mocked_" + this.usage + "_" + path;
+            if (!_.isUndefined(this[mocked_handler])) {
+                // Provide your own mock by enpoint and specific process
+                result = this[mocked_handler].call(this, data);
+            }
         }
         if (!result) {
             throw "NOT IMPLEMENTED: " + path;

--- a/shopfloor_mobile_base/templates/main.xml
+++ b/shopfloor_mobile_base/templates/main.xml
@@ -34,11 +34,12 @@
                 <script type="text/javascript">
           var shopfloor_app_info = <t t-raw="json.dumps(app_info)" />;
         </script>
-                <t t-call="shopfloor_mobile_base.shopfloor_app_assets" />
+                <!-- TODO: it would be nice to load this resources dinamically (see Roadmap) -->
                 <t
                     t-call="shopfloor_mobile_base.shopfloor_app_demo_assets"
                     t-if="app_info.demo_mode"
                 />
+                <t t-call="shopfloor_mobile_base.shopfloor_app_assets" />
             </t>
             <noscript>
                 <strong>


### PR DESCRIPTION
This PR:
- Loads the demo assets before the app assets to fix an error related to assets with type="module" (more info [here](https://javascript.info/modules-intro#:~:text=downloading%20external%20module%20scripts%20%3Cscript%20type%3D%22module%22%20src%3D%22...%22%3E%20doesn%E2%80%99t%20block%20HTML%20processing%2C%20they%20load%20in%20parallel%20with%20other%20resources.)).
- Updates the _call method used in the mocked odoo so that the mocked handlers only take effect if there's no other demo data available.