### PR TITLE
shopfloor: fix zp set destination qty zero

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -587,6 +587,12 @@ class MessageAction(Component):
             ),
         }
 
+    def picking_zero_quantity(self):
+        return {
+            "message_type": "error",
+            "body": _("The picked quantity must be a value above zero."),
+        }
+
     def recovered_previous_session(self):
         return {
             "message_type": "info",

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -972,6 +972,14 @@ class ZonePicking(Component):
         if response:
             return response
 
+        if quantity <= 0:
+            message = self.msg_store.picking_zero_quantity()
+            return self._response_for_set_line_destination(
+                move_line,
+                message=message,
+                qty_done=self._get_prefill_qty(move_line, qty=0),
+            )
+
         extra_message = ""
         if not accept_only_package:
             # When the barcode is a location

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -579,3 +579,30 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
             move_lines,
             message=self.service.msg_store.confirm_pack_moved(),
         )
+
+    def test_set_destination_location_zero_quantity(self):
+        """Scanned barcode is the destination location.
+
+        Quantity to move is zero -> error raised, user can try again.
+
+        """
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        move_line = self.picking1.move_lines.move_line_ids
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.packing_location.barcode,
+                "quantity": 0,
+            },
+        )
+        # Check response
+        self.assert_response_set_line_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message=self.service.msg_store.picking_zero_quantity(),
+            qty_done=move_line.product_uom_qty,
+        )

--- a/shopfloor/tests/test_zone_picking_set_line_destination_no_prefill_qty.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination_no_prefill_qty.py
@@ -115,3 +115,31 @@ class ZonePickingSetLineDestinationNoPrefillQtyCase(ZonePickingCommonCase):
                 move_line,
                 qty_done=qty_done,
             )
+
+    def test_set_destination_location_zero_quantity(self):
+        """Scanned barcode is the destination location.
+
+        Quantity to move is zero -> error raised, user can try again.
+
+        """
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        move_line = self.picking1.move_lines.move_line_ids
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.packing_location.barcode,
+                "quantity": 0,
+            },
+        )
+        # Check response
+        self.assert_response_set_line_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message=self.service.msg_store.picking_zero_quantity(),
+            # And that the quantity done is zero
+            qty_done=0,
+        )


### PR DESCRIPTION
Do not allow a user to pick a quantity of zero or less. When the `no_prefill_qty` is set. A quantity of zero is the default value and it will still work.

ref.: rau-109