### PR TITLE
[14.0][FIX] shopfloor, single pack transfer: set putaway destination for mixed package levels

### DIFF
--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -190,7 +190,6 @@ class SinglePackTransfer(Component):
                 "company_id": self.env.company.id,
             }
         )
-        package_level._generate_moves()
         picking.action_confirm()
         picking.action_assign()
         return package_level

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -275,8 +275,8 @@ class SinglePackTransfer(Component):
                 message=self.msg_store.operation_not_found()
             )
         # package.move_ids may be empty, it seems
-        move = package_level.move_line_ids.move_id
-        if move.state == "done":
+        moves = package_level.move_ids | package_level.move_line_ids.move_id
+        if "done" in moves.mapped("state"):
             return self._response_for_start(message=self.msg_store.already_done())
 
         package_level.is_done = False

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -192,6 +192,11 @@ class SinglePackTransfer(Component):
         )
         picking.action_confirm()
         picking.action_assign()
+        # For packages that contain several products (so linked to several
+        # moves), the putaway destination computation of the strategy
+        # triggered by `action_assign()` above won't work, so we trigger
+        # the computation manually here at the package level.
+        package_level.recompute_pack_putaway()
         return package_level
 
     def _is_move_state_valid(self, moves):


### PR DESCRIPTION
For packages that contain several products (so linked to several moves), the putaway destination computation of the strategy triggered by `action_assign()` above won't work, so we trigger the computation manually here at the package level to get the expected destination.

A first attempt was to handle this in the base module `stock_storage_type` (see #423), but I miss some knowledge there as it introduces a regression.

The last commit is here to fix a singleton error we have when canceling a flow processing a mixed package level:
```python
Traceback (most recent call last):
  File "/odoo/external-src/rest-framework/rest_log/components/service.py", line 43, in _dispatch_with_db_logging
    result = super().dispatch(method_name, *args, params=params)
  File "/odoo/external-src/rest-framework/base_rest/components/service.py", line 158, in dispatch
    res = method(*args, **secure_params)
  File "/odoo/external-src/rest-framework/base_rest/restapi.py", line 102, in response_wrap
    response = f(*args, **kw)
  File "/odoo/external-src/wms/shopfloor/services/single_pack_transfer.py", line 279, in cancel
    if move.state == "done":
  File "/odoo/src/odoo/fields.py", line 965, in __get__
    record.ensure_one()
  File "/odoo/src/odoo/models.py", line 5011, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: stock.move(2445619, 2445620)
```

Ref. rau-39