### PR TITLE
[14.0] stock_available_to_promise_release: multi-stages of release

### DIFF
--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -10,6 +10,9 @@ _logger = logging.getLogger(__name__)
 class StockRule(models.Model):
     _inherit = "stock.rule"
 
+    def _get_custom_move_fields(self):
+        return super()._get_custom_move_fields() + ["date_priority"]
+
     def _run_pull(self, procurements):
         actions_to_run = []
 


### PR DESCRIPTION
In case of multi-stages releases, the priority date must be kept.
The new moves created have bigger ids, so the comparison sign for moves having same priority date has been inverted to propagate the allocation to the new moves

cc @sebalix @mt-software-de 