### PR TITLE
[14.0] shopfloor: checkout allow pack all lines at once

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -740,3 +740,13 @@ class MessageAction(Component):
             "message_type": "warning",
             "body": _("No available work could be found."),
         }
+
+    def confirm_put_all_goods_in_delivery_package(self, packaging_type):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "Delivery package type scanned: %(name)s. "
+                "Scan again to place all goods in the same package."
+            )
+            % dict(name=packaging_type.name),
+        }

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -38,3 +38,12 @@ class CheckoutCommonCase(CommonCase):
 
     def _packaging_data(self, packaging):
         return self.data.packaging(packaging)
+
+    def _data_for_select_line(self, picking, **kw):
+        data = {
+            "picking": self._stock_picking_data(picking),
+            "group_lines_by_location": True,
+            "need_confirm_pack_all": False,
+        }
+        data.update(kw)
+        return data

--- a/shopfloor/tests/test_checkout_cancel_line.py
+++ b/shopfloor/tests/test_checkout_cancel_line.py
@@ -87,10 +87,7 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(picking),
             message={"body": "Package cancelled", "message_type": "success"},
         )
 
@@ -115,10 +112,7 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(picking),
             message={"body": "Line cancelled", "message_type": "success"},
         )
 

--- a/shopfloor/tests/test_checkout_list_package.py
+++ b/shopfloor/tests/test_checkout_list_package.py
@@ -163,10 +163,7 @@ class CheckoutScanSetDestPackageCase(CheckoutCommonCase, SelectDestPackageMixin)
             response,
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(self.picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(self.picking),
             message=self.msg_store.goods_packed_in(self.delivery_package),
         )
 
@@ -271,10 +268,7 @@ class CheckoutScanSetDestPackageCase(CheckoutCommonCase, SelectDestPackageMixin)
             response,
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
-            data={
-                "group_lines_by_location": True,
-                "picking": self._stock_picking_data(self.picking),
-            },
+            data=self._data_for_select_line(self.picking),
             message=self.msg_store.goods_packed_in(self.delivery_package),
         )
 

--- a/shopfloor/tests/test_checkout_new_package.py
+++ b/shopfloor/tests/test_checkout_new_package.py
@@ -56,9 +56,6 @@ class CheckoutNewPackageCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
             response,
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(picking),
             message=self.msg_store.goods_packed_in(new_package),
         )

--- a/shopfloor/tests/test_checkout_no_package.py
+++ b/shopfloor/tests/test_checkout_no_package.py
@@ -57,10 +57,7 @@ class CheckoutNoPackageCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
             response,
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(self.picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(self.picking),
             message={
                 "message_type": "success",
                 "body": "Product(s) processed as raw product(s)",

--- a/shopfloor/tests/test_checkout_scan.py
+++ b/shopfloor/tests/test_checkout_scan.py
@@ -13,10 +13,7 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(picking),
         )
 
     def test_scan_document_stock_picking_ok(self):

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -359,10 +359,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
         self.assert_response(
             response,
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(picking),
             message=self.msg_store.goods_packed_in(new_package),
         )
 

--- a/shopfloor/tests/test_checkout_select.py
+++ b/shopfloor/tests/test_checkout_select.py
@@ -40,10 +40,7 @@ class CheckoutSelectCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(self.picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(self.picking),
         )
 
     def _test_error(self, picking, msg):

--- a/shopfloor/tests/test_checkout_select_line.py
+++ b/shopfloor/tests/test_checkout_select_line.py
@@ -79,10 +79,7 @@ class CheckoutSelectLineCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
         self.assert_response(
             response,
             next_state="select_line",
-            data={
-                "picking": self._stock_picking_data(self.picking),
-                "group_lines_by_location": True,
-            },
+            data=self._data_for_select_line(self.picking),
             message=message,
         )
 

--- a/shopfloor_mobile/static/wms/src/scenario/checkout_states.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout_states.js
@@ -46,7 +46,7 @@ export const checkout_states = function ($instance) {
         select_line: {
             display_info: {
                 title: "Pick the product by scanning something",
-                scan_placeholder: "Scan pack / product / lot",
+                scan_placeholder: "Scan pack / product / lot / delivery package",
             },
             events: {
                 summary: "on_summary",
@@ -58,6 +58,7 @@ export const checkout_states = function ($instance) {
                     $instance.odoo.call("scan_line", {
                         picking_id: $instance.state.data.picking.id,
                         barcode: scanned.text,
+                        confirm_pack_all: $instance.state.data.need_confirm_pack_all,
                     })
                 );
             },


### PR DESCRIPTION
Depends on:

- [x] https://github.com/OCA/wms/pull/547
- [x] https://github.com/OCA/wms/pull/562 

Main changes:

* [shopfloor: checkout allow pack all lines at once](https://github.com/OCA/wms/commit/a8baec01f83a87e77cdee3260482c7911fa2dfed)

On the select_line screen,
you can now skip the selection and scan a delivery package.

When this happens, the system asks for confirmation.

If you scan again the delivery package,
all lines will be selected and packed at the same time in the same package.