### PR TITLE
shopfloor: Add first scan location option on zp

### DIFF
--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -19,7 +19,8 @@
     "pick_pack_same_time": true,
     "unload_package_at_destination": true,
     "multiple_move_single_pack": true,
-    "no_prefill_qty": true
+    "no_prefill_qty": true,
+    "scan_location_or_pack_first": true
 }
         </field>
     </record>

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -158,6 +158,16 @@ class ShopfloorMenu(models.Model):
     show_oneline_package_content_is_possible = fields.Boolean(
         compute="_compute_show_oneline_package_content_is_possible"
     )
+    scan_location_or_pack_first = fields.Boolean(
+        string="Scan first location or pack",
+        help=(
+            "When selecting work, force the user to first scan a location or pack,"
+            "then the product or lot."
+        ),
+    )
+    scan_location_or_pack_first_is_possible = fields.Boolean(
+        compute="_compute_scan_location_or_pack_first_is_possible"
+    )
 
     @api.onchange("unload_package_at_destination")
     def _onchange_unload_package_at_destination(self):
@@ -366,4 +376,11 @@ class ShopfloorMenu(models.Model):
         for menu in self:
             menu.show_oneline_package_content_is_possible = menu.scenario_id.has_option(
                 "show_oneline_package_content"
+            )
+
+    @api.depends("scenario_id")
+    def _compute_scan_location_or_pack_first_is_possible(self):
+        for menu in self:
+            menu.scan_location_or_pack_first_is_possible = menu.scenario_id.has_option(
+                "scan_location_or_pack_first"
             )

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -61,6 +61,7 @@ from . import test_zone_picking_start
 from . import test_zone_picking_select_picking_type
 from . import test_zone_picking_select_line
 from . import test_zone_picking_select_line_no_prefill_qty
+from . import test_zone_picking_select_line_first_scan_location
 from . import test_zone_picking_set_line_destination
 from . import test_zone_picking_set_line_destination_no_prefill_qty
 from . import test_zone_picking_set_line_destination_pick_pack

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -308,12 +308,14 @@ class ZonePickingCommonCase(CommonCase):
         confirmation_required=False,
         product=None,
         sublocation=None,
+        location_first=None,
     ):
         data = {
             "zone_location": self.data.location(zone_location),
             "picking_type": self.data.picking_type(picking_type),
             "move_lines": self.data.move_lines(move_lines, with_picking=True),
             "confirmation_required": confirmation_required,
+            "scan_location_or_pack_first": location_first,
         }
         if product:
             data["product"] = self.data.product(product)
@@ -343,6 +345,7 @@ class ZonePickingCommonCase(CommonCase):
         confirmation_required=False,
         product=None,
         sublocation=None,
+        location_first=False,
     ):
         self._assert_response_select_line(
             "select_line",
@@ -355,6 +358,7 @@ class ZonePickingCommonCase(CommonCase):
             confirmation_required=confirmation_required,
             product=product,
             sublocation=sublocation,
+            location_first=location_first,
         )
 
     def _assert_response_set_line_destination(

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -189,6 +189,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
                 self.zone_sublocation2
             ),
             sublocation=self.zone_sublocation2,
+            location_first=False,
         )
 
     def test_scan_source_barcode_package(self):
@@ -271,6 +272,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             move_lines=move_lines,
             sublocation=self.zone_sublocation1,
             message=self.service.msg_store.several_products_in_package(pack),
+            location_first=False,
         )
 
     def test_scan_source_barcode_package_can_replace_in_line(self):
@@ -430,6 +432,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             message=self.service.msg_store.several_products_in_location(
                 self.zone_sublocation3
             ),
+            location_first=False,
         )
         response = self.service.dispatch(
             "scan_source",

--- a/shopfloor/tests/test_zone_picking_select_line_first_scan_location.py
+++ b/shopfloor/tests/test_zone_picking_select_line_first_scan_location.py
@@ -1,0 +1,68 @@
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from .test_zone_picking_base import ZonePickingCommonCase
+
+
+class ZonePickingSelectLineFirstScanLocationCase(ZonePickingCommonCase):
+    """Tests for endpoint used from select_line with option 'First scan location'
+
+    * /scan_source
+
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+        self.menu.sudo().scan_location_or_pack_first = True
+
+    def test_scan_source_first_the_product_not_ok(self):
+        """Check first scanning a product barcode is not allowed."""
+        response = self.service.dispatch(
+            "scan_source",
+            params={"barcode": self.product_a.barcode},
+        )
+        move_lines = self.service._find_location_move_lines(
+            locations=self.zone_location
+        )
+        self.assertTrue(response.get("data").get("select_line"))
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            message=self.service.msg_store.barcode_not_found(),
+            move_lines=move_lines,
+            location_first=True,
+        )
+
+    def test_scan_source_scan_location_then_product_ok(self):
+        """Check scanning location and then product is fine."""
+        # Have the same product multiple time in sublocation 2
+        pickingA = self._create_picking(
+            lines=[(self.product_b, 12), (self.product_c, 13)]
+        )
+        self._fill_stock_for_moves(
+            pickingA.move_lines, in_lot=True, location=self.zone_sublocation2
+        )
+        pickingA.action_assign()
+        # Scan product B, send sublocation to simulate a previous scan for a location
+        response = self.service.dispatch(
+            "scan_source",
+            params={
+                "barcode": self.product_b.barcode,
+                "sublocation_id": self.zone_sublocation2.id,
+            },
+        )
+        move_lines = self.service._find_location_move_lines(
+            locations=self.zone_sublocation2, product=self.product_b
+        )
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            message=self.service.msg_store.several_move_with_different_lot(),
+            move_lines=move_lines,
+            product=self.product_b,
+            sublocation=self.zone_sublocation2,
+            location_first=True,
+        )

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -108,6 +108,13 @@
                     />
                   <field name="show_oneline_package_content" />
               </group>
+              <group
+                    name="scan_location_or_pack_first"
+                    attrs="{'invisible': [('scan_location_or_pack_first_is_possible', '=', False)]}"
+                >
+                  <field name="scan_location_or_pack_first_is_possible" invisible="1" />
+                  <field name="scan_location_or_pack_first" />
+              </group>
             </group>
         </field>
     </record>

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -606,7 +606,19 @@ const ZonePicking = {
                 select_line: {
                     display_info: {
                         title: "Select move",
-                        scan_placeholder: "Scan location / pack / product / lot",
+                        scan_placeholder: () => {
+                            const sublocation = this.state.data.sublocation;
+                            if (
+                                this.state.data.scan_location_or_pack_first &&
+                                !sublocation
+                            ) {
+                                return "Scan location / pack";
+                            }
+                            if (sublocation) {
+                                return "Scan product / lot / package";
+                            }
+                            return "Scan location / pack / product / lot";
+                        },
                     },
                     events: {
                         select: "on_select",


### PR DESCRIPTION
Add a new scenario option `First scan location or pack`. And implement it on the zone picking scenario.

ref.: rau-113