### PR TITLE
[14.0] shopfloor: checkout add show_oneline_package_content option

### DIFF
--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -39,7 +39,8 @@
         <field name="key">checkout</field>
         <field name="options_edit">
 {
-    "no_prefill_qty": true
+    "no_prefill_qty": true,
+    "show_oneline_package_content": true
 }
         </field>
     </record>

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -150,6 +150,14 @@ class ShopfloorMenu(models.Model):
     no_prefill_qty_is_possible = fields.Boolean(
         compute="_compute_no_prefill_qty_is_possible"
     )
+    show_oneline_package_content = fields.Boolean(
+        string="Show one-line package content",
+        help="Display the content of package if it contains 1 line only",
+        default=False,
+    )
+    show_oneline_package_content_is_possible = fields.Boolean(
+        compute="_compute_show_oneline_package_content_is_possible"
+    )
 
     @api.onchange("unload_package_at_destination")
     def _onchange_unload_package_at_destination(self):
@@ -351,4 +359,11 @@ class ShopfloorMenu(models.Model):
         for menu in self:
             menu.no_prefill_qty_is_possible = menu.scenario_id.has_option(
                 "no_prefill_qty"
+            )
+
+    @api.depends("scenario_id")
+    def _compute_show_oneline_package_content_is_possible(self):
+        for menu in self:
+            menu.show_oneline_package_content_is_possible = menu.scenario_id.has_option(
+                "show_oneline_package_content"
             )

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -57,6 +57,7 @@ class Checkout(Component):
         return {
             "picking": self._data_for_stock_picking(picking),
             "group_lines_by_location": True,
+            "show_oneline_package_content": self.work.menu.show_oneline_package_content,
             "need_confirm_pack_all": need_confirm_pack_all,
         }
 
@@ -1550,6 +1551,7 @@ class ShopfloorCheckoutValidatorResponse(Component):
         return dict(
             self._schema_stock_picking(),
             group_lines_by_location={"type": "boolean"},
+            show_oneline_package_content={"type": "boolean"},
             need_confirm_pack_all={"type": "boolean"},
         )
 

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -43,6 +43,7 @@ class CheckoutCommonCase(CommonCase):
         data = {
             "picking": self._stock_picking_data(picking),
             "group_lines_by_location": True,
+            "show_oneline_package_content": False,
             "need_confirm_pack_all": False,
         }
         data.update(kw)

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -98,6 +98,16 @@
                   <field name="no_prefill_qty_is_possible" invisible="1" />
                   <field name="no_prefill_qty" />
               </group>
+              <group
+                    name="show_oneline_package_content"
+                    attrs="{'invisible': [('show_oneline_package_content_is_possible', '=', False)]}"
+                >
+                  <field
+                        name="show_oneline_package_content_is_possible"
+                        invisible="1"
+                    />
+                  <field name="show_oneline_package_content" />
+              </group>
             </group>
         </field>
     </record>

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -309,6 +309,10 @@ const Checkout = {
             return {
                 group_color: this.utils.colors.color_for("screen_step_todo"),
                 card_klass: "loud-labels",
+                list_item_options: {
+                    show_oneline_package_content: this.state.data
+                        .show_oneline_package_content,
+                },
             };
         },
         select_package_manual_select_opts: function () {


### PR DESCRIPTION
On the menu item you can decide to enable the option 'show_oneline_package_content'.
Once enabled, on the select line screen,
if the package contains only one line
the lot and the product name will be shown.

The use case it tries to solve:
you have multiple packs in front of you
and you want to be able to scan any of the packs
using the lot or the product.


**BEFORE**

<img src="https://user-images.githubusercontent.com/347149/221181130-ad078fb8-56b4-4bca-bd28-ddc3a49be757.png" width="300" />


**AFTER**
<img src="https://user-images.githubusercontent.com/347149/221181161-d5aa1af8-5e12-49fc-80a4-846e429725d3.png" width="300" />

ref: cos-3950