### PR TITLE
shopfloor: zp use pack location as sublocation

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -569,7 +569,12 @@ class ZonePicking(Component):
         if packaging.package_has_several_lots(package):
             message = self.msg_store.several_lots_in_package(package)
         if message:
-            return self.list_move_lines(), message
+            return (
+                self._list_move_lines(
+                    self.zone_location, sublocation=package.location_id or False
+                ),
+                message,
+            )
         move_lines = self._find_location_move_lines(
             locations=sublocation, package=package
         )

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -255,19 +255,22 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         next step 'select_line expected.
         """
         pack = self.free_package
-        self._update_qty_in_location(self.zone_location, self.product_a, 2, pack)
-        self._update_qty_in_location(self.zone_location, self.product_b, 2, pack)
+        self._update_qty_in_location(self.zone_sublocation1, self.product_a, 2, pack)
+        self._update_qty_in_location(self.zone_sublocation1, self.product_b, 2, pack)
         response = self.service.dispatch(
             "scan_source",
             params={"barcode": pack.name},
         )
-        move_lines = self.service._find_location_move_lines()
+        move_lines = self.service._find_location_move_lines(
+            locations=self.zone_sublocation1
+        )
         move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
         self.assert_response_select_line(
             response,
             zone_location=self.zone_location,
             picking_type=self.picking_type,
             move_lines=move_lines,
+            sublocation=self.zone_sublocation1,
             message=self.service.msg_store.several_products_in_package(pack),
         )
 


### PR DESCRIPTION
When scanning a package use the location of that package to filter on sub location.
So if the package has multiple products, the user will not be required to scan a location after scanning the product.

ref.: rau-93