### PR TITLE
[14.0][FIX] shopfloor, delivery: process lines of one delivery operation

### DIFF
--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -285,3 +285,11 @@ class StockMoveLine(models.Model):
         # triggered, force it
         to_assign_moves.move_line_ids.package_level_id.modified(["move_line_ids"])
         self.package_level_id.modified(["move_line_ids"])
+
+    def _filter_on_picking(self, picking=False):
+        """Filter a bunch of lines on a picking.
+
+        If no picking is provided the first one is taken.
+        """
+        picking = picking or fields.first(self.picking_id)
+        return self.filtered_domain([("picking_id", "=", picking.id)])

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -367,6 +367,10 @@ class Delivery(Component):
                     location=location,
                     message=self.msg_store.product_mixed_package_scan_package(),
                 )
+        # Filter lines to keep only ones from one delivery operation
+        # (we do not want to process lines of another delivery operation)
+        lines = lines._filter_on_picking(picking)
+        # Validate lines (this will validate the delivery if all lines are processed)
         if self._set_lines_done(lines, product_qty):
             return self._response_for_deliver(
                 location=location, message=self.msg_store.transfer_complete(new_picking)

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -183,6 +183,35 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
             self.raw_move.mapped("move_line_ids"), self.product_d.barcode
         )
 
+    def test_scan_deliver_scan_raw_product_in_multiple_pickings(self):
+        # Scan a raw product (not related to a package or lot) which is present
+        # in multiple delivery operations (so two different moves).
+        # We should be able to process these two moves one after the other.
+        picking2 = self._create_picking(
+            lines=[
+                # D as raw product
+                (self.product_d, 10),
+            ]
+        )
+        raw_move2 = picking2.move_lines
+        self._fill_stock_for_moves(raw_move2)
+        picking2.action_assign()
+        # Scan the first move
+        self._test_scan_set_done_ok(
+            self.raw_move.mapped("move_line_ids"), self.product_d.barcode
+        )
+        # Scan the second move
+        # NOTE: we do not use '_test_scan_set_done_ok' here as we expect
+        # the delivery to be complete (we process its only move line).
+        response = self.service.dispatch(
+            "scan_deliver", params={"barcode": self.product_d.barcode}
+        )
+        self.assert_response_deliver(
+            response, message=self.service.msg_store.transfer_complete(picking2)
+        )
+        self.assertEqual(raw_move2.quantity_done, 10)
+        self.assertEqual(raw_move2.state, "done")
+
     def test_scan_deliver_scan_product_not_found(self):
         response = self.service.dispatch(
             "scan_deliver", params={"barcode": self.free_product.barcode}


### PR DESCRIPTION
If the same bulk product was present in several delivery operations (of the same picking type), the first call to `scan_deliver` was working, but with the side-effect to set the `qty_done` for the lines of ALL delivery operations related to this product.

This fix will process only the lines from one delivery operation at a time, leaving the other lines untouched so they can be processed by subsequent calls to `scan_deliver`, without raising the `"No product found among current transfers."` error anymore (product was not found because of the `qty_done` set during the first scan).

cc @jbaudoux 

Ref rau-69