### PR TITLE
[14.0] stock_available_to_promise_release: propagate date_priority

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -94,7 +94,7 @@ class StockMove(models.Model):
                         OR (
                             m.priority = move.priority
                             AND m.date_priority = move.date_priority
-                            AND m.id < move.id
+                            AND m.id > move.id
                         )
                     )
                     OR (
@@ -288,6 +288,11 @@ class StockMove(models.Model):
         if self.env.context.get("release_available_to_promise"):
             vals.update({"procure_method": self.procure_method, "need_release": True})
         return vals
+
+    def _prepare_procurement_values(self):
+        res = super()._prepare_procurement_values()
+        res["date_priority"] = self.date_priority
+        return res
 
     def _run_stock_rule(self):
         """Launch procurement group run method with remaining quantity

--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -10,6 +10,9 @@ _logger = logging.getLogger(__name__)
 class StockRule(models.Model):
     _inherit = "stock.rule"
 
+    def _get_custom_move_fields(self):
+        return super()._get_custom_move_fields() + ["date_priority"]
+
     def _run_pull(self, procurements):
         actions_to_run = []
 


### PR DESCRIPTION
In case of multi-stages releases, the priority date must be kept.
The new moves created have bigger ids, so the comparison sign for moves having same priority date has been inverted to propagate the allocation to the new moves.

cc @sebalix @mt-software-de 