### PR TITLE
[14][BACKPORT] stock_available_to_promise add unrelease

### DIFF
--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -18,6 +18,7 @@
         "views/stock_location_route_views.xml",
         "views/res_config_settings.xml",
         "wizards/stock_release_views.xml",
+        "wizards/stock_unrelease_views.xml",
     ],
     "installable": True,
     "license": "LGPL-3",

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -347,7 +347,16 @@ class StockMove(models.Model):
         )
 
     def _action_cancel(self):
+        # Check that it is a released move...
+        # If yes unreleased it
+        moves_to_unrelease = self.filtered(lambda m: m.unrelease_allowed)
+        moves_to_unrelease.unrelease()
+        # moves_origin = self.move_orig_ids
+        # __import__("pdb").set_trace()
         super()._action_cancel()
+        # mc = self.filtered(lambda m: m.state=="cancel")
+        # __import__("pdb").set_trace()
+        # mc.move_orig_ids.unrelease()
         self.write({"need_release": False})
         return True
 

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -2,6 +2,7 @@
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+import itertools
 import logging
 import operator as py_operator
 
@@ -50,8 +51,50 @@ class StockMove(models.Model):
         search="_search_release_ready",
     )
     need_release = fields.Boolean(index=True, copy=False)
+    unrelease_allowed = fields.Boolean(compute="_compute_unrelease_allowed")
     zip_code = fields.Char(related="partner_id.zip", store=True)
     city = fields.Char(related="partner_id.city", store=True)
+
+    @api.depends("rule_id", "rule_id.available_to_promise_defer_pull")
+    def _compute_unrelease_allowed(self):
+        user_is_allowed = self.env.user.has_group("stock.group_stock_user")
+        for move in self:
+            unrelease_allowed = (
+                user_is_allowed
+                and not move.need_release
+                and move.state not in ("done", "cancel")
+                and move.picking_type_id.code == "outgoing"
+                and move.rule_id.available_to_promise_defer_pull
+            )
+            if unrelease_allowed:
+                iterator = move._get_chained_moves_iterator("move_orig_ids")
+                next(iterator)  # skip the current move
+                for origin_moves in iterator:
+                    origin_moves = origin_moves.filtered(
+                        lambda m: m.state not in ("done", "cancel")
+                    )
+                    origin_qty_todo = sum(origin_moves.mapped("product_qty"))
+                    unrelease_allowed = (
+                        float_compare(
+                            move.product_qty,
+                            origin_qty_todo,
+                            precision_rounding=move.product_uom.rounding,
+                        )
+                        <= 0
+                    )
+                    if not unrelease_allowed:
+                        break
+            move.unrelease_allowed = unrelease_allowed
+
+    def _check_unrelease_allowed(self):
+        for move in self:
+            if not move.unrelease_allowed:
+                raise UserError(
+                    _(
+                        "You are not allowed to unrelease this move %(move_name)s.",
+                        move_name=move.display_name,
+                    )
+                )
 
     def _previous_promised_qty_sql_main_query(self):
         return """
@@ -456,3 +499,63 @@ class StockMove(models.Model):
         priorities = self.mapped("move_dest_ids.picking_id.priority")
         if priorities:
             self.picking_id.write({"priority": max(priorities)})
+
+    def _get_chained_moves_iterator(self, chain_field):
+        """Return an iterator on the moves of the chain.
+
+        The iterator returns the moves in the order of the chain.
+        The loop into the iterator is the current moves.
+        """
+        moves = self
+        while moves:
+            yield moves
+            moves = moves.mapped(chain_field)
+
+    def unrelease(self):
+        """Unrelease moves"""
+        self._check_unrelease_allowed()
+        self.write({"need_release": True})
+        impacted_picking_ids = set()
+        for move in self:
+            iterator = move._get_chained_moves_iterator("move_orig_ids")
+            next(iterator)  # skip the current move
+            for origin_moves in iterator:
+                origin_moves = origin_moves.filtered(
+                    lambda m: m.state not in ("done", "cancel")
+                )
+                if origin_moves:
+                    origin_moves = self._split_origins(origin_moves)
+                    impacted_picking_ids.update(origin_moves.mapped("picking_id").ids)
+                    # avoid to propagate cancel to the original move
+                    origin_moves.write({"propagate_cancel": False})
+                    origin_moves._action_cancel()
+        self.write({"need_release": True})
+        for picking, moves in itertools.groupby(self, lambda m: m.picking_id):
+            move_names = "\n".join([m.display_name for m in moves])
+            body = _(
+                "The following moves have been un-released: \n%(move_names)s",
+                move_names=move_names,
+            )
+            picking.message_post(body=body)
+
+    def _split_origins(self, origins):
+        """Split the origins of the move according to the quantity into the
+        move and the quantity in the origin moves.
+
+        Return the origins for the move's quantity.
+        """
+        self.ensure_one()
+        qty = self.product_qty
+        rounding = self.product_uom.rounding
+        new_origin_moves = self.env["stock.move"]
+        while float_compare(qty, 0, precision_rounding=rounding) > 0 and origins:
+            origin = origins[0]
+            if float_compare(qty, origin.product_qty, precision_rounding=rounding) >= 0:
+                qty -= origin.product_qty
+                new_origin_moves |= origin
+            else:
+                new_move_vals = origin._split(qty)
+                new_origin_moves |= self.create(new_move_vals)
+                break
+            origins -= origin
+        return new_origin_moves

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -58,7 +58,7 @@ class StockMove(models.Model):
     @api.depends("rule_id", "rule_id.available_to_promise_defer_pull")
     def _compute_unrelease_allowed(self):
         for move in self:
-            unrelease_allowed = self._is_unrelease_allowed()
+            unrelease_allowed = move._is_unreleaseable()
             if unrelease_allowed:
                 iterator = move._get_chained_moves_iterator("move_orig_ids")
                 next(iterator)  # skip the current move
@@ -70,7 +70,7 @@ class StockMove(models.Model):
                         break
             move.unrelease_allowed = unrelease_allowed
 
-    def _is_unrelease_allowed(self):
+    def _is_unreleaseable(self):
         """Check if the move can be unrelease. At this stage we only check if
         the move is at the end of a chain of moves and has the caracteristics
         to be unrelease. We don't check the conditions on the origin moves.
@@ -538,12 +538,19 @@ class StockMove(models.Model):
             yield moves
             moves = moves.mapped(chain_field)
 
-    def unrelease(self):
-        """Unrelease moves"""
-        self._check_unrelease_allowed()
-        self.write({"need_release": True})
+    def unrelease(self, safe_unrelease=False):
+        """Unrelease unreleasavbe moves
+
+        If safe_unrelease is True, the unreleasaable moves for which the
+        processing has already started will be ignored
+        """
+        moves_to_unrelease = self.filtered(lambda m: m._is_unreleaseable())
+        if safe_unrelease:
+            moves_to_unrelease = self.filtered("unrelease_allowed")
+        moves_to_unrelease._check_unrelease_allowed()
+        moves_to_unrelease.write({"need_release": True})
         impacted_picking_ids = set()
-        for move in self:
+        for move in moves_to_unrelease:
             iterator = move._get_chained_moves_iterator("move_orig_ids")
             next(iterator)  # skip the current move
             for origin_moves in iterator:
@@ -556,8 +563,10 @@ class StockMove(models.Model):
                     # avoid to propagate cancel to the original move
                     origin_moves.write({"propagate_cancel": False})
                     origin_moves._action_cancel()
-        self.write({"need_release": True})
-        for picking, moves in itertools.groupby(self, lambda m: m.picking_id):
+        moves_to_unrelease.write({"need_release": True})
+        for picking, moves in itertools.groupby(
+            moves_to_unrelease, lambda m: m.picking_id
+        ):
             move_names = "\n".join([m.display_name for m in moves])
             body = _(
                 "The following moves have been un-released: \n%(move_names)s",

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -76,7 +76,7 @@ class StockPicking(models.Model):
                 picking.release_ready = False
                 picking.release_ready_count = 0
                 continue
-            move_lines = picking.move_ids.filtered(
+            move_lines = picking.move_lines.filtered(
                 lambda move: move.state not in ("cancel", "done") and move.need_release
             )
             if picking._get_shipping_policy() == "one":
@@ -177,4 +177,4 @@ class StockPicking(models.Model):
         If safe_unrelease is True, the unreleasaable moves for which the
         processing has already started will be ignored
         """
-        self.mapped("move_ids").unrelease(safe_unrelease=safe_unrelease)
+        self.mapped("move_lines").unrelease(safe_unrelease=safe_unrelease)

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -171,5 +171,10 @@ class StockPicking(models.Model):
         action["context"] = {}
         return action
 
-    def unrelease(self):
-        self.mapped("move_ids").filtered("unrelease_allowed").unrelease()
+    def unrelease(self, safe_unrelease=False):
+        """Unrelease the moves of the picking.
+
+        If safe_unrelease is True, the unreleasaable moves for which the
+        processing has already started will be ignored
+        """
+        self.mapped("move_ids").unrelease(safe_unrelease=safe_unrelease)

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -170,3 +170,6 @@ class StockPicking(models.Model):
         action["domain"] = [("picking_id", "=", self.id), ("need_release", "=", True)]
         action["context"] = {}
         return action
+
+    def unrelease(self):
+        self.mapped("move_ids").filtered("unrelease_allowed").unrelease()

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -76,8 +76,8 @@ class StockPicking(models.Model):
                 picking.release_ready = False
                 picking.release_ready_count = 0
                 continue
-            move_lines = picking.move_lines.filtered(
-                lambda move: move.state not in ("cancel", "done")
+            move_lines = picking.move_ids.filtered(
+                lambda move: move.state not in ("cancel", "done") and move.need_release
             )
             if picking._get_shipping_policy() == "one":
                 picking.release_ready_count = sum(

--- a/stock_available_to_promise_release/models/stock_picking_type.py
+++ b/stock_available_to_promise_release/models/stock_picking_type.py
@@ -8,6 +8,12 @@ class StockPickingType(models.Model):
     _inherit = "stock.picking.type"
 
     count_picking_need_release = fields.Integer(compute="_compute_picking_count")
+    unrelease_on_backorder = fields.Boolean(
+        string="Unrelease on backorder",
+        help="If checked, when a backorder is created the moves into the "
+        "backorder are unreleased if they come from a route configured "
+        "to manually release moves",
+    )
 
     def _compute_picking_count_need_release_domains(self):
         return {

--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -13,6 +13,10 @@ class StockRule(models.Model):
     def _get_custom_move_fields(self):
         return super()._get_custom_move_fields() + ["date_priority"]
 
+    available_to_promise_defer_pull = fields.Boolean(
+        related="route_id.available_to_promise_defer_pull", store=True
+    )
+
     def _run_pull(self, procurements):
         actions_to_run = []
 

--- a/stock_available_to_promise_release/security/ir.model.access.csv
+++ b/stock_available_to_promise_release/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_stock_release_wizard,access.stock.release.wizard,model_stock_release,stock.group_stock_user,1,1,1,0
+access_stock_unrelease_wizard,access.stock.unrelease.wizard,model_stock_unrelease,stock.group_stock_user,1,1,1,0

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_reservation
+from . import test_unrelease

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_reservation
 from . import test_unrelease
+from . import test_unrelease_2steps

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -117,3 +117,18 @@ class PromiseReleaseCommonCase(common.SavepointCase):
                 "outgoing_qty",
             ]
         )
+
+    @classmethod
+    def _prev_picking(cls, picking):
+        return picking.move_ids.move_orig_ids.picking_id
+
+    @classmethod
+    def _out_picking(cls, pickings):
+        return pickings.filtered(lambda r: r.picking_type_code == "outgoing")
+
+    @classmethod
+    def _deliver(cls, picking):
+        picking.action_assign()
+        for line in picking.mapped("move_ids.move_line_ids"):
+            line.qty_done = line.reserved_qty
+        picking._action_done()

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -120,7 +120,7 @@ class PromiseReleaseCommonCase(common.SavepointCase):
 
     @classmethod
     def _prev_picking(cls, picking):
-        return picking.move_ids.move_orig_ids.picking_id
+        return picking.move_lines.move_orig_ids.picking_id
 
     @classmethod
     def _out_picking(cls, pickings):
@@ -129,6 +129,6 @@ class PromiseReleaseCommonCase(common.SavepointCase):
     @classmethod
     def _deliver(cls, picking):
         picking.action_assign()
-        for line in picking.mapped("move_ids.move_line_ids"):
+        for line in picking.mapped("move_lines.move_line_ids"):
             line.qty_done = line.reserved_qty
         picking._action_done()

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -1,0 +1,80 @@
+# Copyright 2019 Camptocamp (https://www.camptocamp.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from datetime import datetime
+
+from odoo.exceptions import UserError
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.shipping = cls._out_picking(
+            cls._create_picking_chain(
+                cls.wh, [(cls.product1, 5)], date=datetime(2019, 9, 2, 16, 0)
+            )
+        )
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 15.0)
+        cls.wh.delivery_route_id.write(
+            {
+                "available_to_promise_defer_pull": True,
+                "no_backorder_at_release": True,
+            }
+        )
+
+        cls.shipping.release_available_to_promise()
+        cls.picking = cls._prev_picking(cls.shipping)
+        cls.picking.action_assign()
+
+    def test_unrelease_full(self):
+        """Unrelease all moves of a released ship. The pick should be deleted and
+        the moves should be mark as to release"""
+
+        self.assertEqual(self.picking.state, "assigned")
+        self.assertRecordValues(
+            self.shipping.move_ids,
+            [
+                {
+                    "state": "waiting",
+                    "need_release": False,
+                    "unrelease_allowed": True,
+                }
+            ],
+        )
+        self.shipping.move_ids.unrelease()
+        self.assertRecordValues(
+            self.shipping.move_ids,
+            [
+                {
+                    "state": "waiting",
+                    "need_release": True,
+                    "unrelease_allowed": False,
+                }
+            ],
+        )
+        self.assertEqual(self.picking.move_ids.state, "cancel")
+        self.assertEqual(self.picking.state, "cancel")
+
+        # I can release again the move and a new pick is created
+        self.shipping.release_available_to_promise()
+        new_picking = self._prev_picking(self.shipping) - self.picking
+        self.assertTrue(new_picking)
+        self.assertEqual(new_picking.state, "assigned")
+
+    def test_unrelease_partially_processed_move(self):
+        """Check it's not possible to unrelease a move that has been partially
+        processed"""
+        line = self.picking.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty - 1
+        self.picking.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        self.assertEqual(self.picking.state, "done")
+        self.assertFalse(self.shipping.move_ids.unrelease_allowed)
+        with self.assertRaisesRegex(
+            UserError, "You are not allowed to unrelease this move"
+        ):
+            self.shipping.move_ids.unrelease()

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -1,6 +1,7 @@
-# Copyright 2019 Camptocamp (https://www.camptocamp.com)
+# Copyright 2022 ACSONE SA/NV (https://www.acsone.eu)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
+from contextlib import contextmanager
 from datetime import datetime
 
 from odoo.exceptions import UserError
@@ -29,11 +30,8 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         cls.picking = cls._prev_picking(cls.shipping)
         cls.picking.action_assign()
 
-    def test_unrelease_full(self):
-        """Unrelease all moves of a released ship. The pick should be deleted and
-        the moves should be mark as to release"""
-
-        self.assertEqual(self.picking.state, "assigned")
+    @contextmanager
+    def _assert_full_unreleased(self):
         self.assertRecordValues(
             self.shipping.move_ids,
             [
@@ -44,7 +42,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                 }
             ],
         )
-        self.shipping.move_ids.unrelease()
+        yield
         self.assertRecordValues(
             self.shipping.move_ids,
             [
@@ -57,6 +55,12 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         )
         self.assertEqual(self.picking.move_ids.state, "cancel")
         self.assertEqual(self.picking.state, "cancel")
+
+    def test_unrelease_full(self):
+        """Unrelease all moves of a released ship. The pick should be deleted and
+        the moves should be mark as to release"""
+        with self._assert_full_unreleased():
+            self.shipping.move_ids.unrelease()
 
         # I can release again the move and a new pick is created
         self.shipping.release_available_to_promise()
@@ -78,3 +82,99 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             UserError, "You are not allowed to unrelease this move"
         ):
             self.shipping.move_ids.unrelease()
+
+    def test_unrelease_move_with_origin_in_printed_picking(self):
+        """Check it's not possible to unrelease a move with origin moves into a
+        printed picking"""
+        self.picking.printed = True
+        self.assertFalse(self.shipping.move_ids.unrelease_allowed)
+        with self.assertRaisesRegex(
+            UserError, "You are not allowed to unrelease this move"
+        ):
+            self.shipping.move_ids.unrelease()
+
+    def test_unrelease_backorder(self):
+        """Check the unrelease of a shipping backorder move"""
+        # we do a partial pick and validate the picking to create a backorder
+        # a validation
+        line = self.picking.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty - 1
+        self.picking.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        self.shipping.action_assign()
+        line = self.shipping.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty
+        self.shipping.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        # at this stage, our backorder ship move is linked to a pick move to do
+        backorder_ship = self.shipping.backorder_ids
+        self.assertTrue(backorder_ship)
+        self.assertTrue(backorder_ship.move_ids.unrelease_allowed)
+        self.assertTrue(
+            backorder_ship.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )
+        backorder_pick = self._prev_picking(backorder_ship) - self.picking
+        self.assertEqual(backorder_pick.state, "assigned")
+        backorder_ship.move_ids.unrelease()
+        # after the un release, our backorder ship move is not more linked to
+        # a pick move to do
+        self.assertFalse(backorder_ship.move_ids.unrelease_allowed)
+        self.assertEqual(backorder_pick.state, "cancel")
+        self.assertFalse(
+            backorder_ship.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )
+
+    def test_auto_unrelease_on_backorder(self):
+        """Check that moves into a backorder are unreleased if specified on
+        the picking type"""
+        self.shipping.picking_type_id.unrelease_on_backorder = True
+        # we do a partial pick and validate the picking to create a backorder
+        # a validation
+        line = self.picking.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty - 1
+        self.picking.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        self.shipping.action_assign()
+        line = self.shipping.move_ids.move_line_ids
+        line.qty_done = line.reserved_qty
+        # at this stage, our ship move is linked to a pick move to do
+        self.assertTrue(
+            self.shipping.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )
+        self.shipping.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        backorder_ship = self.shipping.backorder_ids
+        self.assertTrue(backorder_ship)
+        self.assertTrue(backorder_ship.need_release)
+        self.assertFalse(backorder_ship.move_ids.unrelease_allowed)
+        # no move pick move to do for our move into the backorder
+        self.assertFalse(
+            backorder_ship.move_ids.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
+        )
+
+    def test_unrelease_picking_wizard(self):
+        wizard = self.env["stock.unrelease"].create({})
+        with self._assert_full_unreleased():
+            wizard.with_context(
+                active_ids=self.shipping.ids, active_model=self.shipping._name
+            ).unrelease()
+
+    def test_unrelease_moves_wizard(self):
+        wizard = self.env["stock.unrelease"].create({})
+        with self._assert_full_unreleased():
+            wizard.with_context(
+                active_ids=self.shipping.move_ids.ids,
+                active_model=self.shipping.move_ids._name,
+            ).unrelease()

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -22,7 +22,6 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         cls.wh.delivery_route_id.write(
             {
                 "available_to_promise_defer_pull": True,
-                "no_backorder_at_release": True,
             }
         )
 
@@ -33,7 +32,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
     @contextmanager
     def _assert_full_unreleased(self):
         self.assertRecordValues(
-            self.shipping.move_ids,
+            self.shipping.move_lines,
             [
                 {
                     "state": "waiting",
@@ -44,7 +43,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         )
         yield
         self.assertRecordValues(
-            self.shipping.move_ids,
+            self.shipping.move_lines,
             [
                 {
                     "state": "waiting",
@@ -53,14 +52,14 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                 }
             ],
         )
-        self.assertEqual(self.picking.move_ids.state, "cancel")
+        self.assertEqual(self.picking.move_lines.state, "cancel")
         self.assertEqual(self.picking.state, "cancel")
 
     def test_unrelease_full(self):
         """Unrelease all moves of a released ship. The pick should be deleted and
         the moves should be mark as to release"""
         with self._assert_full_unreleased():
-            self.shipping.move_ids.unrelease()
+            self.shipping.move_lines.unrelease()
 
         # I can release again the move and a new pick is created
         self.shipping.release_available_to_promise()
@@ -71,95 +70,61 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
     def test_unrelease_partially_processed_move(self):
         """Check it's not possible to unrelease a move that has been partially
         processed"""
-        line = self.picking.move_ids.move_line_ids
-        line.qty_done = line.reserved_qty - 1
+        line = self.picking.move_lines.move_line_ids
+        line.qty_done = line.product_qty - 1
         self.picking.with_context(
             skip_immediate=True, skip_backorder=True
         ).button_validate()
         self.assertEqual(self.picking.state, "done")
-        self.assertFalse(self.shipping.move_ids.unrelease_allowed)
+        self.assertFalse(self.shipping.move_lines.unrelease_allowed)
         with self.assertRaisesRegex(
             UserError, "You are not allowed to unrelease this move"
         ):
-            self.shipping.move_ids.unrelease()
+            self.shipping.move_lines.unrelease()
 
     def test_unrelease_move_with_origin_in_printed_picking(self):
         """Check it's not possible to unrelease a move with origin moves into a
         printed picking"""
         self.picking.printed = True
-        self.assertFalse(self.shipping.move_ids.unrelease_allowed)
+        self.assertFalse(self.shipping.move_lines.unrelease_allowed)
         with self.assertRaisesRegex(
             UserError, "You are not allowed to unrelease this move"
         ):
-            self.shipping.move_ids.unrelease()
+            self.shipping.move_lines.unrelease()
 
     def test_unrelease_backorder(self):
         """Check the unrelease of a shipping backorder move"""
         # we do a partial pick and validate the picking to create a backorder
         # a validation
-        line = self.picking.move_ids.move_line_ids
-        line.qty_done = line.reserved_qty - 1
+        line = self.picking.move_lines.move_line_ids
+        line.qty_done = line.product_qty - 1
         self.picking.with_context(
             skip_immediate=True, skip_backorder=True
         ).button_validate()
         self.shipping.action_assign()
-        line = self.shipping.move_ids.move_line_ids
-        line.qty_done = line.reserved_qty
+        line = self.shipping.move_lines.move_line_ids
+        line.qty_done = line.product_qty
         self.shipping.with_context(
             skip_immediate=True, skip_backorder=True
         ).button_validate()
         # at this stage, our backorder ship move is linked to a pick move to do
         backorder_ship = self.shipping.backorder_ids
         self.assertTrue(backorder_ship)
-        self.assertTrue(backorder_ship.move_ids.unrelease_allowed)
+        self.assertTrue(backorder_ship.move_lines.unrelease_allowed)
         self.assertTrue(
-            backorder_ship.move_ids.move_orig_ids.filtered(
+            backorder_ship.move_lines.move_orig_ids.filtered(
                 lambda m: m.state not in ("cancel", "done")
             )
         )
         backorder_pick = self._prev_picking(backorder_ship) - self.picking
         self.assertEqual(backorder_pick.state, "assigned")
-        backorder_ship.move_ids.unrelease()
+        backorder_ship.move_lines.unrelease()
         # after the un release, our backorder ship move is not more linked to
         # a pick move to do
-        self.assertFalse(backorder_ship.move_ids.unrelease_allowed)
+        self.assertFalse(backorder_ship.move_lines.unrelease_allowed)
         self.assertEqual(backorder_pick.state, "cancel")
         self.assertFalse(
-            backorder_ship.move_ids.move_orig_ids.filtered(
-                lambda m: m.state not in ("cancel", "done")
-            )
-        )
-
-    def test_auto_unrelease_on_backorder(self):
-        """Check that moves into a backorder are unreleased if specified on
-        the picking type"""
-        self.shipping.picking_type_id.unrelease_on_backorder = True
-        # we do a partial pick and validate the picking to create a backorder
-        # a validation
-        line = self.picking.move_ids.move_line_ids
-        line.qty_done = line.reserved_qty - 1
-        self.picking.with_context(
-            skip_immediate=True, skip_backorder=True
-        ).button_validate()
-        self.shipping.action_assign()
-        line = self.shipping.move_ids.move_line_ids
-        line.qty_done = line.reserved_qty
-        # at this stage, our ship move is linked to a pick move to do
-        self.assertTrue(
-            self.shipping.move_ids.move_orig_ids.filtered(
-                lambda m: m.state not in ("cancel", "done")
-            )
-        )
-        self.shipping.with_context(
-            skip_immediate=True, skip_backorder=True
-        ).button_validate()
-        backorder_ship = self.shipping.backorder_ids
-        self.assertTrue(backorder_ship)
-        self.assertTrue(backorder_ship.need_release)
-        self.assertFalse(backorder_ship.move_ids.unrelease_allowed)
-        # no move pick move to do for our move into the backorder
-        self.assertFalse(
-            backorder_ship.move_ids.move_orig_ids.filtered(
+            backorder_ship.move_lines.move_orig_ids.filtered(
                 lambda m: m.state not in ("cancel", "done")
             )
         )
@@ -175,6 +140,6 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         wizard = self.env["stock.unrelease"].create({})
         with self._assert_full_unreleased():
             wizard.with_context(
-                active_ids=self.shipping.move_ids.ids,
-                active_model=self.shipping.move_ids._name,
+                active_ids=self.shipping.move_lines.ids,
+                active_model=self.shipping.move_lines._name,
             ).unrelease()

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -61,10 +61,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
 
         action_cancel is called on all related pickings not set to done.
         """
-        self.assertTrue(self.picking1.move_lines.product_uom_qty == 5)
         self.shipping1.action_cancel()
         self.assertEqual(self.shipping1.state, "cancel")
-        self.assertEqual(self.picking1.move_lines.mapped("product_uom_qty"), [3.0, 2.0])
-        self.assertEqual(
-            self.picking1.move_lines.mapped("state"), ["assigned", "cancel"]
-        )
+        line_active = self.picking1.move_lines.filtered(lambda l: l.state == "assigned")
+        line_cancel = self.picking1.move_lines.filtered(lambda l: l.state == "cancel")
+        self.assertEqual(line_active.product_uom_qty, 3.0)
+        self.assertEqual(line_cancel.product_uom_qty, 2.0)

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from datetime import datetime
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        delivery_pick_rule = cls.wh.delivery_route_id.rule_ids.filtered(
+            lambda r: r.location_src_id == cls.loc_stock
+        )
+        delivery_pick_rule.group_propagation_option = "fixed"
+
+        cls.pc1 = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 2)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.shipping1 = cls._out_picking(cls.pc1)
+        cls.pc2 = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 3)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.shipping2 = cls._out_picking(cls.pc2)
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 15.0)
+        cls.wh.delivery_route_id.write(
+            {
+                "available_to_promise_defer_pull": True,
+            }
+        )
+        cls.shipping1.release_available_to_promise()
+        cls.shipping2.release_available_to_promise()
+        cls.picking1 = cls._prev_picking(cls.shipping1)
+        cls.picking1.action_assign()
+        cls.picking2 = cls._prev_picking(cls.shipping2)
+        cls.picking2.action_assign()
+
+    def test_unrelease_delivery_no_picking_done(self):
+        # the pick moves for delivery 1 and 2 are merged
+        self.assertEqual(self.picking1, self.picking2)
+        self.shipping1.unrelease()
+        self.assertEqual(len(self.picking1.move_lines), 2)
+        move_cancel = self.picking1.move_lines.filtered(lambda m: m.state == "cancel")
+        self.assertEqual(move_cancel.product_uom_qty, 2)
+        self.assertTrue(self.shipping1.need_release)
+
+    # def test_unrelease_picking_is_done(self):
+    #     # the pick moves for delivery 1 and 2 are merged
+    #     self.assertEqual(self.picking1, self.picking2)
+    #     # do the first step
+    #     for line in self.picking1.move_line_ids:
+    #         line.qty_done = line.product_uom_qty
+    #     self.picking1.button_validate()
+    #     self.assertEqual(self.picking1.state, "done")
+    #     self.shipping1.unrelease()
+
+    def test_simulate_cancel_so(self):
+        """Simulate a sale order cancelation.
+
+        action_cancel is called on all related pickings not set to done.
+        """
+        self.assertTrue(self.picking1.move_lines.product_uom_qty == 5)
+        self.shipping1.action_cancel()
+        self.assertEqual(self.shipping1.state, "cancel")
+        self.assertEqual(self.picking1.move_lines.mapped("product_uom_qty"), [3.0, 2.0])
+        self.assertEqual(
+            self.picking1.move_lines.mapped("state"), ["assigned", "cancel"]
+        )

--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -25,4 +25,22 @@
             </xpath>
         </field>
     </record>
+
+    <record id="stock_picking_type_form" model="ir.ui.view">
+        <field name="name">stock.picking.type.kanban</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+             <group name="locations" position="after">
+                 <group
+                    name="release"
+                    string="Chained moves release process"
+                    attrs='{"invisible": [("code", "!=", "outgoing")]}'
+                >
+                     <field name="unrelease_on_backorder" />
+                 </group>
+             </group>
+        </field>
+    </record>
+
 </odoo>

--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -31,7 +31,10 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">
-             <group name="locations" position="after">
+             <xpath
+                expr="//group[@groups='stock.group_stock_multi_locations']"
+                position="after"
+            >
                  <group
                     name="release"
                     string="Chained moves release process"
@@ -39,7 +42,7 @@
                 >
                      <field name="unrelease_on_backorder" />
                  </group>
-             </group>
+             </xpath>
         </field>
     </record>
 

--- a/stock_available_to_promise_release/views/stock_picking_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_views.xml
@@ -41,6 +41,17 @@
                     </div>
                 </button>
             </div>
+            <button name="action_assign_serial" position="after">
+                <field name="unrelease_allowed" invisible="1" />
+                <button
+                    name="unrelease"
+                    attrs="{'invisible': [('unrelease_allowed', '=', False)]}"
+                    string="Un Release"
+                    type="object"
+                    icon="fa-cube"
+                    groups="stock.group_stock_user"
+                />
+            </button>
         </field>
     </record>
     <record id="view_picking_release_tree" model="ir.ui.view">

--- a/stock_available_to_promise_release/wizards/__init__.py
+++ b/stock_available_to_promise_release/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_release
+from . import stock_unrelease

--- a/stock_available_to_promise_release/wizards/stock_unrelease.py
+++ b/stock_available_to_promise_release/wizards/stock_unrelease.py
@@ -15,7 +15,5 @@ class StockUnRelease(models.TransientModel):
         records = (
             self.env[model].browse(self.env.context.get("active_ids", [])).exists()
         )
-        if model == "stock.move":
-            records = records.filtered("unrelease_allowed")
-        records.unrelease()
+        records.unrelease(safe_unrelease=True)
         return {"type": "ir.actions.act_window_close"}

--- a/stock_available_to_promise_release/wizards/stock_unrelease.py
+++ b/stock_available_to_promise_release/wizards/stock_unrelease.py
@@ -1,0 +1,21 @@
+# Copyright 2023 ACSONE SA/NV (https://www.acsone.eu)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+
+class StockUnRelease(models.TransientModel):
+    _name = "stock.unrelease"
+    _description = "Stock Allocations Un Release"
+
+    def unrelease(self):
+        model = self.env.context.get("active_model")
+        if model not in ("stock.move", "stock.picking"):
+            return
+        records = (
+            self.env[model].browse(self.env.context.get("active_ids", [])).exists()
+        )
+        if model == "stock.move":
+            records = records.filtered("unrelease_allowed")
+        records.unrelease()
+        return {"type": "ir.actions.act_window_close"}

--- a/stock_available_to_promise_release/wizards/stock_unrelease_views.xml
+++ b/stock_available_to_promise_release/wizards/stock_unrelease_views.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_stock_unrelease_form" model="ir.ui.view">
+        <field name="name">Stock Allocations Un Release</field>
+        <field name="model">stock.unrelease</field>
+        <field name="arch" type="xml">
+            <form string="Stock Allocations Un Release">
+                <p class="oe_grey">
+                    The selected records will be un released.
+                </p>
+                <footer>
+                    <button
+                        name="unrelease"
+                        string="Un Release"
+                        type="object"
+                        class="btn-primary"
+                    />
+                    <button string="Cancel" class="btn-secondary" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+    <record id="action_view_stock_move_unrelease_form" model="ir.actions.act_window">
+        <field name="name">Un Release Move Allocations</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.unrelease</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="groups_id" eval="[(4,ref('stock.group_stock_user'))]" />
+        <field name="binding_model_id" ref="stock.model_stock_move" />
+    </record>
+    <record id="action_view_stock_picking_unrelease_form" model="ir.actions.act_window">
+        <field name="name">Un Release Transfers Allocations</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.unrelease</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+        <field name="groups_id" eval="[(4,ref('stock.group_stock_user'))]" />
+        <field name="binding_model_id" ref="stock.model_stock_picking" />
+    </record>
+</odoo>


### PR DESCRIPTION
This is from a pr on 16.0

* https://github.com/OCA/wms/pull/478

Only the unrelease feature is backported

A unit test with a combo of  2 steps delivery is being added.
And also unreleasing a chain of moves on a move cancellation. 