### PR TITLE
shopfloor: do not propagate user_id to backorder

### DIFF
--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -66,7 +66,11 @@ class StockAction(Component):
         for picking in moves.picking_id:
             moves_todo = picking.move_lines & moves
             if self._check_backorder(picking, moves_todo):
+                existing_backorders = picking.backorder_ids
                 picking._action_done()
+                new_backorders = picking.backorder_ids - existing_backorders
+                if new_backorders:
+                    new_backorders.write({"user_id": False})
             else:
                 moves_todo.extract_and_action_done()
 

--- a/shopfloor/tests/test_location_content_transfer_set_destination_all.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_all.py
@@ -125,6 +125,7 @@ class LocationContentTransferSetDestinationAllCase(LocationContentTransferCommon
         self.assertEqual(move_d.product_qty, 5)
         self.assertTrue(self.picking2.backorder_ids)
         self.assertNotEqual(self.picking2.backorder_ids.state, "done")
+        self.assertFalse(self.picking2.backorder_ids.user_id)
         self.assertEqual(self.picking2.backorder_ids.move_lines.product_qty, 5)
 
     def test_set_destination_all_with_partially_available_move_with_ancestor(self):


### PR DESCRIPTION
In the shopfloor workflow the user_id should not be propagated to any backorder created.

ref: rau-102