### PR TITLE
[14.0][IMP] shopfloor_mobile_base: create event to handle 401 error

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/fetch.js
+++ b/shopfloor_mobile_base/static/wms/src/fetch.js
@@ -10,7 +10,37 @@
 
 // Credit https://stackoverflow.com/questions/43792026
 
-window.standardFetch = fetch;
+window._standardFetch = fetch;
+
+window.standardFetch = function () {
+    var fetchUnauthorized = new Event("fetchUnauthorized", {
+        view: document,
+        bubbles: true,
+        cancelable: false,
+    });
+
+    // Pass the supplied arguments to the real fetch function
+    var fetchCall = window._standardFetch.apply(this, arguments);
+
+    const _check_unauthorized = (data) => {
+        if (data.status === 401) {
+            fetchUnauthorized.data = {
+                body: data.body,
+                url: data.url,
+                status: data.status,
+                status_text: data.statusText,
+            };
+            document.dispatchEvent(fetchUnauthorized);
+        }
+    };
+
+    fetchCall.then(function (data) {
+        // Check if the user is unauthorized
+        // and trigger the fetchUnauthorized event
+        _check_unauthorized(data);
+    });
+    return fetchCall;
+};
 
 /**
  * Patch `fetch` to trigger events on start and end request.

--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -282,7 +282,9 @@ new Vue({
         _on_logout_default: function () {
             this.authenticated = false;
             this._clearAppData();
-            this.$router.push({name: "login"});
+            if (this.$route.name !== "login") {
+                this.$router.push({name: "login"});
+            }
             this.trigger("logout:success", {root: this});
             return Promise.resolve();
         },


### PR DESCRIPTION
With this change, we can listen to any requests that fail with code error 401 and add any necessary logic (e.g. redirect to the login page).