### PR TITLE
[WIP][14.0] stock_storage_type: set putaway dest. on package_levels

### DIFF
--- a/stock_storage_type/models/stock_move.py
+++ b/stock_storage_type/models/stock_move.py
@@ -12,3 +12,18 @@ class StockMove(models.Model):
         return super()._prepare_move_line_vals(
             quantity=quantity, reserved_quant=reserved_quant
         )
+
+    def _action_assign(self):
+        # The computation done by the putaway strategy is acting on moves, not
+        # on the package levels that could be linked to several products/moves,
+        # so we have to trigger the computation on the package level as well
+        # to get the expected putaway destination.
+        res = super()._action_assign()
+        package_level_ids = [
+            move.package_level_id.id
+            for move in self
+            if move.state == "assigned" and len(move.package_level_id.move_ids) > 1
+        ]
+        package_levels = self.env["stock.package_level"].browse(package_level_ids)
+        package_levels.recompute_pack_putaway()
+        return res


### PR DESCRIPTION
For packages containing several products, the putaway destination has to be set manually by clicking on the "Recompute putaway destination" button while it is done automatically for simple moves (or package levels with only one product/move).
This commit aims to set the putaway destination automatically when the underlying moves are assigned.

I am not sure about this PR yet, and it introduces regressions (a test has been added to raise it). Is it something we want? I don't know why the putaway of a package level has to be computed manually currently, I miss some info.

cc @jbaudoux 