### PR TITLE
[14.0] shopfloor: checkout scan change lot

### DIFF
--- a/shopfloor/actions/change_package_lot.py
+++ b/shopfloor/actions/change_package_lot.py
@@ -161,6 +161,9 @@ class ChangePackageLot(Component):
         # lines
         move_line.move_id._action_assign()
 
+        self._change_pack_lot_change_lot__before_assign(
+            previous_lot, lot, to_assign_moves
+        )
         # Find other available goods for the lines which were using the
         # lot before...
         to_assign_moves._action_assign()
@@ -169,6 +172,11 @@ class ChangePackageLot(Component):
         if message_parts:
             message["body"] = "{} {}".format(message["body"], " ".join(message_parts))
         return response_ok_func(move_line, message=message)
+
+    def _change_pack_lot_change_lot__before_assign(
+        self, previous_lot, lot, to_assign_moves
+    ):
+        pass
 
     def _package_content_replacement_allowed(self, package, move_line):
         # we can't replace by a package which doesn't contain the product...

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -486,6 +486,12 @@ class MessageAction(Component):
             "body": _("This lot does not exist anymore."),
         }
 
+    def lot_not_found_in_picking(self):
+        return {
+            "message_type": "error",
+            "body": _("Lot is not in the current transfer."),
+        }
+
     def lot_not_found_in_pickings(self):
         return {
             "message_type": "warning",

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -773,6 +773,15 @@ class MessageAction(Component):
             "body": _("Lot changed"),
         }
 
+    def lot_change_wrong_lot(self, lot_name):
+        return {
+            "message_type": "error",
+            "body": _("Scanned lot differs from the previous scan: %(lot)s.")
+            % {
+                "lot": lot_name,
+            },
+        }
+
     def lot_change_no_line_found(self):
         return {
             "message_type": "error",

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -91,6 +91,15 @@ class MessageAction(Component):
             ),
         }
 
+    def lot_different_change(self):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "You scanned a different lot with the same product, "
+                "do you want to change lot? Scan it again to confirm."
+            ),
+        }
+
     def package_not_available_in_picking(self, package, picking):
         return {
             "message_type": "warning",
@@ -755,4 +764,16 @@ class MessageAction(Component):
                 "Scan again to place all goods in the same package."
             )
             % dict(name=packaging_type.name),
+        }
+
+    def lot_changed(self):
+        return {
+            "message_type": "info",
+            "body": _("Lot changed"),
+        }
+
+    def lot_change_no_line_found(self):
+        return {
+            "message_type": "error",
+            "body": _("Unable to find a line with the same product but different lot."),
         }

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -96,7 +96,8 @@ class MessageAction(Component):
             "message_type": "warning",
             "body": _(
                 "You scanned a different lot with the same product, "
-                "do you want to change lot? Scan it again to confirm."
+                "do you want to change lot? Scan it again to confirm. "
+                "The first line matching this product will be updated. "
             ),
         }
 

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -236,21 +236,19 @@ class Checkout(Component):
         return self._select_picking(pickings, "select_document")
 
     def _select_document_from_package(self, package, **kw):
-        pickings = package.move_line_ids.filtered(
+        picking = package.move_line_ids.filtered(
             lambda ml: ml.state not in ("cancel", "done")
         ).mapped("picking_id")
-        if len(pickings) > 1:
+        if len(picking) > 1:
             # Filter only if we find several pickings to narrow the
             # selection to one of the good type. If we have one picking
             # of the wrong type, it will be caught in _select_picking
             # with the proper error message.
             # Side note: rather unlikely to have several transfers ready
             # and moving the same things
-            pickings = pickings.filtered(
+            picking = picking.filtered(
                 lambda p: p.picking_type_id in self.picking_types
             )
-        if len(pickings) == 1:
-            picking = pickings
         return self._select_picking(picking, "select_document")
 
     def _select_document_from_product(self, product, line_domain=None, **kw):

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -537,10 +537,7 @@ class Checkout(Component):
         if not lines:
             return self._response_for_select_line(
                 picking,
-                message={
-                    "message_type": "error",
-                    "body": _("Lot is not in the current transfer."),
-                },
+                message=self.msg_store.lot_not_found_in_picking(),
             )
 
         # When lots are as units outside of packages, we can select them for

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -539,7 +539,7 @@ class Checkout(Component):
 
     def _select_lines_from_lot(self, picking, selection_lines, lot, **kw):
         message = None
-        lines = selection_lines.filtered(lambda l: l.lot_id == lot)
+        lines = self._picking_lines_by_lot(picking, selection_lines, lot)
         if not lines:
             if not kw.get("confirm_lot"):
                 lines_same_product = selection_lines.filtered(
@@ -614,6 +614,10 @@ class Checkout(Component):
 
         self._select_lines(lines, prefill_qty=1)
         return self._response_for_select_package(picking, lines, message=message)
+
+    def _picking_lines_by_lot(self, picking, selection_lines, lot):
+        """Control filtering of selected lines by given lot."""
+        return selection_lines.filtered(lambda l: l.lot_id == lot)
 
     def _change_lot_response_handler_ok(self, move_line, message=None):
         return message

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -552,14 +552,15 @@ class Checkout(Component):
                         and not l.move_id.move_orig_ids
                     )
                 )
-                # However if one line is matching the same product, invite the user
-                # to change the lot by scanning again the lot
-                if len(lines_same_product) == 1:
+                # If there's at least one product matching we are good to go.
+                # In any case, only the 1st line matching will be affected.
+                if lines_same_product:
                     return self._response_for_select_line(
                         picking,
                         message=self.msg_store.lot_different_change(),
                         need_confirm_lot=True,
                     )
+                    # TODO: add a msg saying the lot has been changed
                 return self._response_for_select_line(
                     picking,
                     message=self.msg_store.lot_not_found_in_picking(),

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -41,23 +41,28 @@ class Checkout(Component):
     _description = __doc__
 
     def _response_for_select_line(
-        self, picking, message=None, need_confirm_pack_all=False
+        self, picking, message=None, need_confirm_pack_all=False, need_confirm_lot=False
     ):
         if all(line.shopfloor_checkout_done for line in picking.move_line_ids):
             return self._response_for_summary(picking, message=message)
         return self._response(
             next_state="select_line",
             data=self._data_for_select_line(
-                picking, need_confirm_pack_all=need_confirm_pack_all
+                picking,
+                need_confirm_pack_all=need_confirm_pack_all,
+                need_confirm_lot=need_confirm_lot,
             ),
             message=message,
         )
 
-    def _data_for_select_line(self, picking, need_confirm_pack_all=False):
+    def _data_for_select_line(
+        self, picking, need_confirm_pack_all=False, need_confirm_lot=False
+    ):
         return {
             "picking": self._data_for_stock_picking(picking),
             "group_lines_by_location": True,
             "need_confirm_pack_all": need_confirm_pack_all,
+            "need_confirm_lot": need_confirm_lot,
         }
 
     def _response_for_summary(self, picking, need_confirm=False, message=None):
@@ -404,7 +409,7 @@ class Checkout(Component):
             {"qty_done": 0, "shopfloor_user_id": False}
         )
 
-    def scan_line(self, picking_id, barcode, confirm_pack_all=False):
+    def scan_line(self, picking_id, barcode, confirm_pack_all=False, confirm_lot=False):
         """Scan move lines of the stock picking
 
         It allows to select move lines of the stock picking for the next
@@ -435,7 +440,7 @@ class Checkout(Component):
 
         search_result = self._scan_line_find(picking, barcode)
         result_handler = getattr(self, "_select_lines_from_" + search_result.type)
-        kw = {"confirm_pack_all": confirm_pack_all}
+        kw = {"confirm_pack_all": confirm_pack_all, "confirm_lot": confirm_lot}
         return result_handler(picking, selection_lines, search_result.record, **kw)
 
     def _scan_line_find(self, picking, barcode, search_types=None):
@@ -533,12 +538,56 @@ class Checkout(Component):
         )
 
     def _select_lines_from_lot(self, picking, selection_lines, lot, **kw):
+        message = None
         lines = selection_lines.filtered(lambda l: l.lot_id == lot)
         if not lines:
-            return self._response_for_select_line(
-                picking,
-                message=self.msg_store.lot_not_found_in_picking(),
+            if not kw.get("confirm_lot"):
+                lines_same_product = selection_lines.filtered(
+                    lambda l: (
+                        l.product_id == lot.product_id
+                        # We cannot change a lot on a move having ancestors.
+                        # That would mean we already picked up the wrong lot
+                        # on the previous move(s) and Odoo already restricts
+                        # the reservation based on the previous move(s).
+                        and not l.move_id.move_orig_ids
+                    )
+                )
+                # However if one line is matching the same product, invite the user
+                # to change the lot by scanning again the lot
+                if len(lines_same_product) == 1:
+                    return self._response_for_select_line(
+                        picking,
+                        message=self.msg_store.lot_different_change(),
+                        need_confirm_lot=True,
+                    )
+                return self._response_for_select_line(
+                    picking,
+                    message=self.msg_store.lot_not_found_in_picking(),
+                )
+            # Change lot confirmed
+            line = fields.first(
+                selection_lines.filtered(
+                    lambda l: l.product_id == lot.product_id and l.lot_id != lot
+                )
             )
+            if not line:
+                return self._response_for_select_line(
+                    picking,
+                    message=self.msg_store.lot_change_no_line_found(),
+                )
+            response_ok_func = self._change_lot_response_handler_ok
+            response_error_func = self._change_lot_response_handler_error
+            change_package_lot = self._actions_for("change.package.lot")
+            message = change_package_lot.change_lot(
+                line, lot, response_ok_func, response_error_func
+            )
+            if message["message_type"] == "error":
+                return self._response_for_select_line(picking, message=message)
+            else:
+                lines = line
+                # Some lines have been recreated, refresh the recordset
+                # to avoid CacheMiss error
+                selection_lines = self._lines_to_pack(picking)
 
         # When lots are as units outside of packages, we can select them for
         # packing, but if they are in a package, we want the user to scan the packages.
@@ -549,6 +598,8 @@ class Checkout(Component):
         # package, but also if we have one lot as a package and the same lot as
         # a unit in another line. In both cases, we want the user to scan the
         # package.
+        # NOTE: change_pack_lot already checked this, so if we changed the lot
+        # we are already safe.
         if packages and len({line.package_id for line in lines}) > 1:
             return self._response_for_select_line(
                 picking, message=self.msg_store.lot_multiple_packages_scan_package()
@@ -557,11 +608,17 @@ class Checkout(Component):
             # Select all the lines of the package when we scan a lot in a
             # package and we have only one.
             return self._select_lines_from_package(
-                picking, selection_lines, packages, **kw
+                picking, selection_lines, packages, message=message
             )
 
         self._select_lines(lines, prefill_qty=1)
-        return self._response_for_select_package(picking, lines)
+        return self._response_for_select_package(picking, lines, message=message)
+
+    def _change_lot_response_handler_ok(self, move_line, message=None):
+        return message
+
+    def _change_lot_response_handler_error(self, move_line, message=None):
+        return message
 
     def _select_lines_from_serial(self, picking, selection_lines, lot, **kw):
         # Search for serial number is actually the same as searching for lot (as of v14...)
@@ -1342,6 +1399,11 @@ class ShopfloorCheckoutValidator(Component):
                 "nullable": True,
                 "required": False,
             },
+            "confirm_lot": {
+                "type": "boolean",
+                "nullable": True,
+                "required": False,
+            },
         }
 
     def select_line(self):
@@ -1546,6 +1608,7 @@ class ShopfloorCheckoutValidatorResponse(Component):
             self._schema_stock_picking(),
             group_lines_by_location={"type": "boolean"},
             need_confirm_pack_all={"type": "boolean"},
+            need_confirm_lot={"type": "boolean"},
         )
 
     @property

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -44,6 +44,7 @@ class CheckoutCommonCase(CommonCase):
             "picking": self._stock_picking_data(picking),
             "group_lines_by_location": True,
             "need_confirm_pack_all": False,
+            "need_confirm_lot": False,
         }
         data.update(kw)
         return data

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -44,7 +44,7 @@ class CheckoutCommonCase(CommonCase):
             "picking": self._stock_picking_data(picking),
             "group_lines_by_location": True,
             "need_confirm_pack_all": False,
-            "need_confirm_lot": False,
+            "need_confirm_lot": None,
         }
         data.update(kw)
         return data

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -1,5 +1,7 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import _
+
 from .test_checkout_scan_line_base import CheckoutScanLineCaseBase
 
 
@@ -131,7 +133,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         # more than one package, it would be an error.
         self._test_scan_line_ok(self.product_a.barcode, picking.move_line_ids)
 
-    def _test_scan_line_error(self, picking, barcode, message):
+    def _test_scan_line_error(self, picking, barcode, message, need_confirm_lot=False):
         """Test errors for /scan_line
 
         :param picking: the picking we are currently working with (selected)
@@ -144,7 +146,9 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self.assert_response(
             response,
             next_state="select_line",
-            data=self._data_for_select_line(picking),
+            data=dict(
+                self._data_for_select_line(picking), need_confirm_lot=need_confirm_lot
+            ),
             message=message,
         )
 
@@ -246,17 +250,50 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
             },
         )
 
-    def test_scan_line_error_lot_not_in_picking(self):
+    def test_scan_line_error_lot_different_change_success(self):
+        """Scan the wrong lot while a line with the same product exists."""
         picking = self._create_picking(lines=[(self.product_a, 10)])
         self._fill_stock_for_moves(picking.move_lines, in_lot=True)
         picking.action_assign()
+        previous_lot = picking.move_line_ids.lot_id
+        # Create a lot that is not registered in the location we are working on
+        # so a draft inventory for control is generated automatically when the
+        # lot is changed.
         lot = self.env["stock.production.lot"].create(
             {"product_id": self.product_a.id, "company_id": self.env.company.id}
         )
         self._test_scan_line_error(
             picking,
             lot.name,
-            self.msg_store.lot_not_found_in_picking(),
+            self.msg_store.lot_different_change(),
+            need_confirm_lot=True,
+        )
+        # Second scan to confirm the change of lot
+        response = self.service.dispatch(
+            "scan_line",
+            params={
+                "picking_id": picking.id,
+                "barcode": lot.name,
+                "confirm_lot": True,
+            },
+        )
+        message = self.msg_store.lot_replaced_by_lot(previous_lot, lot)
+        inventory_message = _("A draft inventory has been created for control.")
+        message["body"] = f"{message['body']} {inventory_message}"
+        self.assert_response(
+            response,
+            next_state="select_package",
+            data={
+                "selected_move_lines": [
+                    self._move_line_data(ml) for ml in picking.move_line_ids
+                ],
+                "picking": self.service.data.picking(picking),
+                "packing_info": self.service._data_for_packing_info(picking),
+                "no_package_enabled": not self.service.options.get(
+                    "checkout__disable_no_package"
+                ),
+            },
+            message=message,
         )
 
     def test_scan_line_error_lot_in_two_packages(self):

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -133,7 +133,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         # more than one package, it would be an error.
         self._test_scan_line_ok(self.product_a.barcode, picking.move_line_ids)
 
-    def _test_scan_line_error(self, picking, barcode, message, need_confirm_lot=False):
+    def _test_scan_line_error(self, picking, barcode, message, need_confirm_lot=None):
         """Test errors for /scan_line
 
         :param picking: the picking we are currently working with (selected)
@@ -266,7 +266,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
             picking,
             lot.name,
             self.msg_store.lot_different_change(),
-            need_confirm_lot=True,
+            need_confirm_lot=lot.name,
         )
         # Second scan to confirm the change of lot
         response = self.service.dispatch(
@@ -274,7 +274,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
             params={
                 "picking_id": picking.id,
                 "barcode": lot.name,
-                "confirm_lot": True,
+                "confirm_lot": lot.name,
             },
         )
         message = self.msg_store.lot_replaced_by_lot(previous_lot, lot)

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -256,7 +256,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             lot.name,
-            {"message_type": "error", "body": "Lot is not in the current transfer."},
+            self.msg_store.lot_not_found_in_picking(),
         )
 
     def test_scan_line_error_lot_in_two_packages(self):

--- a/shopfloor_mobile/static/wms/src/scenario/checkout_states.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout_states.js
@@ -59,6 +59,7 @@ export const checkout_states = function ($instance) {
                         picking_id: $instance.state.data.picking.id,
                         barcode: scanned.text,
                         confirm_pack_all: $instance.state.data.need_confirm_pack_all,
+                        confirm_lot: $instance.state.data.need_confirm_lot,
                     })
                 );
             },


### PR DESCRIPTION
[shopfloor, checkout: allow change lot on line select](https://github.com/OCA/wms/commit/0ff8111742482165230f5b3c9a1a3d45212c8bf3)

When it comes to select a line, scanning the wrong lot will invite the
user to scan it again to change it on the relevant line only if there is
one sharing the same product.