### PR TITLE
[16.0] stock_available_to_promise_release: manage backorders and allows unrelease

### DIFF
--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Stock Available to Promise Release",
-    "version": "16.0.1.0.0",
+    "version": "16.0.2.0.0",
     "summary": "Release Operations based on available to promise",
     "author": "Camptocamp,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",

--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -18,6 +18,7 @@
         "views/stock_route_views.xml",
         "views/res_config_settings.xml",
         "wizards/stock_release_views.xml",
+        "wizards/stock_unrelease_views.xml",
     ],
     "installable": True,
     "license": "LGPL-3",

--- a/stock_available_to_promise_release/migrations/16.0.2.0.0/post-migrate.py
+++ b/stock_available_to_promise_release/migrations/16.0.2.0.0/post-migrate.py
@@ -1,0 +1,14 @@
+# Copyright 2022 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info(
+        "stock_available_to_promise_release: Configure picking types"
+        " to prevent new moves into released pickings"
+    )
+    cr.execute("update stock_picking_type set prevent_new_move_after_release = true")

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -514,8 +514,10 @@ class StockMove(models.Model):
         moves_to_unrelease._check_unrelease_allowed()
         moves_to_unrelease.write({"need_release": True})
         impacted_picking_ids = set()
+
         for move in moves_to_unrelease:
             iterator = move._get_chained_moves_iterator("move_orig_ids")
+            moves_to_cancel = self.env["stock.move"]
             next(iterator)  # skip the current move
             for origin_moves in iterator:
                 origin_moves = origin_moves.filtered(
@@ -526,7 +528,9 @@ class StockMove(models.Model):
                     impacted_picking_ids.update(origin_moves.mapped("picking_id").ids)
                     # avoid to propagate cancel to the original move
                     origin_moves.write({"propagate_cancel": False})
-                    origin_moves._action_cancel()
+                    # origin_moves._action_cancel()
+                    moves_to_cancel |= origin_moves
+            moves_to_cancel._action_cancel()
         moves_to_unrelease.write({"need_release": True})
         for picking, moves in itertools.groupby(
             moves_to_unrelease, lambda m: m.picking_id

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -427,9 +427,6 @@ class StockMove(models.Model):
 
         self.env["procurement.group"].run_defer(procurement_requests)
 
-        # Set all transfers released to "printed", consider the work has
-        # been planned and started and another "release" of moves should
-        # (for instance) merge new pickings with this "round of release".
         pulled_moves._after_release_assign_moves()
         pulled_moves._after_release_update_chain()
 
@@ -473,12 +470,6 @@ class StockMove(models.Model):
         """
         context = self.env.context
         self = self.with_context(release_available_to_promise=True)
-        # Rely on `printed` flag to make _assign_picking create a new picking.
-        # See `stock.move._assign_picking` and
-        # `stock.move._search_picking_for_assignation`.
-        original_printed = self.picking_id.printed
-        if not self.picking_id.printed and not self.rule_id.no_backorder_at_release:
-            self.picking_id.printed = True
         new_move = self  # Work on the current move if split doesn't occur
         new_move_vals = self._split(remaining_qty)
         if new_move_vals:
@@ -488,10 +479,6 @@ class StockMove(models.Model):
         # thus the `_should_be_assigned` condition is not satisfied
         # and the move is not assigned.
         new_move._assign_picking()
-
-        # restore the original value of the printed flag only used to ensure
-        # that a backorder is created if required
-        self.picking_id.printed = original_printed
         return new_move.with_context(**context)
 
     def _assign_picking_post_process(self, new=False):
@@ -569,3 +556,13 @@ class StockMove(models.Model):
                 break
             origins -= origin
         return new_origin_moves
+
+    def _search_picking_for_assignation_domain(self):
+        domain = super()._search_picking_for_assignation_domain()
+        if self.env.context.get("release_available_to_promise"):
+            force_new_picking = not self.rule_id.no_backorder_at_release
+            if force_new_picking:
+                domain = expression.AND([domain, [("id", "!=", self.picking_id.id)]])
+        if self.picking_type_id.prevent_new_move_after_release:
+            domain = expression.AND([domain, [("last_release_date", "=", False)]])
+        return domain

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -330,6 +330,9 @@ class StockMove(models.Model):
         )
 
     def _action_cancel(self):
+        # Unrelease moves that can be, before canceling them.
+        moves_to_unrelease = self.filtered(lambda m: m.unrelease_allowed)
+        moves_to_unrelease.unrelease()
         super()._action_cancel()
         self.write({"need_release": False})
         return True

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -49,8 +49,77 @@ class StockMove(models.Model):
         search="_search_release_ready",
     )
     need_release = fields.Boolean(index=True, copy=False)
+    unrelease_allowed = fields.Boolean(compute="_compute_unrelease_allowed")
     zip_code = fields.Char(related="partner_id.zip", store=True)
     city = fields.Char(related="partner_id.city", store=True)
+
+    @api.depends("rule_id", "rule_id.available_to_promise_defer_pull")
+    def _compute_unrelease_allowed(self):
+        for move in self:
+            unrelease_allowed = move._is_unreleaseable()
+            if unrelease_allowed:
+                iterator = move._get_chained_moves_iterator("move_orig_ids")
+                next(iterator)  # skip the current move
+                for origin_moves in iterator:
+                    unrelease_allowed = move._is_unrelease_allowed_on_origin_moves(
+                        origin_moves
+                    )
+                    if not unrelease_allowed:
+                        break
+            move.unrelease_allowed = unrelease_allowed
+
+    def _is_unreleaseable(self):
+        """Check if the move can be unrelease. At this stage we only check if
+        the move is at the end of a chain of moves and has the caracteristics
+        to be unrelease. We don't check the conditions on the origin moves.
+        The conditions on the origin moves are checked in the method
+        _is_unrelease_allowed_on_origin_moves.
+        """
+        self.ensure_one()
+        user_is_allowed = self.env.user.has_group("stock.group_stock_user")
+        return (
+            user_is_allowed
+            and not self.need_release
+            and self.state not in ("done", "cancel")
+            and self.picking_type_id.code == "outgoing"
+            and self.rule_id.available_to_promise_defer_pull
+        )
+
+    def _is_unrelease_allowed_on_origin_moves(self, origin_moves):
+        """We check that the origin moves are in a state that allows the unrelease
+        of the current move. At this stage, a move can't be unreleased if
+          * a picking is already printed. (The work on the picking is planed and
+            we don't want to change it)
+          * the processing of the origin moves is partially started.
+        """
+        self.ensure_one()
+        pickings = origin_moves.mapped("picking_id")
+        if pickings.filtered("printed"):
+            # The picking is printed, we can't unrelease the move
+            # because the processing of the origin moves is started.
+            return False
+        origin_moves = origin_moves.filtered(
+            lambda m: m.state not in ("done", "cancel")
+        )
+        origin_qty_todo = sum(origin_moves.mapped("product_qty"))
+        return (
+            float_compare(
+                self.product_qty,
+                origin_qty_todo,
+                precision_rounding=self.product_uom.rounding,
+            )
+            <= 0
+        )
+
+    def _check_unrelease_allowed(self):
+        for move in self:
+            if not move.unrelease_allowed:
+                raise UserError(
+                    _(
+                        "You are not allowed to unrelease this move %(move_name)s.",
+                        move_name=move.display_name,
+                    )
+                )
 
     def _previous_promised_qty_sql_main_query(self):
         return """
@@ -442,3 +511,61 @@ class StockMove(models.Model):
         while moves:
             yield moves
             moves = moves.mapped(chain_field)
+
+    def unrelease(self, safe_unrelease=False):
+        """Unrelease unreleasavbe moves
+
+        If safe_unrelease is True, the unreleasaable moves for which the
+        processing has already started will be ignored
+        """
+        moves_to_unrelease = self.filtered(lambda m: m._is_unreleaseable())
+        if safe_unrelease:
+            moves_to_unrelease = self.filtered("unrelease_allowed")
+        moves_to_unrelease._check_unrelease_allowed()
+        moves_to_unrelease.write({"need_release": True})
+        impacted_picking_ids = set()
+        for move in moves_to_unrelease:
+            iterator = move._get_chained_moves_iterator("move_orig_ids")
+            next(iterator)  # skip the current move
+            for origin_moves in iterator:
+                origin_moves = origin_moves.filtered(
+                    lambda m: m.state not in ("done", "cancel")
+                )
+                if origin_moves:
+                    origin_moves = move._split_origins(origin_moves)
+                    impacted_picking_ids.update(origin_moves.mapped("picking_id").ids)
+                    # avoid to propagate cancel to the original move
+                    origin_moves.write({"propagate_cancel": False})
+                    origin_moves._action_cancel()
+        moves_to_unrelease.write({"need_release": True})
+        for picking, moves in itertools.groupby(
+            moves_to_unrelease, lambda m: m.picking_id
+        ):
+            move_names = "\n".join([m.display_name for m in moves])
+            body = _(
+                "The following moves have been un-released: \n%(move_names)s",
+                move_names=move_names,
+            )
+            picking.message_post(body=body)
+
+    def _split_origins(self, origins):
+        """Split the origins of the move according to the quantity into the
+        move and the quantity in the origin moves.
+
+        Return the origins for the move's quantity.
+        """
+        self.ensure_one()
+        qty = self.product_qty
+        rounding = self.product_uom.rounding
+        new_origin_moves = self.env["stock.move"]
+        while float_compare(qty, 0, precision_rounding=rounding) > 0 and origins:
+            origin = fields.first(origins)
+            if float_compare(qty, origin.product_qty, precision_rounding=rounding) >= 0:
+                qty -= origin.product_qty
+                new_origin_moves |= origin
+            else:
+                new_move_vals = origin._split(qty)
+                new_origin_moves |= self.create(new_move_vals)
+                break
+            origins -= origin
+        return new_origin_moves

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -189,3 +189,14 @@ class StockPicking(models.Model):
         action["domain"] = [("picking_id", "=", self.id), ("need_release", "=", True)]
         action["context"] = {}
         return action
+
+    def _create_backorder(self):
+        backorders = super()._create_backorder()
+        backorders_to_unrelease = backorders.filtered(
+            lambda p: p.picking_type_id.unrelease_on_backorder
+        )
+        if backorders_to_unrelease:
+            backorders_to_unrelease.mapped("move_ids").filtered(
+                "unrelease_allowed"
+            ).unrelease()
+        return backorders

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -77,13 +77,13 @@ class StockPicking(models.Model):
                 picking.release_ready = False
                 picking.release_ready_count = 0
                 continue
-            move_lines = picking.move_ids.filtered(
+            move_ids = picking.move_ids.filtered(
                 lambda move: move.state not in ("cancel", "done") and move.need_release
             )
             if picking._get_shipping_policy() == "one":
                 picking.release_ready_count = sum(
                     1
-                    for move in move_lines
+                    for move in move_ids
                     if float_compare(
                         move.ordered_available_to_promise_qty,
                         move.product_qty,
@@ -91,12 +91,10 @@ class StockPicking(models.Model):
                     )
                     == 0
                 )
-                picking.release_ready = picking.release_ready_count == len(move_lines)
+                picking.release_ready = picking.release_ready_count == len(move_ids)
             else:
                 picking.release_ready_count = sum(
-                    1
-                    for move in move_lines
-                    if move.ordered_available_to_promise_qty > 0
+                    1 for move in move_ids if move.ordered_available_to_promise_qty > 0
                 )
                 picking.release_ready = bool(picking.release_ready_count)
 

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -78,7 +78,7 @@ class StockPicking(models.Model):
                 picking.release_ready_count = 0
                 continue
             move_lines = picking.move_ids.filtered(
-                lambda move: move.state not in ("cancel", "done")
+                lambda move: move.state not in ("cancel", "done") and move.need_release
             )
             if picking._get_shipping_policy() == "one":
                 picking.release_ready_count = sum(

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -131,7 +131,7 @@ class StockPicking(models.Model):
             for key, value in self.env.context.items()
             if not key.startswith("default_")
         }
-        self.mapped("move_ids").with_context(**context).release_available_to_promise()
+        self.move_ids.with_context(**context).release_available_to_promise()
 
     def _release_link_backorder(self, origin_picking):
         self.backorder_id = origin_picking
@@ -190,3 +190,11 @@ class StockPicking(models.Model):
                 "unrelease_allowed"
             ).unrelease()
         return backorders
+
+    def unrelease(self, safe_unrelease=False):
+        """Unrelease the moves of the picking.
+
+        If safe_unrelease is True, the unreleasable moves for which the
+        processing has already started will be ignored
+        """
+        self.mapped("move_ids").unrelease(safe_unrelease=safe_unrelease)

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -29,15 +29,7 @@ class StockPicking(models.Model):
     zip_code = fields.Char(related="partner_id.zip", store=True)
     state_id = fields.Many2one(related="partner_id.state_id", store=True)
     city = fields.Char(related="partner_id.city", store=True)
-
-    set_printed_at_release = fields.Boolean(compute="_compute_set_printed_at_release")
-
-    @api.depends("move_ids")
-    def _compute_set_printed_at_release(self):
-        for picking in self:
-            picking.set_printed_at_release = not (
-                any(picking.move_ids.mapped("rule_id.no_backorder_at_release"))
-            )
+    last_release_date = fields.Datetime()
 
     @api.depends("move_ids.need_release")
     def _compute_need_release(self):
@@ -158,13 +150,11 @@ class StockPicking(models.Model):
         ``self`` contains all the stock.picking of the chain up
         to the released one.
         """
-        self._after_release_set_printed()
+        self._after_release_set_last_release_date()
         self._after_release_set_expected_date()
 
-    def _after_release_set_printed(self):
-        self.filtered(
-            lambda p: not p.printed and p.set_printed_at_release
-        ).printed = True
+    def _after_release_set_last_release_date(self):
+        self.last_release_date = fields.Datetime.now()
 
     def _after_release_set_expected_date(self):
         prep_time = self.env.company.stock_release_max_prep_time

--- a/stock_available_to_promise_release/models/stock_picking_type.py
+++ b/stock_available_to_promise_release/models/stock_picking_type.py
@@ -10,14 +10,17 @@ class StockPickingType(models.Model):
     count_picking_need_release = fields.Integer(compute="_compute_picking_count")
     unrelease_on_backorder = fields.Boolean(
         string="Unrelease on backorder",
-        help="If checked, when a backorder is created the moves into the "
-        "backorder are unreleased if they come from a route configured "
-        "to manually release moves",
+        help="If checked, when a backorder is created (i.e. at the validation of "
+        "the delivery), the moves into the backorder are unreleased as long as "
+        "they came from a route configured to manually release moves. This means "
+        "that the moves that were not delivered are put back in need for release "
+        "and the unprocessed internal pulled moves are canceled.",
     )
     prevent_new_move_after_release = fields.Boolean(
         string="Prevent new move after release",
-        help="If checked, when a picking is released it's no more possible to "
-        "assign new moves to it.",
+        help="If checked, once a delivery picking has been released, no more "
+        "moves will be added to it. For example, if you add lines in the origin "
+        "sales order, the new moves will be added to a new delivery.",
     )
 
     def _compute_picking_count_need_release_domains(self):

--- a/stock_available_to_promise_release/models/stock_picking_type.py
+++ b/stock_available_to_promise_release/models/stock_picking_type.py
@@ -8,6 +8,12 @@ class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
     count_picking_need_release = fields.Integer(compute="_compute_picking_count")
+    unrelease_on_backorder = fields.Boolean(
+        string="Unrelease on backorder",
+        help="If checked, when a backorder is created the moves into the "
+        "backorder are unreleased if they come from a route configured "
+        "to manually release moves",
+    )
 
     def _compute_picking_count_need_release_domains(self):
         return {

--- a/stock_available_to_promise_release/models/stock_picking_type.py
+++ b/stock_available_to_promise_release/models/stock_picking_type.py
@@ -14,6 +14,11 @@ class StockPickingType(models.Model):
         "backorder are unreleased if they come from a route configured "
         "to manually release moves",
     )
+    prevent_new_move_after_release = fields.Boolean(
+        string="Prevent new move after release",
+        help="If checked, when a picking is released it's no more possible to "
+        "assign new moves to it.",
+    )
 
     def _compute_picking_count_need_release_domains(self):
         return {

--- a/stock_available_to_promise_release/models/stock_route.py
+++ b/stock_available_to_promise_release/models/stock_route.py
@@ -14,3 +14,10 @@ class StockRoute(models.Model):
         "Transfers must be released manually when they have enough available"
         " to promise.",
     )
+
+    no_backorder_at_release = fields.Boolean(
+        string="No backorder at release",
+        default=False,
+        help="When releasing a transfer, do not create a backorder for the "
+        "moves created for the unavailable quantities.",
+    )

--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -10,13 +10,21 @@ _logger = logging.getLogger(__name__)
 class StockRule(models.Model):
     _inherit = "stock.rule"
 
+    available_to_promise_defer_pull = fields.Boolean(
+        related="route_id.available_to_promise_defer_pull", store=True
+    )
+
+    no_backorder_at_release = fields.Boolean(
+        related="route_id.no_backorder_at_release", store=True
+    )
+
     def _run_pull(self, procurements):
         actions_to_run = []
 
         for procurement, rule in procurements:
             if (
                 not self.env.context.get("_rule_no_available_defer")
-                and rule.route_id.available_to_promise_defer_pull
+                and rule.available_to_promise_defer_pull
                 # We still want to create the first part of the chain
                 and not rule.picking_type_id.code == "outgoing"
             ):

--- a/stock_available_to_promise_release/readme/USAGE.rst
+++ b/stock_available_to_promise_release/readme/USAGE.rst
@@ -13,9 +13,11 @@ By default, when an outgoing transfer is released, a backorder is created for
 the remaining quantities for products not available at release time. This behaviour
 can also be changed by stock route by setting the option "No backorder at release".
 In such a case, moves created for unavailable products will remain in the original
-outgoing picking and no backorder will be created. At the same time, outgoing
-picking will not bet set to printed at release time if one move has been created
-from a route whith the option "No backorder at release" set.
+outgoing picking and no backorder will be created.
+
+One a picking is released, you can also ensure that new move will no more be
+assigned to a released picking by setting the option "Prevent new move after release".
+on the stock picking type.
 
 At the end of the picking process (when the picking is validated) of an outgoing
 transfer, if a backorder is created, the chained moves can be automatically

--- a/stock_available_to_promise_release/readme/USAGE.rst
+++ b/stock_available_to_promise_release/readme/USAGE.rst
@@ -5,3 +5,19 @@ Stock Move". A move can be released only if the available to promise quantity is
 greater than zero. This quantity is computed as the product's virtual quantity
 minus the previous moves in the list (previous being defined by the field
 "Priority Date").
+
+This behaviour is activated by stock route by setting the option
+"Release based on Available to Promise".
+
+By default, when an outgoing transfer is released, a backorder is created for
+the remaining quantities for products not available at release time. This behaviour
+can also be changed by stock route by setting the option "No backorder at release".
+In such a case, moves created for unavailable products will remain in the original
+outgoing picking and no backorder will be created. At the same time, outgoing
+picking will not bet set to printed at release time if one move has been created
+from a route whith the option "No backorder at release" set.
+
+At the end of the picking process (when the picking is validated) of an outgoing
+transfer, if a backorder is created, the chained moves can be automatically
+unreleased. This behaviour is activated by setting the option "Unrelease on backorder"
+on the stock picking type.

--- a/stock_available_to_promise_release/security/ir.model.access.csv
+++ b/stock_available_to_promise_release/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_stock_release_wizard,access.stock.release.wizard,model_stock_release,stock.group_stock_user,1,1,1,0
+access_stock_unrelease_wizard,access.stock.unrelease.wizard,model_stock_unrelease,stock.group_stock_user,1,1,1,0

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_reservation
+from . import test_unrelease

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_reservation
 from . import test_unrelease
 from . import test_unrelease_2steps
+from . import test_unrelease_3steps

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_reservation
 from . import test_unrelease
+from . import test_unrelease_2steps

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -117,3 +117,18 @@ class PromiseReleaseCommonCase(common.TransactionCase):
                 "outgoing_qty",
             ]
         )
+
+    @classmethod
+    def _prev_picking(cls, picking):
+        return picking.move_ids.move_orig_ids.picking_id
+
+    @classmethod
+    def _out_picking(cls, pickings):
+        return pickings.filtered(lambda r: r.picking_type_code == "outgoing")
+
+    @classmethod
+    def _deliver(cls, picking):
+        picking.action_assign()
+        for line in picking.mapped("move_ids.move_line_ids"):
+            line.qty_done = line.reserved_qty
+        picking._action_done()

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -705,6 +705,224 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             ],
         )
 
+    def test_defer_creation_no_backorder_partial_available(self):
+        """Test that the creation of a backorder is not done at release time
+        when the field `ǹo_backorder_at_release` is set on the stock.route"""
+        self.wh.delivery_route_id.write(
+            {"available_to_promise_defer_pull": True, "no_backorder_at_release": True}
+        )
+        self._update_qty_in_location(self.loc_bin1, self.product1, 7.0)
+        pickings = self._create_picking_chain(self.wh, [(self.product1, 20)])
+        self.assertEqual(len(pickings), 1, "expect only the last out->customer")
+
+        cust_picking = pickings
+        move_state = cust_picking.mapped("move_ids").mapped("state")
+        self.assertTrue(len(move_state) == 1 and move_state[0] == "waiting")
+        self.assertEqual(cust_picking.state, "waiting")
+        self.assertRecordValues(
+            cust_picking,
+            [
+                {
+                    "state": "waiting",
+                    "location_id": self.wh.wh_output_stock_loc_id.id,
+                    "location_dest_id": self.loc_customer.id,
+                    "printed": False,
+                }
+            ],
+        )
+
+        cust_picking.release_available_to_promise()
+        split_cust_picking = cust_picking.backorder_ids
+        self.assertEqual(len(split_cust_picking), 0)
+
+        out_picking = self._pickings_in_group(pickings.group_id) - cust_picking
+        # the complete one is assigned and placed into stock output
+        self.assertRecordValues(
+            out_picking,
+            [
+                {
+                    "state": "assigned",
+                    "location_id": self.wh.lot_stock_id.id,
+                    "location_dest_id": self.wh.wh_output_stock_loc_id.id,
+                    "printed": False,
+                }
+            ],
+        )
+        # the released customer picking is not set to "printed"
+        self.assertRecordValues(cust_picking, [{"printed": False}])
+
+        self.assertRecordValues(out_picking.move_ids, [{"product_qty": 7.0}])
+
+        # the splite moves remains into the customer picking
+        self.assertRecordValues(
+            cust_picking.move_ids,
+            [
+                {"product_qty": 7.0, "state": "waiting"},
+                {"product_qty": 13.0, "state": "waiting"},
+            ],
+        )
+
+        # let's deliver what we can
+        self._deliver(out_picking)
+        self.assertRecordValues(out_picking, [{"state": "done"}])
+        self.assertRecordValues(cust_picking, [{"state": "assigned"}])
+        self.assertRecordValues(
+            cust_picking.move_ids,
+            [
+                {
+                    "state": "assigned",
+                    "product_qty": 7.0,
+                    "reserved_availability": 7.0,
+                    "procure_method": "make_to_order",
+                },
+                {
+                    "state": "waiting",
+                    "product_qty": 13.0,
+                    "reserved_availability": 0.0,
+                    "procure_method": "make_to_order",
+                },
+            ],
+        )
+
+        self._deliver(cust_picking)
+        self.assertRecordValues(cust_picking, [{"state": "done"}])
+
+        cust_backorder = (
+            self._pickings_in_group(cust_picking.group_id) - cust_picking - out_picking
+        )
+        self.assertEqual(len(cust_backorder), 1)
+
+        self.env["stock.move"].invalidate_model(
+            fnames=[
+                "previous_promised_qty",
+                "ordered_available_to_promise_uom_qty",
+                "ordered_available_to_promise_qty",
+            ]
+        )
+        # nothing happen, no stock
+        self.assertEqual(len(self._pickings_in_group(cust_picking.group_id)), 3)
+        cust_backorder.release_available_to_promise()
+        self.assertEqual(len(self._pickings_in_group(cust_picking.group_id)), 3)
+
+        self.env["stock.move"].invalidate_model(
+            fnames=[
+                "previous_promised_qty",
+                "ordered_available_to_promise_uom_qty",
+                "ordered_available_to_promise_qty",
+            ]
+        )
+        # We add stock, so now the release must create the next
+        # chained move
+        self._update_qty_in_location(self.loc_bin1, self.product1, 30)
+        cust_backorder.release_available_to_promise()
+        out_backorder = (
+            self._pickings_in_group(cust_picking.group_id)
+            - cust_backorder
+            - cust_picking
+            - out_picking
+        )
+        self.assertRecordValues(
+            out_backorder.move_ids,
+            [
+                {
+                    "state": "assigned",
+                    "product_qty": 13.0,
+                    "reserved_availability": 13.0,
+                    "procure_method": "make_to_stock",
+                    "location_id": self.wh.lot_stock_id.id,
+                    "location_dest_id": self.wh.wh_output_stock_loc_id.id,
+                }
+            ],
+        )
+
+    def test_defer_creation_no_backorder_not_available(self):
+        """Unreleased moves are not put in a backorder if
+        `ǹo_backorder_at_release` is set to True"""
+        self.wh.delivery_route_id.write(
+            {"available_to_promise_defer_pull": True, "no_backorder_at_release": True}
+        )
+        self._update_qty_in_location(self.loc_bin1, self.product1, 10.0)
+        self._update_qty_in_location(self.loc_bin1, self.product2, 10.0)
+        pickings = self._create_picking_chain(
+            self.wh,
+            [
+                (self.product1, 20),
+                (self.product2, 10),
+                (self.product3, 20),
+                (self.product4, 10),
+            ],
+        )
+        self.assertEqual(len(pickings), 1, "expect only the last out->customer")
+
+        cust_picking = pickings
+        self.assertRecordValues(
+            cust_picking,
+            [
+                {
+                    "state": "waiting",
+                    "location_id": self.wh.wh_output_stock_loc_id.id,
+                    "location_dest_id": self.loc_customer.id,
+                },
+            ],
+        )
+
+        cust_picking.release_available_to_promise()
+        backorder = cust_picking.backorder_ids
+        self.assertFalse(backorder)
+        self.assertRecordValues(
+            cust_picking.move_ids.sorted("id"),
+            [
+                # product 1 is partially available -> split
+                {
+                    "product_qty": 10.0,
+                    "product_id": self.product1.id,
+                    "state": "waiting",
+                },
+                # product 2 is fully available
+                {
+                    "product_qty": 10.0,
+                    "product_id": self.product2.id,
+                    "state": "waiting",
+                },
+                # these 2 moves were not released
+                {
+                    "product_qty": 20.0,
+                    "product_id": self.product3.id,
+                    "state": "waiting",
+                },
+                {
+                    "product_qty": 10.0,
+                    "product_id": self.product4.id,
+                    "state": "waiting",
+                },
+                # remaining 10 on product 1 because it was partially available
+                {
+                    "product_qty": 10.0,
+                    "product_id": self.product1.id,
+                    "state": "waiting",
+                },
+            ],
+        )
+
+        out_picking = self._pickings_in_group(pickings.group_id) - cust_picking
+        self.assertRecordValues(
+            out_picking,
+            [
+                {
+                    "state": "assigned",
+                    "location_id": self.wh.lot_stock_id.id,
+                    "location_dest_id": self.wh.wh_output_stock_loc_id.id,
+                }
+            ],
+        )
+        self.assertRecordValues(
+            out_picking.move_ids,
+            [
+                {"product_qty": 10.0, "product_id": self.product1.id},
+                {"product_qty": 10.0, "product_id": self.product2.id},
+            ],
+        )
+
     def test_defer_creation_uom(self):
         self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
         self._update_qty_in_location(self.loc_bin1, self.product1, 12.0)

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -497,12 +497,13 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                     "state": "waiting",
                     "location_id": self.wh.wh_output_stock_loc_id.id,
                     "location_dest_id": self.loc_customer.id,
-                    "printed": False,
+                    "last_release_date": False,
                 }
             ],
         )
-
-        cust_picking.release_available_to_promise()
+        release_date = datetime(2022, 11, 10, 17, 21)
+        with freeze_time(release_date):
+            cust_picking.move_ids.release_available_to_promise()
         split_cust_picking = cust_picking.backorder_ids
         self.assertEqual(len(split_cust_picking), 1)
 
@@ -519,13 +520,13 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                     "state": "assigned",
                     "location_id": self.wh.lot_stock_id.id,
                     "location_dest_id": self.wh.wh_output_stock_loc_id.id,
-                    "printed": True,
+                    "last_release_date": release_date,
                 }
             ],
         )
-        # the released customer picking is set to "printed"
-        self.assertRecordValues(cust_picking, [{"printed": True}])
-        # the split once stays in the original location
+        # the released customer picking has a last_release_date
+        self.assertRecordValues(cust_picking, [{"last_release_date": release_date}])
+        # the split one stays in the original location
         self.assertRecordValues(
             split_cust_picking,
             [
@@ -533,7 +534,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                     "state": "waiting",
                     "location_id": self.wh.wh_output_stock_loc_id.id,
                     "location_dest_id": self.loc_customer.id,
-                    "printed": False,
+                    "last_release_date": False,
                 }
             ],
         )
@@ -657,6 +658,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                     "state": "waiting",
                     "location_id": self.wh.wh_output_stock_loc_id.id,
                     "location_dest_id": self.loc_customer.id,
+                    "last_release_date": False,
                 }
             ],
         )
@@ -1177,3 +1179,17 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         pick.action_confirm()
         pick.release_available_to_promise()
         self.assertEqual(pick.move_ids.move_orig_ids.picking_id.priority, "1")
+
+    def test_backorder_creation_after_release(self):
+        self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
+        self._update_qty_in_location(self.loc_bin1, self.product1, 20.0)
+        picking = self._create_picking_chain(self.wh, [(self.product1, 5)])
+        picking.release_available_to_promise()
+        move = picking.move_ids
+        new_move = move.copy()
+        new_move._assign_picking()
+        self.assertEqual(picking, new_move.picking_id)
+        picking.picking_type_id.prevent_new_move_after_release = True
+        new_move = move.copy()
+        new_move._assign_picking()
+        self.assertNotEqual(picking, new_move.picking_id)

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -10,18 +10,6 @@ from .common import PromiseReleaseCommonCase
 
 
 class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
-    def _prev_picking(self, picking):
-        return picking.move_ids.move_orig_ids.picking_id
-
-    def _out_picking(self, pickings):
-        return pickings.filtered(lambda r: r.picking_type_code == "outgoing")
-
-    def _deliver(self, picking):
-        picking.action_assign()
-        for line in picking.mapped("move_ids.move_line_ids"):
-            line.qty_done = line.reserved_qty
-        picking._action_done()
-
     def test_horizon_date(self):
         move = self.env["stock.move"].create(
             {

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -1,0 +1,84 @@
+# Copyright 2022 ACSONE SA/NV (https://www.acsone.eu)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from contextlib import contextmanager
+from datetime import datetime
+
+from odoo.exceptions import UserError
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.shipping = cls._out_picking(
+            cls._create_picking_chain(
+                cls.wh, [(cls.product1, 5)], date=datetime(2019, 9, 2, 16, 0)
+            )
+        )
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 15.0)
+        cls.wh.delivery_route_id.write(
+            {
+                "available_to_promise_defer_pull": True,
+                "no_backorder_at_release": True,
+            }
+        )
+
+        cls.shipping.release_available_to_promise()
+        cls.picking = cls._prev_picking(cls.shipping)
+        cls.picking.action_assign()
+
+    @contextmanager
+    def _assert_full_unreleased(self):
+        self.assertRecordValues(
+            self.shipping.move_ids,
+            [
+                {
+                    "state": "waiting",
+                    "need_release": False,
+                    "unrelease_allowed": True,
+                }
+            ],
+        )
+        yield
+        self.assertRecordValues(
+            self.shipping.move_ids,
+            [
+                {
+                    "state": "waiting",
+                    "need_release": True,
+                    "unrelease_allowed": False,
+                }
+            ],
+        )
+        self.assertEqual(self.picking.move_ids.state, "cancel")
+        self.assertEqual(self.picking.state, "cancel")
+
+    def test_unrelease_full(self):
+        """Unrelease all moves of a released ship. The pick should be deleted and
+        the moves should be mark as to release"""
+        with self._assert_full_unreleased():
+            self.shipping.move_ids.unrelease()
+
+        # I can release again the move and a new pick is created
+        self.shipping.release_available_to_promise()
+        new_picking = self._prev_picking(self.shipping) - self.picking
+        self.assertTrue(new_picking)
+        self.assertEqual(new_picking.state, "assigned")
+
+    def test_unrelease_partially_processed_move(self):
+        """Check it's not possible to unrelease a move that has been partially
+        processed"""
+        line = self.picking.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty - 1
+        self.picking.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        self.assertEqual(self.picking.state, "done")
+        self.assertFalse(self.shipping.move_ids.unrelease_allowed)
+        with self.assertRaisesRegex(
+            UserError, "You are not allowed to unrelease this move"
+        ):
+            self.shipping.move_ids.unrelease()

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -82,3 +82,74 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             UserError, "You are not allowed to unrelease this move"
         ):
             self.shipping.move_ids.unrelease()
+
+    def test_unrelease_backorder(self):
+        """Check the unrelease of a shipping backorder move"""
+        # we do a partial pick and validate the picking to create a backorder
+        # a validation
+        line = self.picking.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty - 1
+        self.picking.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        self.shipping.action_assign()
+        line = self.shipping.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty
+        self.shipping.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        # at this stage, our backorder ship move is linked to a pick move to do
+        backorder_ship = self.shipping.backorder_ids
+        self.assertTrue(backorder_ship)
+        self.assertTrue(backorder_ship.move_ids.unrelease_allowed)
+        self.assertTrue(
+            backorder_ship.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )
+        backorder_pick = self._prev_picking(backorder_ship) - self.picking
+        self.assertEqual(backorder_pick.state, "assigned")
+        backorder_ship.move_ids.unrelease()
+        # after the un release, our backorder ship move is not more linked to
+        # a pick move to do
+        self.assertFalse(backorder_ship.move_ids.unrelease_allowed)
+        self.assertEqual(backorder_pick.state, "cancel")
+        self.assertFalse(
+            backorder_ship.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )
+
+    def test_auto_unrelease_on_backorder(self):
+        """Check that moves into a backorder are unreleased if specified on
+        the picking type"""
+        self.shipping.picking_type_id.unrelease_on_backorder = True
+        # we do a partial pick and validate the picking to create a backorder
+        # a validation
+        line = self.picking.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty - 1
+        self.picking.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        self.shipping.action_assign()
+        line = self.shipping.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty
+        # at this stage, our ship move is linked to a pick move to do
+        self.assertTrue(
+            self.shipping.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )
+        self.shipping.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        backorder_ship = self.shipping.backorder_ids
+        self.assertTrue(backorder_ship)
+        self.assertTrue(backorder_ship.need_release)
+        self.assertFalse(backorder_ship.move_ids.unrelease_allowed)
+        # no move pick move to do for our move into the backorder
+        self.assertFalse(
+            backorder_ship.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -30,16 +30,21 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                 "available_to_promise_defer_pull": True,
             }
         )
-        cls.shipping1.release_available_to_promise()
-        cls.shipping2.release_available_to_promise()
+        shippings = cls.shipping1 | cls.shipping2
+        cls.deliveries = shippings
+        shippings.release_available_to_promise()
         cls.picking1 = cls._prev_picking(cls.shipping1)
         cls.picking1.action_assign()
         cls.picking2 = cls._prev_picking(cls.shipping2)
         cls.picking2.action_assign()
 
     def test_unrelease_delivery_no_picking_done(self):
-        # the pick moves for delivery 1 and 2 are merged
-        self.assertEqual(self.picking1, self.picking2)
+        # the picking for delivery 1 and 2 are merged into one move
+        # Not the case with stock_group_by_partner_by_carrier
+        # self.assertEqual(self.picking1.move_lines.move_line_ids.product_uom_qty, 5)
+        self.assertEqual(
+            self.picking1.move_lines.move_dest_ids, self.deliveries.move_lines
+        )
         self.shipping1.unrelease()
         self.assertEqual(len(self.picking1.move_lines), 2)
         move_cancel = self.picking1.move_lines.filtered(lambda m: m.state == "cancel")
@@ -63,7 +68,8 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         """
         self.shipping1.action_cancel()
         self.assertEqual(self.shipping1.state, "cancel")
-        line_active = self.picking1.move_lines.filtered(lambda l: l.state == "assigned")
-        line_cancel = self.picking1.move_lines.filtered(lambda l: l.state == "cancel")
-        self.assertEqual(line_active.product_uom_qty, 3.0)
-        self.assertEqual(line_cancel.product_uom_qty, 2.0)
+        move_active = self.picking1.move_lines.filtered(lambda l: l.state == "assigned")
+        move_cancel = self.picking1.move_lines.filtered(lambda l: l.state == "cancel")
+        self.assertEqual(move_active.product_uom_qty, 3.0)
+        self.assertEqual(move_cancel.product_uom_qty, 2.0)
+        self.assertEqual(move_active.move_dest_ids, self.shipping2.move_lines)

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -61,10 +61,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
 
         action_cancel is called on all related pickings not set to done.
         """
-        self.assertTrue(self.picking1.move_lines.product_uom_qty == 5)
         self.shipping1.action_cancel()
         self.assertEqual(self.shipping1.state, "cancel")
-        self.assertEqual(self.picking1.move_lines.mapped("product_uom_qty"), [3.0, 2.0])
-        self.assertEqual(
-            self.picking1.move_lines.mapped("state"), ["assigned", "cancel"]
-        )
+        line_active = self.picking1.move_lines.filtered(lambda l: l.state == "assigned")
+        line_cancel = self.picking1.move_lines.filtered(lambda l: l.state == "cancel")
+        self.assertEqual(line_active.product_uom_qty, 3.0)
+        self.assertEqual(line_cancel.product_uom_qty, 2.0)

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -41,13 +41,11 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
     def test_unrelease_delivery_no_picking_done(self):
         # the picking for delivery 1 and 2 are merged into one move
         # Not the case with stock_group_by_partner_by_carrier
-        # self.assertEqual(self.picking1.move_lines.move_line_ids.product_uom_qty, 5)
-        self.assertEqual(
-            self.picking1.move_lines.move_dest_ids, self.deliveries.move_lines
-        )
+        # self.assertEqual(self.picking1.move_ids.move_line_ids.product_uom_qty, 5)
+        self.assertEqual(self.picking1.move_ids.move_dest_ids, self.deliveries.move_ids)
         self.shipping1.unrelease()
-        self.assertEqual(len(self.picking1.move_lines), 2)
-        move_cancel = self.picking1.move_lines.filtered(lambda m: m.state == "cancel")
+        self.assertEqual(len(self.picking1.move_ids), 2)
+        move_cancel = self.picking1.move_ids.filtered(lambda m: m.state == "cancel")
         self.assertEqual(move_cancel.product_uom_qty, 2)
         self.assertTrue(self.shipping1.need_release)
 
@@ -68,8 +66,8 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         """
         self.shipping1.action_cancel()
         self.assertEqual(self.shipping1.state, "cancel")
-        move_active = self.picking1.move_lines.filtered(lambda l: l.state == "assigned")
-        move_cancel = self.picking1.move_lines.filtered(lambda l: l.state == "cancel")
+        move_active = self.picking1.move_ids.filtered(lambda l: l.state == "assigned")
+        move_cancel = self.picking1.move_ids.filtered(lambda l: l.state == "cancel")
         self.assertEqual(move_active.product_uom_qty, 3.0)
         self.assertEqual(move_cancel.product_uom_qty, 2.0)
-        self.assertEqual(move_active.move_dest_ids, self.shipping2.move_lines)
+        self.assertEqual(move_active.move_dest_ids, self.shipping2.move_ids)

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from datetime import datetime
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        delivery_pick_rule = cls.wh.delivery_route_id.rule_ids.filtered(
+            lambda r: r.location_src_id == cls.loc_stock
+        )
+        delivery_pick_rule.group_propagation_option = "fixed"
+
+        cls.pc1 = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 2)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.shipping1 = cls._out_picking(cls.pc1)
+        cls.pc2 = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 3)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.shipping2 = cls._out_picking(cls.pc2)
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 15.0)
+        cls.wh.delivery_route_id.write(
+            {
+                "available_to_promise_defer_pull": True,
+            }
+        )
+        cls.shipping1.release_available_to_promise()
+        cls.shipping2.release_available_to_promise()
+        cls.picking1 = cls._prev_picking(cls.shipping1)
+        cls.picking1.action_assign()
+        cls.picking2 = cls._prev_picking(cls.shipping2)
+        cls.picking2.action_assign()
+
+    def test_unrelease_delivery_no_picking_done(self):
+        # the pick moves for delivery 1 and 2 are merged
+        self.assertEqual(self.picking1, self.picking2)
+        self.shipping1.unrelease()
+        self.assertEqual(len(self.picking1.move_lines), 2)
+        move_cancel = self.picking1.move_lines.filtered(lambda m: m.state == "cancel")
+        self.assertEqual(move_cancel.product_uom_qty, 2)
+        self.assertTrue(self.shipping1.need_release)
+
+    # def test_unrelease_picking_is_done(self):
+    #     # the pick moves for delivery 1 and 2 are merged
+    #     self.assertEqual(self.picking1, self.picking2)
+    #     # do the first step
+    #     for line in self.picking1.move_line_ids:
+    #         line.qty_done = line.product_uom_qty
+    #     self.picking1.button_validate()
+    #     self.assertEqual(self.picking1.state, "done")
+    #     self.shipping1.unrelease()
+
+    def test_simulate_cancel_so(self):
+        """Simulate a sale order cancelation.
+
+        action_cancel is called on all related pickings not set to done.
+        """
+        self.assertTrue(self.picking1.move_lines.product_uom_qty == 5)
+        self.shipping1.action_cancel()
+        self.assertEqual(self.shipping1.state, "cancel")
+        self.assertEqual(self.picking1.move_lines.mapped("product_uom_qty"), [3.0, 2.0])
+        self.assertEqual(
+            self.picking1.move_lines.mapped("state"), ["assigned", "cancel"]
+        )

--- a/stock_available_to_promise_release/tests/test_unrelease_3steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_3steps.py
@@ -1,0 +1,67 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from datetime import datetime
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseRelease3steps(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.wh.delivery_steps = "pick_pack_ship"
+
+        delivery_pick_rule = cls.wh.delivery_route_id.rule_ids.filtered(
+            lambda r: r.location_src_id == cls.loc_stock
+        )
+        delivery_pick_rule.group_propagation_option = "fixed"
+
+        cls.pc1 = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 2)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.ship1 = cls._out_picking(cls.pc1)
+        cls.pack1 = cls._prev_picking(cls.ship1)
+        cls.pick1 = cls._prev_picking(cls.pack1)
+
+        cls.pc2 = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 3)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.ship2 = cls._out_picking(cls.pc2)
+        cls.pack2 = cls._prev_picking(cls.ship2)
+        cls.pick2 = cls._prev_picking(cls.pack2)
+
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 15.0)
+        cls.wh.delivery_route_id.write(
+            {
+                "available_to_promise_defer_pull": True,
+            }
+        )
+        (cls.ship1 | cls.ship2).release_available_to_promise()
+        assert cls.pick1 == cls.pick2
+        cls.pick1.action_assign()
+
+    def test_unrelease_delivery_no_picking_done(self):
+        # Not the case with stock_group_by_partner_by_carrier
+        # self.assertEqual(self.pick1.move_lines.move_line_ids.product_uom_qty, 5)
+        self.assertEqual(
+            self.pick1.move_lines.move_dest_ids,
+            self.pack1.move_lines | self.pack2.move_lines,
+        )
+        self.ship1.unrelease()
+        self.assertEqual(self.pack1.state, "cancel")
+        self.assertTrue(self.ship1.need_release)
+        self.assertFalse(self.ship2.need_release)
+        # Check pick has one move cancel and one still assign
+        move_active = self.pick1.move_lines.filtered(lambda l: l.state == "assigned")
+        move_cancel = self.pick1.move_lines.filtered(lambda l: l.state == "cancel")
+        # Check the move chain
+        self.assertEqual(self.pack1.state, "cancel")
+        self.assertEqual(self.pack2.state, "waiting")
+        # Active move only for pack2
+        self.assertEqual(move_active.move_dest_ids, self.pack2.move_lines)
+        # The destination move is on pack2 which is wrong, but it is canceled, so
+        # self.assertFalse(move_cancel.move_dest_ids)
+        self.assertFalse(move_cancel.move_orig_ids)
+        self.assertEqual(self.ship2.move_lines.move_orig_ids, self.pack2.move_lines)

--- a/stock_available_to_promise_release/tests/test_unrelease_3steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_3steps.py
@@ -44,24 +44,24 @@ class TestAvailableToPromiseRelease3steps(PromiseReleaseCommonCase):
 
     def test_unrelease_delivery_no_picking_done(self):
         # Not the case with stock_group_by_partner_by_carrier
-        # self.assertEqual(self.pick1.move_lines.move_line_ids.product_uom_qty, 5)
+        # self.assertEqual(self.pick1.move_ids.move_line_ids.product_uom_qty, 5)
         self.assertEqual(
-            self.pick1.move_lines.move_dest_ids,
-            self.pack1.move_lines | self.pack2.move_lines,
+            self.pick1.move_ids.move_dest_ids,
+            self.pack1.move_ids | self.pack2.move_ids,
         )
         self.ship1.unrelease()
         self.assertEqual(self.pack1.state, "cancel")
         self.assertTrue(self.ship1.need_release)
         self.assertFalse(self.ship2.need_release)
         # Check pick has one move cancel and one still assign
-        move_active = self.pick1.move_lines.filtered(lambda l: l.state == "assigned")
-        move_cancel = self.pick1.move_lines.filtered(lambda l: l.state == "cancel")
+        move_active = self.pick1.move_ids.filtered(lambda l: l.state == "assigned")
+        move_cancel = self.pick1.move_ids.filtered(lambda l: l.state == "cancel")
         # Check the move chain
         self.assertEqual(self.pack1.state, "cancel")
         self.assertEqual(self.pack2.state, "waiting")
         # Active move only for pack2
-        self.assertEqual(move_active.move_dest_ids, self.pack2.move_lines)
+        self.assertEqual(move_active.move_dest_ids, self.pack2.move_ids)
         # The destination move is on pack2 which is wrong, but it is canceled, so
         # self.assertFalse(move_cancel.move_dest_ids)
         self.assertFalse(move_cancel.move_orig_ids)
-        self.assertEqual(self.ship2.move_lines.move_orig_ids, self.pack2.move_lines)
+        self.assertEqual(self.ship2.move_ids.move_orig_ids, self.pack2.move_ids)

--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -27,7 +27,7 @@
     </record>
 
     <record id="stock_picking_type_form" model="ir.ui.view">
-        <field name="name">stock.picking.type.kanban</field>
+        <field name="name">stock.picking.type.form</field>
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">

--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -25,4 +25,22 @@
             </xpath>
         </field>
     </record>
+
+    <record id="stock_picking_type_form" model="ir.ui.view">
+        <field name="name">stock.picking.type.kanban</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+             <group name="locations" position="after">
+                 <group
+                    name="release"
+                    string="Chained moves release process"
+                    attrs='{"invisible": [("code", "!=", "outgoing")]}'
+                >
+                     <field name="unrelease_on_backorder" />
+                 </group>
+             </group>
+        </field>
+    </record>
+
 </odoo>

--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -32,12 +32,12 @@
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
              <group name="locations" position="after">
-                 <group
-                    name="release"
-                    string="Chained moves release process"
-                    attrs='{"invisible": [("code", "!=", "outgoing")]}'
-                >
-                     <field name="unrelease_on_backorder" />
+                 <group name="release" string="Chained moves release process">
+                     <field
+                        name="unrelease_on_backorder"
+                        attrs='{"invisible": [("code", "!=", "outgoing")]}'
+                    />
+                     <field name="prevent_new_move_after_release" />
                  </group>
              </group>
         </field>

--- a/stock_available_to_promise_release/views/stock_picking_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_views.xml
@@ -52,6 +52,9 @@
                     groups="stock.group_stock_user"
                 />
             </button>
+            <field name="date_done" position="before">
+                <field name="last_release_date" />
+            </field>
         </field>
     </record>
     <record id="view_picking_release_tree" model="ir.ui.view">
@@ -68,6 +71,9 @@
             </field>
             <field name="origin" position="after">
                 <field name="group_id" optional="hide" />
+            </field>
+            <field name="scheduled_date" position="after">
+                <field name="last_release_date" optional="hide" />
             </field>
             <tree position="inside">
                 <field name="date_priority" optional="show" />

--- a/stock_available_to_promise_release/views/stock_picking_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_views.xml
@@ -41,6 +41,17 @@
                     </div>
                 </button>
             </div>
+            <button name="action_assign_serial" position="after">
+                <field name="unrelease_allowed" invisible="1" />
+                <button
+                    name="unrelease"
+                    attrs="{'invisible': [('unrelease_allowed', '=', False)]}"
+                    string="Un Release"
+                    type="object"
+                    icon="fa-cube"
+                    groups="stock.group_stock_user"
+                />
+            </button>
         </field>
     </record>
     <record id="view_picking_release_tree" model="ir.ui.view">

--- a/stock_available_to_promise_release/views/stock_route_views.xml
+++ b/stock_available_to_promise_release/views/stock_route_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="available_to_promise_defer_pull" />
+                <field name="no_backorder_at_release" />
             </field>
         </field>
     </record>

--- a/stock_available_to_promise_release/views/stock_route_views.xml
+++ b/stock_available_to_promise_release/views/stock_route_views.xml
@@ -5,10 +5,10 @@
         <field name="model">stock.route</field>
         <field name="inherit_id" ref="stock.stock_location_route_form_view" />
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <xpath expr="//group/field[@name='company_id']" position="after">
                 <field name="available_to_promise_defer_pull" />
                 <field name="no_backorder_at_release" />
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/stock_available_to_promise_release/wizards/__init__.py
+++ b/stock_available_to_promise_release/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_release
+from . import stock_unrelease

--- a/stock_available_to_promise_release/wizards/stock_unrelease.py
+++ b/stock_available_to_promise_release/wizards/stock_unrelease.py
@@ -1,0 +1,19 @@
+# Copyright 2023 ACSONE SA/NV (https://www.acsone.eu)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+
+class StockUnRelease(models.TransientModel):
+    _name = "stock.unrelease"
+    _description = "Stock Allocations Un Release"
+
+    def unrelease(self):
+        model = self.env.context.get("active_model")
+        if model not in ("stock.move", "stock.picking"):
+            return
+        records = (
+            self.env[model].browse(self.env.context.get("active_ids", [])).exists()
+        )
+        records.unrelease(safe_unrelease=True)
+        return {"type": "ir.actions.act_window_close"}

--- a/stock_available_to_promise_release/wizards/stock_unrelease_views.xml
+++ b/stock_available_to_promise_release/wizards/stock_unrelease_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_unrelease_form" model="ir.ui.view">
+        <field name="name">Stock Allocations Un Release</field>
+        <field name="model">stock.unrelease</field>
+        <field name="arch" type="xml">
+            <form string="Stock Allocations Un Release">
+                <p class="oe_grey">
+                    The selected records will be un released.
+                </p>
+                <footer>
+                    <button
+                        name="unrelease"
+                        string="Un Release"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="action_view_stock_move_unrelease_form" model="ir.actions.act_window">
+        <field name="name">Un Release Move Allocations</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.unrelease</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="groups_id" eval="[(4,ref('stock.group_stock_user'))]" />
+        <field name="binding_model_id" ref="stock.model_stock_move" />
+    </record>
+    <record id="action_view_stock_picking_unrelease_form" model="ir.actions.act_window">
+        <field name="name">Un Release Transfers Allocations</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.unrelease</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="groups_id" eval="[(4,ref('stock.group_stock_user'))]" />
+        <field name="binding_model_id" ref="stock.model_stock_picking" />
+    </record>
+</odoo>


### PR DESCRIPTION
* [x] includes  #475 

By default, when an outgoing transfer is released, a backorder is created for
the remaining quantities for products not available at release time. This behaviour
can also be changed by stock route by setting the option "No backorder at release".
In such a case, moves created for unavailable products will remain in the original
outgoing picking and no backorder will be created. At the same time, outgoing
picking will not bet set to printed at release time if one move has been created
from a route whith the option "No backorder at release" set.

At the end of the picking process (when the picking is validated) of an outgoing
transfer, if a backorder is created, the chained moves can be automatically
unreleased. This behaviour is activated by setting the option "Unrelease on backorder"
on the stock picking type.

cc @jbaudoux 