### PR TITLE
[14.0] shopfloor: checkout improve lines hooks

### DIFF
--- a/shopfloor/tests/test_checkout_cancel_line.py
+++ b/shopfloor/tests/test_checkout_cancel_line.py
@@ -87,7 +87,10 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={"picking": self._stock_picking_data(picking)},
+            data={
+                "picking": self._stock_picking_data(picking),
+                "group_lines_by_location": True,
+            },
             message={"body": "Package cancelled", "message_type": "success"},
         )
 
@@ -112,7 +115,10 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={"picking": self._stock_picking_data(picking)},
+            data={
+                "picking": self._stock_picking_data(picking),
+                "group_lines_by_location": True,
+            },
             message={"body": "Line cancelled", "message_type": "success"},
         )
 

--- a/shopfloor/tests/test_checkout_list_package.py
+++ b/shopfloor/tests/test_checkout_list_package.py
@@ -163,7 +163,10 @@ class CheckoutScanSetDestPackageCase(CheckoutCommonCase, SelectDestPackageMixin)
             response,
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
-            data={"picking": self._stock_picking_data(self.picking)},
+            data={
+                "picking": self._stock_picking_data(self.picking),
+                "group_lines_by_location": True,
+            },
             message=self.msg_store.goods_packed_in(self.delivery_package),
         )
 

--- a/shopfloor/tests/test_checkout_new_package.py
+++ b/shopfloor/tests/test_checkout_new_package.py
@@ -56,6 +56,9 @@ class CheckoutNewPackageCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
             response,
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
-            data={"picking": self._stock_picking_data(picking)},
+            data={
+                "picking": self._stock_picking_data(picking),
+                "group_lines_by_location": True,
+            },
             message=self.msg_store.goods_packed_in(new_package),
         )

--- a/shopfloor/tests/test_checkout_no_package.py
+++ b/shopfloor/tests/test_checkout_no_package.py
@@ -57,7 +57,10 @@ class CheckoutNoPackageCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
             response,
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
-            data={"picking": self._stock_picking_data(self.picking)},
+            data={
+                "picking": self._stock_picking_data(self.picking),
+                "group_lines_by_location": True,
+            },
             message={
                 "message_type": "success",
                 "body": "Product(s) processed as raw product(s)",

--- a/shopfloor/tests/test_checkout_scan.py
+++ b/shopfloor/tests/test_checkout_scan.py
@@ -13,7 +13,10 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={"picking": self._stock_picking_data(picking)},
+            data={
+                "picking": self._stock_picking_data(picking),
+                "group_lines_by_location": True,
+            },
         )
 
     def test_scan_document_stock_picking_ok(self):

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -117,7 +117,10 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={"picking": self._stock_picking_data(picking)},
+            data={
+                "picking": self._stock_picking_data(picking),
+                "group_lines_by_location": True,
+            },
             message=message,
         )
 

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -359,7 +359,10 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
         self.assert_response(
             response,
             next_state="select_line",
-            data={"picking": self._stock_picking_data(picking)},
+            data={
+                "picking": self._stock_picking_data(picking),
+                "group_lines_by_location": True,
+            },
             message=self.msg_store.goods_packed_in(new_package),
         )
 

--- a/shopfloor/tests/test_checkout_select.py
+++ b/shopfloor/tests/test_checkout_select.py
@@ -40,7 +40,10 @@ class CheckoutSelectCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={"picking": self._stock_picking_data(self.picking)},
+            data={
+                "picking": self._stock_picking_data(self.picking),
+                "group_lines_by_location": True,
+            },
         )
 
     def _test_error(self, picking, msg):

--- a/shopfloor/tests/test_checkout_select_line.py
+++ b/shopfloor/tests/test_checkout_select_line.py
@@ -79,7 +79,10 @@ class CheckoutSelectLineCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
         self.assert_response(
             response,
             next_state="select_line",
-            data={"picking": self._stock_picking_data(self.picking)},
+            data={
+                "picking": self._stock_picking_data(self.picking),
+                "group_lines_by_location": True,
+            },
             message=message,
         )
 

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -61,10 +61,7 @@ const Checkout = {
                     :options="{main: true, key_title: 'name', title_icon: 'mdi-truck-outline'}"
                     />
                 <detail-picking-select
-                    :record="state.data.picking"
-                    :select_records="state.data.picking.move_lines"
-                    :select_records_grouped="utils.wms.group_lines_by_location(state.data.picking.move_lines, {'prepare_records': utils.wms.only_one_package})"
-                    :select_options="select_line_manual_select_opts()"
+                    v-bind="select_line_detail_picking_select_props()"
                     :key="make_state_component_key(['detail-picking-select'])"
                     />
                 <div class="button-list button-vertical-list full">
@@ -287,6 +284,25 @@ const Checkout = {
             return {
                 showActions: false,
             };
+        },
+        select_line_detail_picking_select_props: function () {
+            const picking = this.state.data.picking;
+            const lines = picking.move_lines;
+            let grouped_lines = undefined;
+            if (this.state.data.group_lines_by_location) {
+                grouped_lines = this.select_line_manual_select_group_lines(lines);
+            }
+            return {
+                record: picking,
+                select_records: lines,
+                select_records_grouped: grouped_lines,
+                select_options: this.select_line_manual_select_opts(),
+            };
+        },
+        select_line_manual_select_group_lines: function (lines) {
+            return this.utils.wms.group_lines_by_location(lines, {
+                prepare_records: this.utils.wms.only_one_package,
+            });
         },
         select_line_manual_select_opts: function () {
             return {


### PR DESCRIPTION
* allow to turn off group by location
* ease override for lines manipulation