### PR TITLE
[14.0] sf_mobile_base: add report issue action

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/misc.js
+++ b/shopfloor_mobile_base/static/wms/src/components/misc.js
@@ -383,10 +383,15 @@ Vue.component("user-session-detail", {
             type: Boolean,
             default: true,
         },
+        show_report_issue_action: {
+            type: Boolean,
+            default: true,
+        },
     },
     template: `
   <div :class="$options._componentTag" data-ref="user-session-detail">
     <v-list>
+        <report-issue-action v-if="show_report_issue_action" />
         <v-list-item v-if="show_env"
                 data-ref="session-detail-env"
                 :data-id="$root.app_info.running_env"

--- a/shopfloor_mobile_base/static/wms/src/components/report_issue.js
+++ b/shopfloor_mobile_base/static/wms/src/components/report_issue.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2022 Camptocamp SA (http://www.camptocamp.com)
+ * @author Simone Orsi <simahawk@gmail.com>
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+ */
+
+/* eslint-disable strict */
+import {config_registry} from "/shopfloor_mobile_base/static/wms/src/services/config_registry.js";
+
+config_registry.add("report_issue_config", {
+    default: _.result(shopfloor_app_info, "report_issue_config", {
+        enabled: false,
+        mail_to: "",
+    }),
+});
+
+const REPORT_ISSUE_TEMPLATES = {
+    inline: Vue.compile(`
+        <a class="report-issue-action text-decoration-none"
+           :href="report_issue_mail_to_href">
+           <v-icon v-text="icon"></v-icon> <span v-text="$t('app.report_issue.action_txt')" />
+        </a>
+    `),
+    vertical: Vue.compile(`
+        <v-list-item v-if="report_issue_enabled"
+            class="report-issue-action"
+            data-ref="report-issue-action"
+            :href="report_issue_mail_to_href"
+            >
+            <v-list-item-avatar>
+                <v-avatar :size="icon_size" color="info">
+                    <v-icon dark v-text="icon"></v-icon>
+                </v-avatar>
+            </v-list-item-avatar>
+            <v-list-item-content>
+                <span v-text="$t('app.report_issue.action_txt')" />
+            </v-list-item-content>
+        </v-list-item>
+  `),
+};
+
+Vue.component("report-issue-action", {
+    props: {
+        display_mode: {
+            type: String,
+            default: "vertical",
+        },
+        icon: {
+            type: String,
+            default: "mdi-help-circle-outline",
+        },
+        icon_size: {
+            type: Number,
+            default: 36,
+        },
+    },
+    computed: {
+        report_issue_conf: function () {
+            return this.$root.report_issue_config;
+        },
+        report_issue_enabled: function () {
+            const enabled = this.report_issue_conf.enabled;
+            const configured = _.result(this.report_issue_conf, "mail_to", "").trim()
+                .length;
+            return enabled && configured;
+        },
+        report_issue_mail_to_href: function () {
+            if (!this.report_issue_enabled) {
+                return "";
+            }
+            const email = this.report_issue_conf.mail_to;
+            const subject = this.$t("app.report_issue.mail.subject", {
+                app_name: this.$root.app_info.name,
+            });
+            const body = encodeURIComponent(this._get_report_issue_body());
+            return `mailto:${email}?subject=${subject}&body=${body}`;
+        },
+    },
+    methods: {
+        _get_report_issue_body: function () {
+            const bits = [
+                "",
+                "",
+                "-- " + this.$t("app.report_issue.mail.info_warning_msg") + " --",
+                "",
+                "APP: " + this.$root.app_info.version,
+                "UID: " + this.$root.user.id,
+                "UA: " + window.navigator.userAgent,
+            ];
+            return bits.join("\n");
+        },
+    },
+    render(createElement) {
+        const tmpl = REPORT_ISSUE_TEMPLATES[this.display_mode];
+        return tmpl.render.call(this, createElement);
+    },
+});

--- a/shopfloor_mobile_base/static/wms/src/components/screen.js
+++ b/shopfloor_mobile_base/static/wms/src/components/screen.js
@@ -343,10 +343,9 @@ Vue.component("app-bar-actions", {
 Vue.component("app-version-footer", {
     template: `
         <v-footer absolute padless>
-                <v-col class="text-center font-weight-light" cols="12">
-                    <span class="version">{{ $t('screen.home.version') }}</span> <span class="version-number" v-text="$root.app_info.version" />
-                </v-col>
-            </v-footer>
-        <div>
+            <v-col class="text-center font-weight-light" cols="12">
+                <span class="version">{{ $t('screen.home.version') }}</span> <span class="version-number" v-text="$root.app_info.version" />
+            </v-col>
+        </v-footer>
     `,
 });

--- a/shopfloor_mobile_base/static/wms/src/i18n/i18n.de.js
+++ b/shopfloor_mobile_base/static/wms/src/i18n/i18n.de.js
@@ -72,6 +72,14 @@ const messages_de = {
             test: "Test",
             dev: "Entwicklung",
         },
+        report_issue: {
+            action_txt: "Benötigen Sie Unterstützung?",
+            mail: {
+                subject: "Ich benötige Unterstützung mit der {app_name} app",
+                info_warning_msg:
+                    "BITTE ÄNDERN SIE DIE FOLGENDE INFORMATION/NACHRICHT NICHT",
+            },
+        },
     },
     language: {
         name: {

--- a/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
+++ b/shopfloor_mobile_base/static/wms/src/i18n/i18n.en.js
@@ -70,6 +70,13 @@ const messages_en = {
             test: "Test",
             dev: "Development",
         },
+        report_issue: {
+            action_txt: "Need help?",
+            mail: {
+                subject: "I need help with the {app_name} app",
+                info_warning_msg: "PLEASE, DO NOT ALTER THE INFO BELOW",
+            },
+        },
     },
     language: {
         name: {

--- a/shopfloor_mobile_base/static/wms/src/i18n/i18n.fr.js
+++ b/shopfloor_mobile_base/static/wms/src/i18n/i18n.fr.js
@@ -71,6 +71,14 @@ const messages_fr = {
             test: "Test",
             dev: "Développement",
         },
+        report_issue: {
+            action_txt: "Besoin d'aide?",
+            mail: {
+                subject: "J'ai besoin d'aide avec l'application {app_name}",
+                info_warning_msg:
+                    "VEUILLEZ NE PAS MODIFIER LES INFORMATIONS CI-DESSOUS",
+            },
+        },
     },
     language: {
         name: {

--- a/shopfloor_mobile_base/static/wms/src/loginpage.js
+++ b/shopfloor_mobile_base/static/wms/src/loginpage.js
@@ -75,7 +75,7 @@ export var LoginPage = Vue.component("login-page", {
                         elevation="2"
                         :icon="false"
                         >
-                        <user-session-detail :show_profile="false" :show_user="false" />
+                        <user-session-detail :show_profile="false" :show_user="false" :show_report_issue_action="false" />
                     </v-alert>
                 </v-col>
             </v-row>
@@ -94,6 +94,13 @@ export var LoginPage = Vue.component("login-page", {
                 <v-row align="center">
                     <v-col class="text-center" cols="12">
                         <btn-fullscreen />
+                    </v-col>
+                </v-row>
+            </div>
+            <div class="button-list button-vertical-list full">
+                <v-row align="center">
+                    <v-col class="text-center" cols="12">
+                        <report-issue-action display_mode="inline" />
                     </v-col>
                 </v-row>
             </div>

--- a/shopfloor_mobile_base/templates/assets.xml
+++ b/shopfloor_mobile_base/templates/assets.xml
@@ -141,6 +141,11 @@
             type="module"
         />
         <script
+            id="script_component_report_issue"
+            t-attf-src="/shopfloor_mobile_base/static/wms/src/components/report_issue.js?v=#{app_info.version}"
+            type="module"
+        />
+        <script
             id="script_component_misc"
             t-attf-src="/shopfloor_mobile_base/static/wms/src/components/misc.js?v=#{app_info.version}"
             type="module"


### PR DESCRIPTION
When users have troubles w/ the app
having an easy way to report an issue
with proper technical info is very handy.

Here we go by using direct emails
so that if there's an issue w/ the service
you bypass it completely.

You can enable and customized it via shopfloor_app_info params.