### PR TITLE
[14.0][FIX] shopfloor_manual_product_transfer: fix, unreserve moves having the same product

### DIFF
--- a/shopfloor_manual_product_transfer/services/manual_product_transfer.py
+++ b/shopfloor_manual_product_transfer/services/manual_product_transfer.py
@@ -415,7 +415,7 @@ class ManualProductTransfer(Component):
             # other moves for this product and location
             move_lines = self._find_location_move_lines(location, product, lot)
             move_lines, unreserved_moves, response = self._unreserve_other_lines(
-                location, move_lines
+                location, move_lines, product
             )
             if response:
                 savepoint.rollback()
@@ -491,8 +491,9 @@ class ManualProductTransfer(Component):
                 message=self.msg_store.wrong_record(scanned_product),
             )
 
-    # FIXME copy pasted from location content transfer, put it elsewhere?
-    def _unreserve_other_lines(self, location, move_lines):
+    # FIXME copy pasted from location content transfer with a new 'product'
+    # parameter', put it elsewhere?
+    def _unreserve_other_lines(self, location, move_lines, product):
         """Unreserve move lines in location in another picking type
 
         Returns a tuple of (
@@ -511,6 +512,7 @@ class ManualProductTransfer(Component):
             [
                 ("location_id", "=", location.id),
                 ("state", "in", ("assigned", "partially_available")),
+                ("product_id", "=", product.id),
             ]
         )
         extra_move_lines = location_move_lines - move_lines


### PR DESCRIPTION
This part of code was duplicated from the location content transfer scenario where we don't care about the product, for for the manual product transfer scenario it is important to not unreserve moves that are not related to the product we are actually moving.

Anyway all the unreservation logic will be later extracted in a dedicated module (WIP https://github.com/OCA/wms/pull/476), but I prefer to fix it now here.