### PR TITLE
[14.0][FIX] shopfloor: fix user comparison in 'mark_move_lines_as_picked'

### DIFF
--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -33,7 +33,7 @@ class StockAction(Component):
                 "printed": True,
             }
         )
-        move_lines.picking_id.filtered(lambda p: p.user_id != user.id).user_id = user.id
+        move_lines.picking_id.filtered(lambda p: p.user_id != user).user_id = user.id
 
     def validate_moves(self, moves):
         """Validate moves in different ways depending on several criterias:


### PR DESCRIPTION
Fix related to #403 
```
WARNING odoo odoo.models: Comparing apples and oranges: res.users(209,) == 209 (/__w/wms/wms/shopfloor/actions/stock.py:36)
```