### PR TITLE
[14.0] shopfloor_reception: exclude view locations from scan

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -387,7 +387,7 @@ class Reception(Component):
         if location:
             dest_location = selected_line.location_dest_id
             child_locations = self.env["stock.location"].search(
-                [("id", "child_of", dest_location.id)]
+                [("id", "child_of", dest_location.id), ("usage", "!=", "view")]
             )
             if location not in child_locations:
                 # Scanned location isn't a child of the move's dest location

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -299,6 +299,33 @@ class TestSetQuantity(CommonCase):
             message={"message_type": "error", "body": "You cannot place it here"},
         )
 
+    def test_scan_location_view_usage(self):
+        picking = self._create_picking()
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda l: l.product_id == self.product_a
+        )
+        selected_move_line.shopfloor_user_id = self.env.uid
+        self.dispatch_location.sudo().quant_ids.unlink()
+        self.dispatch_location.sudo().usage = "view"
+        response = self.service.dispatch(
+            "set_quantity",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+                "barcode": self.dispatch_location.barcode,
+            },
+        )
+        data = self.data.picking(picking)
+        self.assert_response(
+            response,
+            next_state="set_quantity",
+            data={
+                "picking": data,
+                "selected_move_line": self.data.move_lines(selected_move_line),
+            },
+            message={"message_type": "error", "body": "You cannot place it here"},
+        )
+
     def test_scan_new_package(self):
         picking = self._create_picking()
         selected_move_line = picking.move_line_ids.filtered(


### PR DESCRIPTION
View locations should not be accepted when scanning a location.

ref: rau-121