### PR TITLE
[14.0] sale_stock_available_to_promise_release_cutoff: set to Alpha

### DIFF
--- a/sale_stock_available_to_promise_release_cutoff/__manifest__.py
+++ b/sale_stock_available_to_promise_release_cutoff/__manifest__.py
@@ -16,4 +16,5 @@
     "auto_install": True,
     "license": "AGPL-3",
     "application": False,
+    "development_status": "Alpha",
 }


### PR DESCRIPTION
As the dependency 'sale_delivery_date' is still in Alpha.

This will fix the CI builds.