### PR TITLE
[14.0] shopfloor: change search location action

### DIFF
--- a/shopfloor/actions/search.py
+++ b/shopfloor/actions/search.py
@@ -14,13 +14,16 @@ class SearchAction(Component):
 
     # TODO: these methods shall be probably replaced by scan anything handlers
 
-    def location_from_scan(self, barcode):
+    def location_from_scan(self, barcode, limit=1):
         model = self.env["stock.location"]
         if not barcode:
             return model.browse()
-        return model.search(
-            ["|", ("barcode", "=", barcode), ("name", "=", barcode)], limit=1
-        )
+        # First search location by barcode
+        res = model.search([("barcode", "=", barcode)], limit=limit)
+        # And only if we have not found through barcode search on the location name
+        if len(res) < limit:
+            res |= model.search([("name", "=", barcode)], limit=(limit - len(res)))
+        return res
 
     def package_from_scan(self, barcode):
         model = self.env["stock.quant.package"]

--- a/shopfloor/tests/test_actions_search.py
+++ b/shopfloor/tests/test_actions_search.py
@@ -22,6 +22,13 @@ class TestSearchCase(TestSearchBaseCase):
         self.assertEqual(handler(False), rec.browse())
         self.assertEqual(handler("NONE"), rec.browse())
 
+    def test_search_location_with_limit(self):
+        rec = self.customer_location
+        rec2 = self.customer_location.sudo().copy({"barcode": "CUSTOMERS2"})
+        handler = self.search.location_from_scan
+        res = handler("Customers", 2)
+        self.assertEqual(res, rec + rec2)
+
     def test_search_package(self):
         rec = self.env["stock.quant.package"].sudo().create({"name": "1234"})
         handler = self.search.package_from_scan


### PR DESCRIPTION
Change the search to first look on the barcode field and then on
location name.