### PR TITLE
[14.0] shopfloor: cluster_picking full bin action opt-out

### DIFF
--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -113,6 +113,16 @@ class ShopfloorMenu(models.Model):
         help=UNLOAD_PACK_AT_DEST_HELP,
     )
 
+    disable_full_bin_action_is_possible = fields.Boolean(
+        compute="_compute_disable_full_bin_action_is_possible"
+    )
+    disable_full_bin_action = fields.Boolean(
+        string="Disable full bin action",
+        default=False,
+        # TODO: improve this desc w/ usecases.
+        help=("When picking, prevent unloading the whole bin when full."),
+    )
+
     allow_force_reservation = fields.Boolean(
         string="Force stock reservation",
         default=False,
@@ -249,6 +259,13 @@ class ShopfloorMenu(models.Model):
     @api.onchange("unreserve_other_moves_is_possible")
     def onchange_unreserve_other_moves_is_possible(self):
         self.allow_unreserve_other_moves = self.unreserve_other_moves_is_possible
+
+    @api.depends("scenario_id")
+    def _compute_disable_full_bin_action_is_possible(self):
+        for menu in self:
+            menu.disable_full_bin_action_is_possible = menu.scenario_id.has_option(
+                "disable_full_bin_action"
+            )
 
     @api.depends("scenario_id")
     def _compute_ignore_no_putaway_available_is_possible(self):

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -114,6 +114,7 @@ class ClusterPicking(Component):
                 ),
                 picking=move_line.picking_id,
             )
+            data["disable_full_bin_action"] = self.work.menu.disable_full_bin_action
         return self._response(next_state="scan_destination", data=data, message=message)
 
     def _response_for_change_pack_lot(self, move_line, message=None):
@@ -1355,7 +1356,7 @@ class ShopfloorClusterPickingValidatorResponse(Component):
             "start_line": self._schema_for_single_line_details,
             "start": {},
             "manual_selection": self._schema_for_batch_selection,
-            "scan_destination": self._schema_for_single_line_details,
+            "scan_destination": self._schema_for_scan_destination,
             "zero_check": self._schema_for_zero_check,
             "unload_all": self._schema_for_unload_all,
             "confirm_unload_all": self._schema_for_unload_all,
@@ -1541,3 +1542,9 @@ class ShopfloorClusterPickingValidatorResponse(Component):
     @property
     def _schema_for_batch_selection(self):
         return self.schemas._schema_search_results_of(self.schemas.picking_batch())
+
+    @property
+    def _schema_for_scan_destination(self):
+        schema = self._schema_for_single_line_details
+        schema["disable_full_bin_action"] = {"type": "boolean"}
+        return schema

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -68,6 +68,13 @@
                     />
               </group>
               <group
+                    name="disable_full_bin_action"
+                    attrs="{'invisible': [('disable_full_bin_action_is_possible', '=', False)]}"
+                >
+                  <field name="disable_full_bin_action_is_possible" invisible="1" />
+                  <field name="disable_full_bin_action" />
+              </group>
+              <group
                     name="multiple_move_single_pack"
                     attrs="{'invisible': [('multiple_move_single_pack_is_possible', '=', False)]}"
                 >

--- a/shopfloor_mobile/static/wms/src/demo/demo.cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.cluster_picking.js
@@ -155,4 +155,39 @@ const DEMO_CLUSTER_PICKING_1 = {
     },
 };
 
-demotools.add_case("cluster_picking", DEMO_CLUSTER_PICKING_1);
+const DEMO_CLUSTER_PICKING_2 = _.cloneDeep(DEMO_CLUSTER_PICKING_1);
+
+DEMO_CLUSTER_PICKING_2.scan_line = {
+    next_state: "scan_destination",
+    data: {
+        scan_destination: {
+            ...demotools.makeBatchPickingLine(),
+            disable_full_bin_action: true,
+        },
+    },
+};
+
+const DEMO_CASE = {
+    by_menu_id: {},
+};
+
+const cluster_picking_menu_case1 = demotools.addAppMenu(
+    {
+        name: "Cluster picking: case 1",
+        scenario: "cluster_picking",
+        picking_types: [{id: 27, name: "Random type"}],
+    },
+    "cp_1"
+);
+const cluster_picking_menu_case2 = demotools.addAppMenu(
+    {
+        name: "Cluster picking: case 2 (no full bin)",
+        scenario: "cluster_picking",
+        picking_types: [{id: 28, name: "Random type"}],
+    },
+    "cp_2"
+);
+DEMO_CASE.by_menu_id[cluster_picking_menu_case1] = DEMO_CLUSTER_PICKING_1;
+DEMO_CASE.by_menu_id[cluster_picking_menu_case2] = DEMO_CLUSTER_PICKING_2;
+
+demotools.add_case("cluster_picking", DEMO_CASE);

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -45,8 +45,12 @@ const ClusterPicking = {
                 <div class="button-list button-vertical-list full mt-10">
                     <v-row align="center">
                         <v-col class="text-center" cols="12">
-                            <v-btn @click="state.on_action_full_bin">
+                            <v-btn color="primary" @click="state.on_action_full_bin" v-if="!state.data.disable_full_bin_action">
                                 Full bin
+                            </v-btn>
+                            <v-btn color="default" disabled v-else="">
+                                <v-icon color="warning" class="pr-1">mdi-block-helper</v-icon>
+                                Full bin disabled by menu
                             </v-btn>
                         </v-col>
                     </v-row>


### PR DESCRIPTION
Add menu flag to disable the full bin action.
This way the operator is forced to finish the picking using additional bins when full.

~NOTE: based on 14a220944f630e073dd8dabff0e0c2b1fcbd825f~