### PR TITLE
[14.0][IMP] shopfloor: find_work

### DIFF
--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -253,9 +253,9 @@ class LocationContentTransfer(Component):
             [
                 ("picking_type_id", "in", self.picking_types.ids),
                 ("state", "=", "assigned"),
-                ("printed", "=", False),
+                ("user_id", "in", (False, self.env.user.id)),
             ],
-            order="create_date",
+            order="user_id, priority desc, scheduled_date asc, id desc",
         )
 
         for next_picking in pickings:


### PR DESCRIPTION
Before:
Only pickings were found which are printed = False
If the a split is happening because of different location in the move lines
Then the new picking will be assigned to the user and printed is set to true
https://github.com/OCA/wms/blob/c0c7c48a20263bb896a5fa9aa4cc65038de4d5c0/shopfloor/services/location_content_transfer.py#L291
If this user leaves the next screen (scan location) without clicking on cancel the picking is still assigned to the user
and not started.
If this user clicks now on Get work again, the picking is not recovered because of https://github.com/OCA/wms/blob/c0c7c48a20263bb896a5fa9aa4cc65038de4d5c0/shopfloor/services/location_content_transfer.py#L188

Because of the printed = True domain 
i will never find the picking again.

With this change all pickings would be found which are assigned to no or the current user. 
Also with the different order, the previous splitted picking would be the first one, which will be found. 