### PR TITLE
Add sublocation scan on shopfloor delivery scenario

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -421,6 +421,29 @@ class MessageAction(Component):
             ).format(location_dest.name),
         }
 
+    def product_in_multiple_sublocation(self, product):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "Product {} found in multiple locations. Scan your location first."
+            ).format(product.name),
+        }
+
+    def lot_in_multiple_sublocation(self, lot):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "Lot {lot} for product {product} found in multiple locations. "
+                "Scan your location first."
+            ).format(lot=lot.name, product=lot.product_id.name),
+        }
+
+    def location_src_set_to_sublocation(self, location_src):
+        return {
+            "message_type": "success",
+            "body": _("Working location changed to {}").format(location_src.name),
+        }
+
     def picking_already_started_in_location(self, pickings):
         return {
             "message_type": "error",

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -40,6 +40,7 @@ from . import test_delivery_reset_qty_done_line
 from . import test_delivery_reset_qty_done_pack
 from . import test_delivery_set_qty_done_pack
 from . import test_delivery_set_qty_done_line
+from . import test_delivery_sublocation
 from . import test_delivery_list_stock_picking
 from . import test_delivery_select
 from . import test_location_content_transfer_base

--- a/shopfloor/tests/test_delivery_base.py
+++ b/shopfloor/tests/test_delivery_base.py
@@ -75,11 +75,21 @@ class DeliveryCommonCase(CommonCase):
     def _stock_picking_data(self, picking):
         return self.service.data_detail.picking_detail(picking)
 
-    def assert_response_deliver(self, response, picking=None, message=None):
+    def _stock_location_data(self, location):
+        return self.service.data.location(location)
+
+    def assert_response_deliver(
+        self, response, picking=None, message=None, location=None
+    ):
         self.assert_response(
             response,
             next_state="deliver",
-            data={"picking": self._stock_picking_data(picking) if picking else None},
+            data={
+                "picking": self._stock_picking_data(picking) if picking else None,
+                "sublocation": self._stock_location_data(location)
+                if location
+                else None,
+            },
             message=message,
         )
 

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -86,7 +86,12 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
 
     def test_scan_deliver_scan_picking_ok(self):
         response = self.service.dispatch(
-            "scan_deliver", params={"barcode": self.picking.name, "picking_id": None}
+            "scan_deliver",
+            params={
+                "barcode": self.picking.name,
+                "picking_id": None,
+                "location_id": None,
+            },
         )
         self.assert_response_deliver(response, picking=self.picking)
 

--- a/shopfloor/tests/test_delivery_sublocation.py
+++ b/shopfloor/tests/test_delivery_sublocation.py
@@ -1,0 +1,175 @@
+# Copyright 2022 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from .test_delivery_base import DeliveryCommonCase
+
+
+class DeliveryScanSublocationCase(DeliveryCommonCase):
+    """Tests sublocation with delivery service."""
+
+    @classmethod
+    def setUpClassBaseData(cls):
+        super().setUpClassBaseData()
+        cls.product_e.tracking = "lot"
+        cls.sublocation = (
+            cls.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "name": "Output 1",
+                    "location_id": cls.picking_type.default_location_src_id.id,
+                    "usage": "internal",
+                    "barcode": "WH-OUTPUT-1",
+                }
+            )
+        )
+        # Picking for the sublocation
+        cls.picking_sublocation = cls._create_picking(
+            lines=[
+                (cls.product_d, 10),  # D as raw product
+                (cls.product_e, 10),  # E as raw product with a lot
+            ]
+        )
+        cls.picking_sublocation.location_id = cls.sublocation
+        cls.raw_move_sublocation = cls.picking_sublocation.move_lines[0]
+        cls.raw_lot_move_sublocation = cls.picking_sublocation.move_lines[1]
+        cls._fill_stock_for_moves(cls.raw_move_sublocation)
+        cls._fill_stock_for_moves(cls.raw_lot_move_sublocation, in_lot=True)
+        cls.picking_sublocation.action_assign()
+        # Picking for the top location
+        cls.picking = picking = cls._create_picking(
+            lines=[
+                (cls.product_d, 10),  # D as raw product
+                (cls.product_e, 10),  # E as raw product with a lot
+            ]
+        )
+        cls.raw_move = picking.move_lines[0]
+        cls.raw_lot_move = picking.move_lines[1]
+        cls._fill_stock_for_moves(cls.raw_move)
+        # Use the same lot on product from both picking
+        cls.lot = cls.raw_lot_move_sublocation.move_line_ids.lot_id
+        cls._fill_stock_for_moves(cls.raw_lot_move, in_lot=cls.lot)
+        picking.action_assign()
+
+    def test_scan_sublocation_exists(self):
+        """Check scanning a sublocation sets it as sublocation."""
+        response = self.service.dispatch(
+            "scan_deliver",
+            params={
+                "barcode": self.sublocation.barcode,
+                "picking_id": None,
+                "location_id": None,
+            },
+        )
+        self.assert_response_deliver(
+            response,
+            picking=None,
+            location=self.sublocation,
+            message=self.service.msg_store.location_src_set_to_sublocation(
+                self.sublocation
+            ),
+        )
+
+    def test_scan_invalid_barcode_in_sublocation(self):
+        response = self.service.dispatch(
+            "scan_deliver",
+            params={
+                "barcode": "NO VALID BARCODE",
+                "picking_id": None,
+                "location_id": self.sublocation.id,
+            },
+        )
+        self.assert_response_deliver(
+            response,
+            location=self.sublocation,
+            message=self.service.msg_store.barcode_not_found(),
+        )
+
+    def test_scan_barcode_in_sublocation(self):
+        """Scan product barcode that exists in sublocation."""
+        response = self.service.dispatch(
+            "scan_deliver",
+            params={
+                "barcode": self.product_d.barcode,
+                "picking_id": None,
+                "location_id": self.sublocation.id,
+            },
+        )
+        self.assert_response_deliver(
+            response,
+            location=self.sublocation,
+            picking=self.picking_sublocation,
+        )
+
+    def test_scan_product_not_in_sublocation(self):
+        """Scan a product in picking type location but not in sublocation set."""
+        response = self.service.dispatch(
+            "scan_deliver",
+            params={
+                "barcode": self.product_c.barcode,
+                "picking_id": None,
+                "location_id": self.sublocation.id,
+            },
+        )
+        self.assert_response_deliver(
+            response,
+            location=self.sublocation,
+            message=self.service.msg_store.product_not_found_in_pickings(),
+        )
+
+    def test_scan_product_exist_in_multiple_sublocation(self):
+        """Check scan of product in multiple location will ask to scan a location."""
+        response = self.service.dispatch(
+            "scan_deliver",
+            params={
+                "barcode": self.product_d.barcode,
+                "picking_id": None,
+            },
+        )
+        self.assert_response_deliver(
+            response,
+            message=self.service.msg_store.product_in_multiple_sublocation(
+                self.product_d
+            ),
+        )
+
+    def test_list_stock_picking_sublocation(self):
+        """Check manual selection filter picking in sublocation."""
+        response = self.service.dispatch(
+            "list_stock_picking", params={"location_id": self.sublocation.id}
+        )
+        self.assert_response_manual_selection(
+            response,
+            pickings=self.picking_sublocation,
+        )
+
+    def test_scan_lot_in_sublocation(self):
+        """Scan a lot that exists in sublocation."""
+        lot = self.raw_lot_move_sublocation.move_line_ids.lot_id
+        response = self.service.dispatch(
+            "scan_deliver",
+            params={
+                "barcode": lot.name,
+                "picking_id": None,
+                "location_id": self.sublocation.id,
+            },
+        )
+        self.assert_response_deliver(
+            response,
+            location=self.sublocation,
+            picking=self.picking_sublocation,
+        )
+
+    def test_scan_lot_exist_in_multiple_sublocation(self):
+        """Check scanning lot in multiple location, will ask location scan first."""
+        response = self.service.dispatch(
+            "scan_deliver",
+            params={
+                "barcode": self.lot.name,
+                "picking_id": None,
+            },
+        )
+        self.assert_response_deliver(
+            response,
+            message=self.service.msg_store.lot_in_multiple_sublocation(self.lot),
+        )

--- a/shopfloor_mobile/static/wms/src/scenario/delivery.js
+++ b/shopfloor_mobile/static/wms/src/scenario/delivery.js
@@ -12,6 +12,7 @@ const Delivery = {
     template: `
         <Screen :screen_info="screen_info">
             <template v-slot:header>
+                <state-display-info :info="current_location_msg()" v-if="current_location()"/>
                 <state-display-info :info="state.display_info" v-if="state.display_info"/>
             </template>
             <searchbar
@@ -37,6 +38,11 @@ const Delivery = {
                     />
             </div>
             <div class="button-list button-vertical-list full">
+                <v-row align="center" v-if="state_is('deliver') && is_current_location_set()">
+                    <v-col class="text-center" cols="12">
+                        <btn-action @click="reset_current_location">Reset location</btn-action>
+                    </v-col>
+                </v-row>
                 <v-row align="center" v-if="state_is('deliver') && has_picking()">
                     <v-col class="text-center" cols="12">
                         <btn-action @click="state.on_mark_as_done">Make partial delivery</btn-action>
@@ -79,6 +85,30 @@ const Delivery = {
                 return {};
             }
             return data.picking;
+        },
+        current_location: function () {
+            const data = this.state_get_data("deliver");
+            if (_.isEmpty(data) || _.isEmpty(data.sublocation)) {
+                return {};
+            }
+            return data.sublocation;
+        },
+        is_current_location_set: function () {
+            return !_.isEmpty(this.current_location());
+        },
+        reset_current_location: function () {
+            this.wait_call(
+                this.odoo.call("scan_deliver", {
+                    barcode: "",
+                    picking_id: this.current_picking().id,
+                })
+            );
+        },
+        current_location_msg: function () {
+            if (this.current_location().id) {
+                return {title: "Working from location " + this.current_location().name};
+            }
+            return "";
         },
         has_picking: function () {
             return !_.isEmpty(this.current_picking());
@@ -157,7 +187,7 @@ const Delivery = {
                 select_document: {
                     display_info: {
                         title: "Start by scanning something",
-                        scan_placeholder: "Scan pack / picking",
+                        scan_placeholder: "Scan pack / product / picking / location",
                     },
                     on_scan: (scanned) => {
                         this.wait_call(
@@ -171,7 +201,7 @@ const Delivery = {
                 deliver: {
                     display_info: {
                         title: "Scan another document",
-                        scan_placeholder: "Scan pack / picking",
+                        scan_placeholder: "Scan pack / product / picking / location",
                     },
                     events: {
                         cancel_picking_line: "on_cancel",
@@ -181,11 +211,16 @@ const Delivery = {
                             this.odoo.call("scan_deliver", {
                                 barcode: scanned.text,
                                 picking_id: this.current_picking().id,
+                                location_id: this.current_location().id,
                             })
                         );
                     },
                     on_manual_selection: (evt) => {
-                        this.wait_call(this.odoo.call("list_stock_picking"));
+                        this.wait_call(
+                            this.odoo.call("list_stock_picking", {
+                                location_id: this.current_location().id,
+                            })
+                        );
                     },
                     on_cancel: (data) => {
                         let endpoint, endpoint_data;


### PR DESCRIPTION
When scanning a product barcode or a lot the scenario will search
for all related move lines and pick the first one by default.

For a shopfloor menu configuration with locations containing sub locations
this is not ideal. Because a user working at a sub location only wants
move lines related to that sub location to be selected.

To help with this situation, a user can first scan his working location
which is kept as long as no other location is scanned.
The sub location set can also be reset by the click of a button.

Also when the search for a move line to work on returns multiple move lines
related to different locations and no location has been preliminary scanned.
The user will be prompted to scann a location first.