### PR TITLE
[14.0] shopfloor, checkout: use 'validate_moves' helper in 'done' endpoint

### DIFF
--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -1205,9 +1205,11 @@ class Checkout(Component):
                         "body": _("Remaining raw product not packed, proceed anyway?"),
                     },
                 )
-        picking._action_done()
+        stock = self._actions_for("stock")
+        lines_done = self._lines_checkout_done(picking)
+        stock.validate_moves(lines_done.move_id)
         return self._response_for_select_document(
-            message=self.msg_store.transfer_done_success(picking)
+            message=self.msg_store.transfer_done_success(lines_done.picking_id)
         )
 
 


### PR DESCRIPTION
Ref 3919