### PR TITLE
[14.0][FIX] shopfloor_mobile: make qty picker reactive

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -290,6 +290,9 @@ export var PackagingQtyPickerDisplay = Vue.component("packaging-qty-picker-displ
             return _.filter(this.sorted_packaging, this.display_pkg);
         },
     },
+    updated: function () {
+        this.qty_todo = parseInt(this.opts.init_value, 10);
+    },
     template: `
 <div :class="[$options._componentTag, opts.mode ? 'mode-' + opts.mode: '', 'd-inline']">
     <span class="packaging" v-for="(pkg, index) in visible_packaging" :key="make_component_key([pkg.id])">

--- a/shopfloor_mobile/static/wms/src/demo/demo.checkout.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.checkout.js
@@ -82,6 +82,14 @@ const DEMO_CHECKOUT = {
             select_line: {picking: select_line_picking},
         },
     },
+    scan_package_action: function (data) {
+        const res = data_for_select_package;
+        const line = res.data.select_package.selected_move_lines.find(function (x) {
+            return x.product.barcode == data.barcode;
+        });
+        line.qty_done++;
+        return res;
+    },
     list_stock_picking: {
         next_state: "manual_selection",
         message: null,


### PR DESCRIPTION
Component "packaging-qty-picker-display" was not working as intended, as the qty_todo was only being evaluated when mounting the component for the first time.
It now uses an updated hook to take care of that.