### PR TITLE
[16.0] stock_release_channel: Manage channel lifecycle

### DIFF
--- a/stock_release_channel/__manifest__.py
+++ b/stock_release_channel/__manifest__.py
@@ -7,7 +7,7 @@
     "version": "16.0.1.0.0",
     "development_status": "Beta",
     "license": "AGPL-3",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, ACSONE SA/NV,Odoo Community Association (OCA)",
     "maintainers": ["sebalix"],
     "website": "https://github.com/OCA/wms",
     "depends": [

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -54,3 +54,23 @@ class StockPicking(models.Model):
             [("need_release", "=", True)],
         )
         need_release._delay_assign_release_channel()
+
+    def _find_release_channel_candidate(self):
+        """Find a release channel candidate for the picking.
+
+        This method is meant to be overridden in other modules. It allows to
+        find a release channel candidate for the current picking based on the
+        picking information.
+
+        For example, you could define release channels based on a geographic area.
+        In this case, you would need to override this method to find the release
+        channel based on the shipping destination. In such a case, it's more
+        efficient to search for a channel where the destination is in the channel
+        area than to search for all the channels and then filter the ones that match
+        the destination as it's done into the method assign_release_channel of the
+        stock.release.channel model.
+
+        :return: a release channel or None
+        """
+        self.ensure_one()
+        return None

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -28,7 +28,8 @@ class StockPicking(models.Model):
             ).assign_release_channel()
 
     def assign_release_channel(self):
-        self.env["stock.release.channel"].assign_release_channel(self)
+        for pick in self:
+            self.env["stock.release.channel"].assign_release_channel(pick)
 
     def release_available_to_promise(self):
         for record in self:

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -170,6 +170,78 @@ class StockReleaseChannel(models.Model):
     )
     last_done_picking_name = fields.Char(compute="_compute_last_done_picking")
     last_done_picking_date_done = fields.Datetime(compute="_compute_last_done_picking")
+    state = fields.Selection(
+        selection=[("open", "Open"), ("locked", "Locked"), ("asleep", "Asleep")],
+        help="The state allows you to control the availability of the release channel.\n"
+        "* Open: Manual and automatic picking assignment to the release is effective "
+        "and release operations are allowed.\n "
+        "* Locked: Release operations are forbidden. (Assignement processes are "
+        "still working)\n"
+        "* Asleep: Assigned pickings not processed are unassigned from the release "
+        "channel.\n",
+        default="open",
+    )
+    is_action_lock_allowed = fields.Boolean(
+        compute="_compute_is_action_lock_allowed",
+        help="Technical field to check if the " "action 'Lock' is allowed.",
+    )
+    is_action_unlock_allowed = fields.Boolean(
+        compute="_compute_is_action_unlock_allowed",
+        help="Technical field to check if the " "action 'Unlock' is allowed.",
+    )
+    is_action_sleep_allowed = fields.Boolean(
+        compute="_compute_is_action_sleep_allowed",
+        help="Technical field to check if the " "action 'Sleep' is allowed.",
+    )
+    is_action_wake_up_allowed = fields.Boolean(
+        compute="_compute_is_action_wake_up_allowed",
+        help="Technical field to check if the " "action 'Wake Up' is allowed.",
+    )
+    is_release_allowed = fields.Boolean(
+        compute="_compute_is_release_allowed",
+        help="Technical field to check if the "
+        "action 'Release Next Batch' is allowed.",
+    )
+
+    @api.depends("state")
+    def _compute_is_action_lock_allowed(self):
+        for rec in self:
+            rec.is_action_lock_allowed = rec.state == "open"
+
+    @api.depends("state")
+    def _compute_is_action_unlock_allowed(self):
+        for rec in self:
+            rec.is_action_unlock_allowed = rec.state == "locked"
+
+    @api.depends("state")
+    def _compute_is_action_sleep_allowed(self):
+        for rec in self:
+            rec.is_action_sleep_allowed = rec.state in ("open", "locked")
+
+    @api.depends("state")
+    def _compute_is_action_wake_up_allowed(self):
+        for rec in self:
+            rec.is_action_wake_up_allowed = rec.state == "asleep"
+
+    @api.depends("state", "release_forbidden")
+    def _compute_is_release_allowed(self):
+        for rec in self:
+            rec.is_release_allowed = rec.state == "open" and not rec.release_forbidden
+
+    def _get_picking_to_unassign_domain(self):
+        return [
+            ("release_channel_id", "in", self.ids),
+            ("state", "not in", ("done", "cancel")),
+        ]
+
+    @api.model
+    def _get_picking_to_assign_domain(self):
+        return [
+            ("release_channel_id", "=", False),
+            ("state", "not in", ("done", "cancel")),
+            ("picking_type_id.code", "=", "outgoing"),
+            ("need_release", "=", True),
+        ]
 
     def _field_picking_domains(self):
         return {
@@ -372,8 +444,9 @@ class StockReleaseChannel(models.Model):
         domain = safe_eval(self.rule_domain) or []
         return domain
 
+    @api.model
     def _get_assignable_release_channel_domain(self):
-        return []
+        return [("state", "!=", "asleep")]
 
     @api.model
     def assign_release_channel(self, picking):
@@ -634,7 +707,18 @@ class StockReleaseChannel(models.Model):
         )
         return partner_pickings
 
+    def _check_is_release_allowed(self):
+        for rec in self:
+            if not rec.is_release_allowed:
+                raise exceptions.UserError(
+                    _(
+                        "The release of pickings is not allowed for channel %(name)s.",
+                        name=rec.name,
+                    )
+                )
+
     def release_next_batch(self):
+        self._check_is_release_allowed()
         self.ensure_one()
         next_pickings = self._get_next_pickings()
         if not next_pickings:
@@ -647,3 +731,73 @@ class StockReleaseChannel(models.Model):
                 }
             }
         next_pickings.release_available_to_promise()
+
+    def _check_is_action_lock_allowed(self):
+        for rec in self:
+            if not rec.is_action_lock_allowed:
+                raise exceptions.UserError(
+                    _(
+                        "Action 'Lock' is not allowed for channel %(name)s.",
+                        name=rec.name,
+                    )
+                )
+
+    def _check_is_action_unlock_allowed(self):
+        for rec in self:
+            if not rec.is_action_unlock_allowed:
+                raise exceptions.UserError(
+                    _(
+                        "Action 'Unlock' is not allowed for channel %(name)s.",
+                        name=rec.name,
+                    )
+                )
+
+    def _check_is_action_sleep_allowed(self):
+        for rec in self:
+            if not rec.is_action_sleep_allowed:
+                raise exceptions.UserError(
+                    _(
+                        "Action 'Sleep' is not allowed for channel %(name)s.",
+                        name=rec.name,
+                    )
+                )
+
+    def _check_is_action_wake_up_allowed(self):
+        for rec in self:
+            if not rec.is_action_wake_up_allowed:
+                raise exceptions.UserError(
+                    _(
+                        "Action 'Wake Up' is not allowed for channel %(name)s.",
+                        name=rec.name,
+                    )
+                )
+
+    def action_lock(self):
+        self._check_is_action_lock_allowed()
+        self.write({"state": "locked"})
+
+    def action_unlock(self):
+        self._check_is_action_unlock_allowed()
+        self.write({"state": "open"})
+
+    def action_sleep(self):
+        self._check_is_action_sleep_allowed()
+        pickings_to_unassign = self.env["stock.picking"].search(
+            self._get_picking_to_unassign_domain()
+        )
+        pickings_to_unassign.write({"release_channel_id": False})
+        pickings_to_unassign.unrelease()
+        self.write({"state": "asleep"})
+
+    def action_wake_up(self):
+        self._check_is_action_wake_up_allowed()
+        self.write({"state": "open"})
+        self.assign_pickings()
+
+    @api.model
+    def assign_pickings(self):
+        pickings = self.env["stock.picking"].search(
+            self._get_picking_to_assign_domain()
+        )
+        for pick in pickings:
+            pick._delay_assign_release_channel()

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -379,6 +379,13 @@ class StockReleaseChannel(models.Model):
             "done",
         ):
             return
+        # get channel candidates from the picking
+        channel = picking._find_release_channel_candidate()
+        if channel:
+            picking.release_channel_id = channel
+            return True
+        # No channel provided by the picking -> try to find one be evaluating the rules
+        # of all available channels
         # do a single query rather than one for each rule*picking
         for channel in self.sudo().search([]):
             if (

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -372,6 +372,10 @@ class StockReleaseChannel(models.Model):
         domain = safe_eval(self.rule_domain) or []
         return domain
 
+    def _get_assignable_release_channel_domain(self):
+        return []
+
+    @api.model
     def assign_release_channel(self, picking):
         picking.ensure_one()
         if picking.picking_type_id.code != "outgoing" or picking.state in (
@@ -387,7 +391,9 @@ class StockReleaseChannel(models.Model):
         # No channel provided by the picking -> try to find one be evaluating the rules
         # of all available channels
         # do a single query rather than one for each rule*picking
-        for channel in self.sudo().search([]):
+        for channel in self.sudo().search(
+            self._get_assignable_release_channel_domain()
+        ):
             if (
                 channel.picking_type_ids
                 and picking.picking_type_id not in channel.picking_type_ids

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -372,25 +372,27 @@ class StockReleaseChannel(models.Model):
         domain = safe_eval(self.rule_domain) or []
         return domain
 
-    def assign_release_channel(self, pickings):
-        pickings = pickings.filtered(
-            lambda picking: picking.picking_type_id.code == "outgoing"
-            and picking.state not in ("cancel", "done")
-        )
-        if not pickings:
+    def assign_release_channel(self, picking):
+        picking.ensure_one()
+        if picking.picking_type_id.code != "outgoing" or picking.state in (
+            "cancel",
+            "done",
+        ):
             return
         # do a single query rather than one for each rule*picking
         for channel in self.sudo().search([]):
-            if channel.picking_type_ids:
-                current = pickings.filtered(
-                    lambda p: p.picking_type_id in channel.picking_type_ids
-                )
-            else:
-                current = pickings
+            if (
+                channel.picking_type_ids
+                and picking.picking_type_id not in channel.picking_type_ids
+            ):
+                continue
 
             domain = channel._prepare_domain()
+
             if domain:
-                current = current.filtered_domain(domain)
+                current = picking.filtered_domain(domain)
+            else:
+                current = picking
 
             if not current:
                 continue
@@ -402,17 +404,14 @@ class StockReleaseChannel(models.Model):
                 continue
             current = channel._assign_release_channel_additional_filter(current)
             current.release_channel_id = channel
+            break
 
-            pickings -= current
-            if not pickings:
-                break
-
-        if pickings:
-            # by this point, all pickings should have been assigned
+        if not picking.release_channel_id:
+            # by this point, the picking should have been assigned
             _logger.warning(
-                "%s transfers could not be assigned to a channel,"
+                "Transfer %s could not be assigned to a channel,"
                 " you should add a final catch-all rule",
-                len(pickings),
+                picking.name,
             )
         return True
 

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -256,24 +256,24 @@ class StockReleaseChannel(models.Model):
                 ),
             ],
             "count_picking_released": [
-                ("need_release", "=", False),
+                ("last_release_date", "!=", False),
                 ("state", "in", ("assigned", "waiting", "confirmed")),
             ],
             "count_picking_assigned": [
-                ("need_release", "=", False),
+                ("last_release_date", "!=", False),
                 ("state", "=", "assigned"),
             ],
             "count_picking_waiting": [
-                ("need_release", "=", False),
+                ("last_release_date", "!=", False),
                 ("state", "in", ("waiting", "confirmed")),
             ],
             "count_picking_late": [
-                ("need_release", "=", False),
+                ("last_release_date", "!=", False),
                 ("scheduled_date", "<", fields.Datetime.now()),
                 ("state", "in", ("assigned", "waiting", "confirmed")),
             ],
             "count_picking_priority": [
-                ("need_release", "=", False),
+                ("last_release_date", "!=", False),
                 ("priority", "=", "1"),
                 ("state", "in", ("assigned", "waiting", "confirmed")),
             ],

--- a/stock_release_channel/readme/CONTRIBUTORS.rst
+++ b/stock_release_channel/readme/CONTRIBUTORS.rst
@@ -2,6 +2,7 @@
 * Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
 * Sébastien Alix <sebastien.alix@camptocamp.com>
 * Jacques-Etienne Baudoux <je@bcim.be>
+* Laurent Mignon <laurent.mignon@acsone.eu>
 
 Design
 ~~~~~~

--- a/stock_release_channel/readme/USAGE.rst
+++ b/stock_release_channel/readme/USAGE.rst
@@ -6,3 +6,23 @@ to release and of the progress of the released transfers.
 When clicking on the "box" button, transfers are released automatically, to
 reach a total of <Max Transfers to release> (option configured in the channel
 settings).
+
+The availability of a release channel depends on its state. A release channel
+can be in one of the following states:
+
+  - Open: the channel is available and can be used to release transfers. New
+    transfer are assigned automatically to this channel.
+  - Locked: the channel is available but the release of transfers from the channel
+    is no more possible. New transfers are still automatically assigned to this
+  - Asleep: the channel is not available and cannot be used to release
+    transfers. It is also no more possible to assign transfers to this channel.
+
+New release channels are by default "Open". You can change its state by using
+the "Lock" and "Sleep" buttons. When the "Sleep" button is used, in addition to
+the state change, not completed transfers assigned to the channel are unassigned
+from the channel. When the "Lock" button is used, only the state change is changed.
+A locked channel can be unlocked by using the "Unlock" button.
+A asleep channel can be waken up by using the "Wake up" button. When the "Wake up"
+button is used, in addition to the state change, the system looks for pending
+transfers requiring a release and try to assign them to a channel in the
+"Open" or "Locked" state.

--- a/stock_release_channel/tests/__init__.py
+++ b/stock_release_channel/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_release_channel
 from . import test_channel_computed_fields
 from . import test_channel_action
 from . import test_channel_release_batch
+from . import test_release_channel_lifecycle

--- a/stock_release_channel/tests/common.py
+++ b/stock_release_channel/tests/common.py
@@ -56,12 +56,13 @@ class ReleaseChannelCase(common.TransactionCase):
             in_date=in_date,
         )
 
-    def _create_single_move(self, product, qty, group=None):
+    @classmethod
+    def _create_single_move(cls, product, qty, group=None):
         # create a group so different moves are not merged in
         # the same picking
         if not group:
-            group = self.env["procurement.group"].create({})
-        picking_type = self.wh.out_type_id
+            group = cls.env["procurement.group"].create({})
+        picking_type = cls.wh.out_type_id
         move_vals = {
             "name": product.name,
             "picking_type_id": picking_type.id,
@@ -69,35 +70,37 @@ class ReleaseChannelCase(common.TransactionCase):
             "product_uom_qty": qty,
             "product_uom": product.uom_id.id,
             "location_id": picking_type.default_location_src_id.id,
-            "location_dest_id": self.customer_location.id,
+            "location_dest_id": cls.customer_location.id,
             "state": "confirmed",
             "procure_method": "make_to_stock",
             "group_id": group.id,
         }
-        move = self.env["stock.move"].create(move_vals)
+        move = cls.env["stock.move"].create(move_vals)
         move._assign_picking()
         return move
 
-    def _create_channel(self, **vals):
-        return self.env["stock.release.channel"].create(vals)
+    @classmethod
+    def _create_channel(cls, **vals):
+        return cls.env["stock.release.channel"].create(vals)
 
-    def _run_procurement(self, move, date=None):
+    @classmethod
+    def _run_procurement(cls, move, date=None):
         values = {
-            "company_id": self.wh.company_id,
+            "company_id": cls.wh.company_id,
             "group_id": move.picking_id.group_id,
             "date_planned": date or fields.Datetime.now(),
-            "warehouse_id": self.wh,
+            "warehouse_id": cls.wh,
         }
-        self.env["procurement.group"].run(
+        cls.env["procurement.group"].run(
             [
-                self.env["procurement.group"].Procurement(
+                cls.env["procurement.group"].Procurement(
                     move.product_id,
                     move.product_uom_qty,
                     move.product_uom,
-                    self.customer_location,
+                    cls.customer_location,
                     "TEST",
                     "TEST",
-                    self.wh.company_id,
+                    cls.wh.company_id,
                     values,
                 )
             ]

--- a/stock_release_channel/tests/test_release_channel_lifecycle.py
+++ b/stock_release_channel/tests/test_release_channel_lifecycle.py
@@ -1,0 +1,82 @@
+# Copyright 2022 ACSONE SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from unittest import mock
+
+from odoo import exceptions
+
+from odoo.addons.queue_job.job import identity_exact
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import ReleaseChannelCase
+
+
+class TestReleaseChannelLifeCycle(ReleaseChannelCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_release_channel_locked_no_release_next_batch(self):
+        self.default_channel.release_next_batch()
+        self.default_channel.action_lock()
+        with self.assertRaisesRegex(
+            exceptions.UserError,
+            "The release of pickings is not allowed",
+        ):
+            self.default_channel.release_next_batch()
+
+    def test_release_channel_asleep_no_release_next_batch(self):
+        self.default_channel.release_next_batch()
+        self.default_channel.action_sleep()
+        with self.assertRaisesRegex(
+            exceptions.UserError,
+            "The release of pickings is not allowed",
+        ):
+            self.default_channel.release_next_batch()
+
+    def test_release_channel_asleep_not_assignable(self):
+        move = self._create_single_move(self.product1, 10)
+        move.picking_id.assign_release_channel()
+        self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
+        self.default_channel.action_sleep()
+        move = self._create_single_move(self.product1, 10)
+        move.picking_id.assign_release_channel()
+        self.assertFalse(move.picking_id.release_channel_id)
+
+    def test_release_channel_wake_up_assign(self):
+        self.default_channel.action_sleep()
+        move = self._create_single_move(self.product1, 10)
+        move.picking_id.assign_release_channel()
+        move.need_release = True
+        self.assertFalse(move.picking_id.release_channel_id)
+        with trap_jobs() as trap:
+            self.default_channel.action_wake_up()
+            trap.assert_jobs_count(1)
+            trap.assert_enqueued_job(
+                move.picking_id.assign_release_channel,
+                args=(),
+                kwargs={},
+                properties=dict(
+                    identity_key=identity_exact,
+                ),
+            )
+            trap.enqueued_jobs[0].perform()
+        self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
+
+    def test_release_channel_sleep_unassign(self):
+        self.move = self._create_single_move(self.product1, 10)
+        self.move.picking_id.assign_release_channel()
+        self.picking = self.move.picking_id
+        self.assertEqual(self.picking.release_channel_id, self.default_channel)
+        self.default_channel.action_sleep()
+        self.assertFalse(self.picking.release_channel_id)
+
+    def test_release_channel_sleep_unrelease(self):
+        self.move = self._create_single_move(self.product1, 10)
+        self.move.picking_id.assign_release_channel()
+        self.picking = self.move.picking_id
+        with mock.patch.object(
+            self.picking.__class__,
+            "unrelease",
+        ) as release_picking:
+            self.default_channel.action_sleep()
+        self.assertEqual(release_picking.call_count, 1)

--- a/stock_release_channel/views/stock_release_channel_views.xml
+++ b/stock_release_channel/views/stock_release_channel_views.xml
@@ -6,8 +6,53 @@
         <field name="model">stock.release.channel</field>
         <field name="arch" type="xml">
             <form>
+                <header>
+                    <field name="is_action_lock_allowed" invisible="1" />
+                    <field name="is_action_unlock_allowed" invisible="1" />
+                    <field name="is_action_sleep_allowed" invisible="1" />
+                    <field name="is_action_wake_up_allowed" invisible="1" />
+                    <button
+                        name="action_lock"
+                        string="Lock"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-lock"
+                        attrs="{'invisible': [('is_action_lock_allowed', '=', False)]}"
+                    />
+                    <button
+                        name="action_unlock"
+                        string="Unlock"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-unlock"
+                        attrs="{'invisible': [('is_action_unlock_allowed', '=', False)]}"
+                    />
+                    <button
+                        name="action_sleep"
+                        string="Sleep"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-bed"
+                        attrs="{'invisible': [('is_action_sleep_allowed', '=', False)]}"
+                    />
+                    <button
+                        name="action_wake_up"
+                        string="Wake Up"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-bolt"
+                        attrs="{'invisible': [('is_action_wake_up_allowed', '=', False)]}"
+                    />
+                    <field
+                        name="state"
+                        widget="statusbar"
+                        statusbar_visible="open,locked,asleep"
+                        readonly="true"
+                    />
+                </header>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
+
                     </div>
                     <field name="active" invisible="1" />
                     <widget
@@ -69,6 +114,21 @@
             <search>
                 <field name="warehouse_id" />
                 <separator />
+                <filter
+                    string="Open"
+                    name="filter_open"
+                    domain="[('state','=','open')]"
+                />
+                <filter
+                    string="Locked"
+                    name="filter_locked"
+                    domain="[('state','=','locked')]"
+                />
+                <filter
+                    string="Aslepp"
+                    name="filter_asleep"
+                    domain="[('state','=','asleep')]"
+                />
                 <filter
                     string="Archived"
                     name="inactive"
@@ -148,8 +208,20 @@
                                     <div class="o_kanban_card_header_title">
                                         <div class="o_primary">
                                             <field name="name" />
+                                            <field name="state" invisible="1" />
+                                            <t
+                                                t-set="classname"
+                                                t-value="{'open': 'fa fa-unlock', 'locked': 'fa fa-lock', 'asleep': 'fa fa-bed'}[record.state.raw_value] || ''"
+                                            />
+                                            <i
+                                                t-attf-class="{{ classname }}"
+                                                role="img"
+                                                title="name"
+                                                style="float: right; line-height: 24px"
+                                            />
                                         </div>
                                     </div>
+
                                     <div class="o_kanban_manage_button_section">
                                         <hr class="mt4 mb4" />
                                         <a
@@ -166,10 +238,15 @@
                                 <div class="container o_kanban_card_content">
                                     <div class="row o_kanban_card_upper_content">
                                         <div class="col-4 o_kanban_primary_left">
+                                            <field
+                                                name="is_release_allowed"
+                                                invisible="1"
+                                            />
                                             <button
                                                 class="btn btn-primary"
                                                 name="release_next_batch"
                                                 type="object"
+                                                attrs="{'invisible': [('is_release_allowed', '=', False)]}"
                                             >
                                                 <i
                                                     class="fa fa-dropbox fa-4x"
@@ -459,26 +536,107 @@
                                     class="container o_kanban_card_manage_pane dropdown-menu"
                                     role="menu"
                                 >
+                                 <div class="row">
+                                     <div
+                                            class="col-6 o_kanban_card_manage_section o_kanban_manage_view"
+                                            name="dropdown-menu-left-panel"
+                                        >
+                                         <field
+                                                name="is_action_lock_allowed"
+                                                invisible="1"
+                                            />
+                                         <field
+                                                name="is_action_unlock_allowed"
+                                                invisible="1"
+                                            />
+                                         <field
+                                                name="is_action_sleep_allowed"
+                                                invisible="1"
+                                            />
+                                         <field
+                                                name="is_action_wake_up_allowed"
+                                                invisible="1"
+                                            />
+                                         <div
+                                                role="menuitem"
+                                                class="o_kanban_card_manage_title"
+                                            >
+                                            <span>Actions</span>
+                                        </div>
+                                         <t
+                                                t-if="record.is_action_lock_allowed.raw_value"
+                                            >
+                                             <div role="menuitem">
+                                                <a
+                                                        name="action_lock"
+                                                        type="object"
+                                                        icon="fa-lock"
+                                                    >Lock</a>
+                                             </div>
+                                        </t>
+                                        <t
+                                                t-if="record.is_action_unlock_allowed.raw_value"
+                                            >
+                                            <div role="menuitem">
+                                                <a
+                                                        name="action_unlock"
+                                                        type="object"
+                                                        icon="fa-unlock"
+                                                    >Unlock</a>
+                                            </div>
+                                        </t>
+                                        <t
+                                                t-if="record.is_action_sleep_allowed.raw_value"
+                                            >
+                                            <div role="menuitem">
+                                                <a
+                                                        name="action_sleep"
+                                                        type="object"
+                                                        icon="fa-bed"
+                                                    >Sleep</a>
+                                            </div>
+                                        </t>
+                                        <t
+                                                t-if="record.is_action_wake_up_allowed.raw_value"
+                                            >
+                                            <div role="menuitem">
+                                                <a
+                                                        name="action_wake_up"
+                                                        type="object"
+                                                        icon="fa-bolt"
+                                                    >Wake Up</a>
+                                            </div>
+                                        </t>
+                                     </div>
+                                     <div
+                                            class="col-6 o_kanban_card_manage_section o_kanban_manage_reporting"
+                                            name="dropdown-menu-right-panel"
+                                        >
+                                     </div>
+                                 </div>
+                                <div class="o_kanban_card_manage_settings row">
                                     <div
-                                        t-if="widget.editable"
-                                        class="o_kanban_card_manage_settings row"
-                                    >
-                                        <div
-                                            class="col-8"
                                             role="menuitem"
                                             aria-haspopup="true"
+                                            class="col-6"
                                         >
-                                            <ul
+                                        <ul
                                                 class="oe_kanban_colorpicker"
                                                 data-field="color"
-                                                role="menu"
+                                                role="popup"
                                             />
-                                        </div>
-                                        <div role="menuitem" class="col-4 text-center">
-                                            <a type="edit">Settings</a>
-                                        </div>
+                                    </div>
+                                    <div role="menuitem" class="col-6">
+                                        <t t-if="widget.editable">
+                                            <a
+                                                    role="menuitem"
+                                                    type="edit"
+                                                    class="dropdown-item"
+                                                >Settings</a>
+                                        </t>
                                     </div>
                                 </div>
+                            </div>
                             </div>
                         </div>
                     </t>
@@ -493,7 +651,9 @@
         <field name="res_model">stock.release.channel</field>
         <field name="view_mode">kanban,tree,form</field>
         <field name="domain">[]</field>
-        <field name="context">{}</field>
+        <field
+            name="context"
+        >{'search_default_filter_open': True, 'search_default_filter_locked': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Release Channel configured
@@ -506,12 +666,33 @@
         <field name="res_model">stock.release.channel</field>
         <field name="view_mode">tree,form,kanban</field>
         <field name="domain">[]</field>
-        <field name="context">{}</field>
+        <field
+            name="context"
+        >{'search_default_filter_open': True, 'search_default_filter_locked': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Add a Release Channel
             </p>
         </field>
+    </record>
+
+    <!-- Assign Pickings in action menu -->
+    <record
+        id="model_stock_release_channel_action_assign_pickings"
+        model="ir.actions.server"
+    >
+        <field name="name">Assign Pickings</field>
+        <field
+            name="model_id"
+            ref="stock_release_channel.model_stock_release_channel"
+        />
+        <field
+            name="binding_model_id"
+            ref="stock_release_channel.model_stock_release_channel"
+        />
+        <field name="binding_view_types">form,tree,kanban</field>
+        <field name="state">code</field>
+        <field name="code">action = model.assign_pickings()</field>
     </record>
 
     <record model="ir.ui.menu" id="stock_release_channel_menu">


### PR DESCRIPTION
* [x] includes #493
* [x] depends on #478 

The availability of a release channel depends on its state. A release channel
can be in one of the following states:

  - Open: the channel is available and can be used to release transfers. New
    transfer are assigned automatically to this channel.
  - Locked: the channel is available but the release of transfers from the channel
    is no more possible. New transfers are still automatically assigned to this
  - Asleep: the channel is not available and cannot be used to release
    transfers. It is also no more possible to assign transfers to this channel.

New release channels are by default "Open". You can change its state by using
the "Lock" and "Sleep" buttons. When the "Sleep" button is used, in addition to
the state change, not completed transfers assigned to the channel are unassigned
from the channel. When the "Lock" button is used, only the state change is changed.
A locked channel can be unlocked by using the "Unlock" button.
A asleep channel can be waken up by using the "Wake up" button. When the "Wake up"
button is used, in addition to the state change, the system looks for pending
transfers requiring a release and try to assign them to a channel in the
"Open" or "Locked" state.