### PR TITLE
shopfloor: fix location content transfer lines selected

### DIFF
--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -211,6 +211,7 @@ class LocationContentTransfer(Component):
             ("qty_done", "=", 0),
             ("state", "in", ("assigned", "partially_available")),
             ("picking_id.user_id", "in", (False, self.env.uid)),
+            ("picking_id.state", "=", "assigned"),
         ]
 
     def _find_location_move_lines(self, location):

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -51,6 +51,7 @@ from . import test_location_content_transfer_base
 from . import test_location_content_transfer_start
 from . import test_location_content_transfer_get_work
 from . import test_location_content_transfer_set_destination_all
+from . import test_location_content_transfer_scan_location
 from . import test_location_content_transfer_single
 from . import test_location_content_transfer_set_destination_package_or_line
 from . import test_location_content_transfer_putaway

--- a/shopfloor/tests/test_location_content_transfer_scan_location.py
+++ b/shopfloor/tests/test_location_content_transfer_scan_location.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from .test_location_content_transfer_base import LocationContentTransferCommonCase
+
+
+class TestLocationContentTransferScanLocation(LocationContentTransferCommonCase):
+    @classmethod
+    def setUpClassBaseData(cls):
+        super().setUpClassBaseData()
+        # One picking with shipping policy set on "When all products are ready"
+        # With only one of the move available in the stock
+        cls.picking1 = cls._create_picking(
+            lines=[(cls.product_a, 10), (cls.product_b, 10)]
+        )
+        cls.picking1.move_type = "one"
+        cls.move1 = cls.picking1.move_lines[0]
+        cls._fill_stock_for_moves(cls.move1, in_package=False, location=cls.content_loc)
+        cls.picking1.action_assign()
+        # Another picking available
+        picking2 = cls._create_picking(lines=[(cls.product_c, 5)])
+        cls._fill_stock_for_moves(picking2.move_lines, location=cls.content_loc)
+        picking2.action_assign()
+
+    def test_lines_returned_by_scan_location(self):
+        """Check that lines from not ready pickings are not offered to work on."""
+        response = self.service.dispatch(
+            "scan_location", params={"barcode": self.content_loc.barcode}
+        )
+        lines = response["data"]["scan_destination_all"]["move_lines"]
+        line_ids = [line["id"] for line in lines]
+        self.assertTrue(self.move1.move_line_ids.id not in line_ids)


### PR DESCRIPTION
A move line can be in ready state, but the related picking not. This happens when the shipping policy on the pciking is set to `one` (When all products are ready).

After this change, move lines from a picking not ready, will not be offered to work on by the location content transfer scenario.