### PR TITLE
shopfloor: fix message wrong package scanned

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -564,21 +564,21 @@ class ZonePicking(Component):
         package = search.package_from_scan(barcode)
         if not package:
             return response, message
-        if packaging.package_has_several_products(package):
-            message = self.msg_store.several_products_in_package(package)
-        if packaging.package_has_several_lots(package):
-            message = self.msg_store.several_lots_in_package(package)
-        if message:
-            return (
-                self._list_move_lines(
-                    self.zone_location, sublocation=package.location_id or False
-                ),
-                message,
-            )
         move_lines = self._find_location_move_lines(
             locations=sublocation, package=package
         )
         if move_lines:
+            if packaging.package_has_several_products(package):
+                message = self.msg_store.several_products_in_package(package)
+            if packaging.package_has_several_lots(package):
+                message = self.msg_store.several_lots_in_package(package)
+            if message:
+                return (
+                    self._list_move_lines(
+                        self.zone_location, sublocation=package.location_id or False
+                    ),
+                    message,
+                )
             move_line = first(move_lines)
             # Fix me for a package prefill qty is zero ?
             qty_done = self._get_prefill_qty(move_line)

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -254,9 +254,8 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned package that several product, aborting
         next step 'select_line expected.
         """
-        pack = self.free_package
-        self._update_qty_in_location(self.zone_sublocation1, self.product_a, 2, pack)
-        self._update_qty_in_location(self.zone_sublocation1, self.product_b, 2, pack)
+        pack = self.picking1.package_level_ids[0].package_id
+        self._update_qty_in_location(pack.location_id, self.product_b, 2, pack)
         response = self.service.dispatch(
             "scan_source",
             params={"barcode": pack.name},


### PR DESCRIPTION
When the source package scanned is not valid not need to check its content for multiple products or lots.

ref: rau-97