### PR TITLE
[14.0] shopfloor: checkout prevent to take more than planned

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -594,6 +594,23 @@ class MessageAction(Component):
             "body": _("The picked quantity must be a value above zero."),
         }
 
+    def selected_lines_qty_done_higher_than_allowed(self):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "The quantity scanned for one or more lines cannot be "
+                "higher than the maximum allowed."
+            ),
+        }
+
+    def line_scanned_qty_done_higher_than_allowed(self):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "Please note that the scanned quantity is higher than the maximum allowed."
+            ),
+        }
+
     def recovered_previous_session(self):
         return {
             "message_type": "info",

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -48,3 +48,22 @@ class CheckoutCommonCase(CommonCase):
         }
         data.update(kw)
         return data
+
+    def _assert_select_package_qty_above(self, response, picking):
+        self.assert_response(
+            response,
+            next_state="select_package",
+            data={
+                "selected_move_lines": [
+                    self._move_line_data(ml) for ml in picking.move_line_ids.sorted()
+                ],
+                "picking": self._picking_summary_data(picking),
+                "packing_info": "",
+                "no_package_enabled": True,
+            },
+            message={
+                "message_type": "warning",
+                "body": "The quantity scanned for one or more lines cannot be "
+                "higher than the maximum allowed.",
+            },
+        )

--- a/shopfloor/tests/test_checkout_set_qty.py
+++ b/shopfloor/tests/test_checkout_set_qty.py
@@ -192,10 +192,10 @@ class CheckoutSetCustomQtyCase(CheckoutSetQtyCommonCase):
         self._assert_selected_qties(
             response,
             selected_lines,
-            {line1: line1.product_uom_qty, line2: line2.product_uom_qty},
+            {line1: line1.product_uom_qty + 1, line2: line2.product_uom_qty},
             message={
-                "body": "Not allowed to pack more than the quantity, "
-                "the value has been changed to the maximum.",
+                "body": "Please note that the scanned quantity "
+                "is higher than the maximum allowed.",
                 "message_type": "warning",
             },
         )


### PR DESCRIPTION
For checkout, in the select_package screen, we now allow the user to scan articles and go beyond the maximum qty_done allowed (line will be highlighted in red and a warning message will be displayed).

However, assigning a package in that situation will not be allowed, and they will still receive an error message.

Depends on:
- [x] https://github.com/OCA/wms/pull/483#issuecomment-1370958786

ref: rau-92