### PR TITLE
[14.0][IMP] shopfloor_workstation_label_printer: leverage `base_report_to_label_printer`

### DIFF
--- a/shopfloor_workstation_label_printer/__manifest__.py
+++ b/shopfloor_workstation_label_printer/__manifest__.py
@@ -10,7 +10,7 @@
     "website": "https://github.com/OCA/wms",
     "development_status": "Alpha",
     "license": "AGPL-3",
-    "depends": ["base_report_to_printer", "shopfloor_workstation"],
+    "depends": ["base_report_to_label_printer", "shopfloor_workstation"],
     "data": ["views/res_users.xml", "views/shopfloor_workstation.xml"],
     "installable": True,
 }

--- a/shopfloor_workstation_label_printer/models/res_users.py
+++ b/shopfloor_workstation_label_printer/models/res_users.py
@@ -1,22 +1,21 @@
 # Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
-from odoo import api, fields, models
+from warnings import warn
+
+from odoo import models
 
 
 class ResUsers(models.Model):
     _inherit = "res.users"
 
-    default_label_printer_id = fields.Many2one(
-        comodel_name="printing.printer", string="Default Label Printer"
-    )
-
-    @api.model
-    def _register_hook(self):
-        super()._register_hook()
-        self.SELF_WRITEABLE_FIELDS.extend(["default_label_printer_id"])
-        self.SELF_READABLE_FIELDS.extend(["default_label_printer_id"])
-
+    # TODO method to remove when migrating to 15.0+
     def get_delivery_label_printer(self, delivery_type):
         self.ensure_one()
+        warn(
+            "'res.users.get_delivery_label_printer' method is deprecated. "
+            "Consider to switch to 'ir.actions.report._get_user_default_printer' "
+            "from 'base_report_to_label_printer' module.",
+            DeprecationWarning,
+        )
         return self.default_label_printer_id


### PR DESCRIPTION
Supersedes #517 

Module [`base_report_to_label_printer`](https://github.com/OCA/report-print-send/pull/313) allows to flag reports as labels and provides a method to get the expected label printer for a given user. So:

- Deprecate the `res.users.get_delivery_label_printer` method. A better alternative is to use `ir.actions.report._get_user_default_printer`.
- Remove the `res.users.default_label_printer_id` field definition from the current module as it already exists in `base_report_to_label_printer`.

Depends on:
- https://github.com/OCA/report-print-send/pull/313

Ref 3798