### PR TITLE
[14.0] stock_available_to_promise_release & stock_release_channel: refactor releasing

### DIFF
--- a/stock_available_to_promise_release/README.rst
+++ b/stock_available_to_promise_release/README.rst
@@ -119,6 +119,7 @@ Authors
 ~~~~~~~
 
 * Camptocamp
+* BCIM
 
 Contributors
 ~~~~~~~~~~~~

--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Stock Available to Promise Release",
     "version": "14.0.2.0.0",
     "summary": "Release Operations based on available to promise",
-    "author": "Camptocamp,Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",
     "category": "Stock Management",
     "depends": ["stock"],

--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Stock Available to Promise Release",
     "version": "14.0.2.0.0",
     "summary": "Release Operations based on available to promise",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",
     "category": "Stock Management",
     "depends": ["stock"],

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -1,4 +1,5 @@
-# Copyright 2019-2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2019 Camptocamp (https://www.camptocamp.com)
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 import itertools
@@ -422,19 +423,30 @@ class StockMove(models.Model):
         quantities.
         """
         procurement_requests = []
-        pulled_moves = self.env["stock.move"]
-        backorder_links = {}
+        released_moves = self.env["stock.move"]
         for move in self:
             available_qty, remaining_qty = move._is_releasable()
             if not available_qty:
                 continue
-
             if remaining_qty:
-                new_move = move._release_split(remaining_qty)
-                backorder_links[new_move.picking_id] = move.picking_id
+                move._release_split(remaining_qty)
+            released_moves |= move
 
+        # Move the unreleased moves to a backorder.
+        # This behavior can be disabled by setting the flag
+        # no_backorder_at_release on the stock.route of the move.
+        released_pickings = released_moves.picking_id
+        unreleased_moves = released_pickings.move_lines - released_moves
+        unreleased_moves_to_bo = unreleased_moves.filtered(
+            lambda m: m.state not in ("done", "cancel")
+            and not m.rule_id.no_backorder_at_release
+        )
+        if unreleased_moves_to_bo:
+            unreleased_moves_to_bo._unreleased_to_backorder()
+
+        # Pull the released moves
+        for move in released_moves:
             move._before_release()
-
             values = move._prepare_procurement_values()
             procurement_requests.append(
                 self.env["procurement.group"].Procurement(
@@ -448,30 +460,12 @@ class StockMove(models.Model):
                     values,
                 )
             )
-            pulled_moves |= move
-
-        # move the unreleased moves to a backorder
-        released_pickings = pulled_moves.picking_id
-        unreleased_moves = released_pickings.move_lines - pulled_moves
-        for unreleased_move in unreleased_moves:
-            if unreleased_move.state in ("done", "cancel"):
-                continue
-            # no split will occur as we keep the same qty, but the move
-            # will be assigned to a new stock.picking
-            original_picking = unreleased_move.picking_id
-            unreleased_move._release_split(unreleased_move.product_qty)
-            backorder_links[unreleased_move.picking_id] = original_picking
-
-        for backorder, origin in backorder_links.items():
-            if backorder != origin:
-                backorder._release_link_backorder(origin)
-
         self.env["procurement.group"].run_defer(procurement_requests)
 
-        pulled_moves._after_release_assign_moves()
-        pulled_moves._after_release_update_chain()
+        released_moves._after_release_assign_moves()
+        released_moves._after_release_update_chain()
 
-        return pulled_moves
+        return released_moves
 
     def _before_release(self):
         """Hook that aims to be overridden."""
@@ -480,8 +474,8 @@ class StockMove(models.Model):
         picking_ids = set()
         moves = self
         while moves:
-            picking_ids.update(moves.mapped("picking_id").ids)
-            moves = moves.mapped("move_orig_ids")
+            picking_ids.update(moves.picking_id.ids)
+            moves = moves.move_orig_ids
         pickings = self.env["stock.picking"].browse(picking_ids)
         pickings._after_release_update_chain()
         # Set the highest priority on all pickings in the chain
@@ -496,31 +490,25 @@ class StockMove(models.Model):
         self.env["stock.move"].browse(move_ids)._action_assign()
 
     def _release_split(self, remaining_qty):
-        """Split move and create a new picking for it.
+        """Split move and put remaining_qty to a backorder move."""
+        new_move_vals = self.with_context(release_available_to_promise=True)._split(
+            remaining_qty
+        )
+        new_move = self.create(new_move_vals)
+        new_move._action_confirm(merge=False)
+        return new_move
 
-        By default, when we split a move at release to isolate the remaining qty
-        into a new move, we also create a new picking for it so that we can
-        release it later as soon as the qty is available.
-        This behavior can be changed by setting the flag no_backorder_at_release
-        on the stock.route of the move. This will allow to create the backorder
-        at the end of the picking process and release the unreleased moves into
-        the same picking as long as the picking is not done. By doing so, we
-        can also cleanup the backorders of the linked pickings created when
-        a released move was not processed (no qty found, or no time to do it for
-         example).
-        """
-        context = self.env.context
-        self = self.with_context(release_available_to_promise=True)
-        new_move = self  # Work on the current move if split doesn't occur
-        new_move_vals = self._split(remaining_qty)
-        if new_move_vals:
-            new_move = self.create(new_move_vals)
-            new_move._action_confirm(merge=False)
-        # Picking assignment is needed here because `_split` copies the move
-        # thus the `_should_be_assigned` condition is not satisfied
-        # and the move is not assigned.
-        new_move._assign_picking()
-        return new_move.with_context(**context)
+    def _unreleased_to_backorder(self):
+        """Move the unreleased moves to a new backorder picking"""
+        origin_pickings = {m.id: m.picking_id for m in self}
+        self.with_context(release_available_to_promise=True)._assign_picking()
+        backorder_links = {}
+        for move in self:
+            origin = origin_pickings[move.id]
+            if origin:
+                backorder_links[move.picking_id] = origin
+        for backorder, origin in backorder_links.items():
+            backorder._release_link_backorder(origin)
 
     def _assign_picking_post_process(self, new=False):
         super()._assign_picking_post_process(new)
@@ -606,7 +594,7 @@ class StockMove(models.Model):
         if self.env.context.get("release_available_to_promise"):
             force_new_picking = not self.rule_id.no_backorder_at_release
             if force_new_picking:
-                domain = expression.AND([domain, [("id", "!=", self.picking_id.id)]])
+                domain = expression.AND([domain, [("id", ">", self.picking_id.id)]])
         if self.picking_type_id.prevent_new_move_after_release:
             domain = expression.AND([domain, [("last_release_date", "=", False)]])
         return domain

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -639,7 +639,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
     def test_defer_multi_move_unreleased_in_backorder(self):
         """Unreleased moves are put in a backorder"""
         self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
-        self._update_qty_in_location(self.loc_bin1, self.product1, 10.0)
+        self._update_qty_in_location(self.loc_bin1, self.product1, 15.0)
         self._update_qty_in_location(self.loc_bin1, self.product2, 10.0)
         pickings = self._create_picking_chain(
             self.wh,
@@ -664,7 +664,6 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             ],
         )
 
-        cust_picking = pickings
         cust_picking.release_available_to_promise()
         backorder = cust_picking.backorder_ids
         self.assertRecordValues(
@@ -681,12 +680,12 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertRecordValues(
             backorder.move_lines,
             [
-                # remaining 10 on product 1 because it was partially available
-                {"product_qty": 10.0, "product_id": self.product1.id},
                 # these 2 moves were not released, so they are moved to a
                 # backorder
                 {"product_qty": 20.0, "product_id": self.product3.id},
                 {"product_qty": 10.0, "product_id": self.product4.id},
+                # remaining 5 on product 1 because it was partially available
+                {"product_qty": 5.0, "product_id": self.product1.id},
             ],
         )
 
@@ -706,7 +705,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertRecordValues(
             out_picking.move_lines,
             [
-                {"product_qty": 10.0, "product_id": self.product1.id},
+                {"product_qty": 15.0, "product_id": self.product1.id},
                 {"product_qty": 10.0, "product_id": self.product2.id},
             ],
         )

--- a/stock_release_channel/models/stock_move.py
+++ b/stock_release_channel/models/stock_move.py
@@ -16,9 +16,9 @@ class StockMove(models.Model):
         released_moves.picking_id.assign_release_channel()
         return released_moves
 
-    def _action_confirm(self, merge=True, merge_into=False):
-        moves = super()._action_confirm(merge=merge, merge_into=merge_into)
-        pickings = moves.filtered("need_release").picking_id
+    def _assign_picking(self):
+        res = super()._assign_picking()
+        pickings = self.filtered("need_release").picking_id
         if pickings:
             pickings._delay_assign_release_channel()
-        return moves
+        return res

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp
+# Copyright 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import _, exceptions, fields, models
@@ -10,7 +11,10 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     release_channel_id = fields.Many2one(
-        comodel_name="stock.release.channel", index=True, ondelete="restrict"
+        comodel_name="stock.release.channel",
+        index=True,
+        ondelete="restrict",
+        copy=False,
     )
     commercial_partner_id = fields.Many2one(
         comodel_name="res.partner",

--- a/stock_release_channel/tests/test_channel_action.py
+++ b/stock_release_channel/tests/test_channel_action.py
@@ -136,3 +136,16 @@ class TestChannelAction(ChannelReleaseCase):
         self._action_done_picking(self.picking)
         action = self.channel.get_action_picking_form()
         self.assertEqual(action["res_id"], self.picking.id)
+
+    def test_return_has_no_channel(self):
+        self.assertTrue(self.picking.release_channel_id is not False)
+        self.test_action_done()
+        wizard = self.env["stock.return.picking"].new(
+            {
+                "picking_id": self.picking.id,
+            }
+        )
+        wizard._onchange_picking_id()
+        reception_picking_id, __ = wizard._create_returns()
+        reception = self.env["stock.picking"].browse(reception_picking_id)
+        self.assertFalse(reception.release_channel_id)


### PR DESCRIPTION
## stock_available_to_promise: refactor releasing

Regroup concepts in methods called on the recordset. One method to split the moves. One method for making the backorder.
This will prevent stock_release_channel to spawn a job for each move. A single job is now spawn to compute the channels. 

## stock_release_channel: do not copy release channel

As a picking return is created by copying the delivery, do not copy the release channel as we don't want it on a return picking (reception picking). 

Ensure the release channel assignment job is created after the move is assigned to the new picking. The job is now created at the end of `_assign_picking`.

cc @sebalix @lmignon @mt-software-de 