### PR TITLE
shopfloor: zone picking scenario stay in zone

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -458,9 +458,8 @@ class ZonePicking(Component):
             return response, message
 
         if not location.is_sublocation_of(self.zone_location):
-            response = self._response_for_start(
-                message=self.msg_store.location_not_allowed()
-            )
+            response = self._list_move_lines(self.zone_location)
+            message = self.msg_store.location_not_allowed()
             return response, message
 
         product, lot, package = self._find_product_in_location(location)

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -103,8 +103,12 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             "scan_source",
             params={"barcode": self.customer_location.barcode},
         )
-        self.assert_response_start(
+        move_lines = self.service._find_location_move_lines()
+        self.assert_response_select_line(
             response,
+            self.zone_location,
+            self.picking_type,
+            move_lines,
             message=self.service.msg_store.location_not_allowed(),
         )
 


### PR DESCRIPTION
When scanning a location out of the previously selected zone, instead of
sending the user back to the start, keep him on the line selection of
the zone.
ref: rau-60