### PR TITLE
shopfloor_reception: fix picking state after auto-posting

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -39,8 +39,8 @@ class StockMove(models.Model):
                 )
             split_move_vals = self._split(qty_to_split)
             split_move = self.create(split_move_vals)
-            split_move._action_confirm(merge=False)
             split_move.move_line_ids = to_move
+            split_move._action_confirm(merge=False)
             split_move._recompute_state()
             split_move._action_assign()
             self._recompute_state()

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -975,19 +975,6 @@ class Reception(Component):
             selected_line, intersection=True
         )
         new_move.extract_and_action_done()
-        # TODO: by using split_other_move_lines above in reception,
-        # we encounter a strange behaviour where a line is created in the original picking
-        # with qty_done=0 and no related move_id.
-        # This is probably caused by package_level_id.
-
-        # The workaround is to look for any orphan lines and delete them,
-        # but this should be investigated to find a better solution.
-        lines = picking.move_line_ids.filtered(
-            lambda l: l.product_id == selected_line.product_id
-        )
-        for line in lines:
-            if not line.move_id:
-                line.unlink()
 
     def set_destination(
         self, picking_id, selected_line_id, location_name, confirmation=False

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -169,3 +169,4 @@ class TestSetDestination(CommonCase):
         )
         self.assertEqual(line_in_picking.product_uom_qty, 7)
         self.assertEqual(line_in_picking.qty_done, 0)
+        self.assertEqual(picking.state, "assigned")


### PR DESCRIPTION
Picking was in waiting state with the remaining moves to receive instead of assigned state (available)