### PR TITLE
[14.0] shopfloor_reception: auto post fixes

### DIFF
--- a/shopfloor_reception/README.rst
+++ b/shopfloor_reception/README.rst
@@ -61,6 +61,7 @@ Contributors
 
 * Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
 * Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Maintainers
 ~~~~~~~~~~~

--- a/shopfloor_reception/readme/CONTRIBUTORS.rst
+++ b/shopfloor_reception/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Matthieu Méquignon <matthieu.mequignon@camptocamp.com>
 * Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -358,7 +358,7 @@ class Reception(Component):
         if package:
             dest_location = selected_line.location_dest_id
             child_locations = self.env["stock.location"].search(
-                [("id", "child_of", dest_location.id)]
+                [("id", "child_of", dest_location.id), ("usage", "!=", "view")]
             )
             pack_location = package.location_id
             if pack_location:
@@ -889,11 +889,11 @@ class Reception(Component):
         location = search.location_from_scan(location_name)
         move_dest_location = selected_line.location_dest_id
         move_child_locations = self.env["stock.location"].search(
-            [("id", "child_of", move_dest_location.id)]
+            [("id", "child_of", move_dest_location.id), ("usage", "!=", "view")]
         )
         pick_type_dest_location = picking.picking_type_id.default_location_dest_id
         pick_type_child_locations = self.env["stock.location"].search(
-            [("id", "child_of", pick_type_dest_location.id)]
+            [("id", "child_of", pick_type_dest_location.id), ("usage", "!=", "view")]
         )
         if location not in move_child_locations | pick_type_child_locations:
             return self._response_for_set_destination(

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -958,6 +958,10 @@ class Reception(Component):
         search = self._actions_for("search")
 
         location = search.location_from_scan(location_name)
+        if not location:
+            return self._response_for_set_destination(
+                picking, selected_line, message=self.msg_store.no_location_found()
+            )
         move_dest_location_ok, pick_type_dest_location_ok = self._check_location_ok(
             location, selected_line, picking
         )

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -11,6 +11,8 @@ class TestSetQuantity(CommonCase):
         cls.product_a_packaging.qty = 5.0
         cls.packing_location.sudo().active = True
         package_model = cls.env["stock.quant.package"]
+        cls.parent_location_dest = cls.env.ref("stock.stock_location_stock")
+        cls.location_dest = cls.shelf2
         cls.package_without_location = package_model.create(
             {
                 "name": "PKG_WO_LOCATION",
@@ -29,11 +31,12 @@ class TestSetQuantity(CommonCase):
                 "packaging_id": cls.product_a_packaging.id,
             }
         )
+        cls.package_with_location_child_of_dest.location_id = cls.location_dest
         cls._update_qty_in_location(
             cls.packing_location, cls.product_a, 10, package=cls.package_with_location
         )
         cls._update_qty_in_location(
-            cls.dispatch_location,
+            cls.parent_location_dest,
             cls.product_a,
             10,
             package=cls.package_with_location_child_of_dest,
@@ -183,6 +186,7 @@ class TestSetQuantity(CommonCase):
         selected_move_line = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_a
         )
+        selected_move_line.location_dest_id = self.parent_location_dest
         selected_move_line.shopfloor_user_id = self.env.uid
         response = self.service.dispatch(
             "set_quantity",
@@ -196,7 +200,7 @@ class TestSetQuantity(CommonCase):
             selected_move_line.result_package_id,
             self.package_with_location_child_of_dest,
         )
-        self.assertEqual(selected_move_line.location_dest_id, self.dispatch_location)
+        self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
         data = self.data.picking(picking, with_progress=True)
         data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(response, next_state="select_move", data={"picking": data})
@@ -260,16 +264,17 @@ class TestSetQuantity(CommonCase):
         selected_move_line = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_a
         )
+        selected_move_line.location_dest_id = self.location_dest
         selected_move_line.shopfloor_user_id = self.env.uid
         response = self.service.dispatch(
             "set_quantity",
             params={
                 "picking_id": picking.id,
                 "selected_line_id": selected_move_line.id,
-                "barcode": self.dispatch_location.barcode,
+                "barcode": self.parent_location_dest.barcode,
             },
         )
-        self.assertEqual(selected_move_line.location_dest_id, self.dispatch_location)
+        self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
         data = self.data.picking(picking, with_progress=True)
         data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(response, next_state="select_move", data={"picking": data})

--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -167,7 +167,7 @@ const Reception = {
                 <item-detail-card
                     :record="line_being_handled"
                     :card_color="utils.colors.color_for('screen_step_todo')"
-                    :options="{key_title: 'location_dest.barcode'}"
+                    :options="{key_title: 'location_dest.name'}"
                     :key="make_state_component_key(['reception-product-item-detail-set-destination-dest-location', state.data.picking.id])"
                 />
             </template>


### PR DESCRIPTION
Some fixes for the reception scenario:

* Auto posting wasn't working when scanning a package in set_quantity.
* "View" locations are not allowed anymore.
* Small change in the frontend for set_destination, we should display the location name.
* Prevent singleton error when multiple moves contain the same product / packaging.

ref: rau-133