### PR TITLE
[IMP] shopfloor_mobile_base: make item-detail-card clickable

### DIFF
--- a/shopfloor_mobile_base/README.rst
+++ b/shopfloor_mobile_base/README.rst
@@ -196,6 +196,7 @@ Contributors
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
 * Jacques-Etienne Baudoux <je@bcim.be>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>
 
 Design
 ~~~~~~

--- a/shopfloor_mobile_base/readme/CONTRIBUTORS.rst
+++ b/shopfloor_mobile_base/readme/CONTRIBUTORS.rst
@@ -5,6 +5,7 @@
 * Raphaël Reverdy <raphael.reverdy@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
 * Jacques-Etienne Baudoux <je@bcim.be>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>
 
 Design
 ~~~~~~

--- a/shopfloor_mobile_base/static/description/index.html
+++ b/shopfloor_mobile_base/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Shopfloor mobile</title>
 <style type="text/css">
 
@@ -532,6 +532,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Raphaël Reverdy &lt;<a class="reference external" href="mailto:raphael.reverdy&#64;akretion.com">raphael.reverdy&#64;akretion.com</a>&gt;</li>
 <li>Sébastien Beau &lt;<a class="reference external" href="mailto:sebastien.beau&#64;akretion.com">sebastien.beau&#64;akretion.com</a>&gt;</li>
 <li>Jacques-Etienne Baudoux &lt;<a class="reference external" href="mailto:je&#64;bcim.be">je&#64;bcim.be</a>&gt;</li>
+<li>Michael Tietz (MT Software) &lt;<a class="reference external" href="mailto:mtietz&#64;mt-software.de">mtietz&#64;mt-software.de</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="design">

--- a/shopfloor_mobile_base/static/wms/src/components/detail/detail_card.js
+++ b/shopfloor_mobile_base/static/wms/src/components/detail/detail_card.js
@@ -6,56 +6,83 @@
 
 import {ItemDetailMixin} from "/shopfloor_mobile_base/static/wms/src/components/detail/detail_mixin.js";
 
+const v_card_content = `
+    <v-card-title v-if="!opts.no_title">
+        <slot name="title">
+            <v-icon v-if="opts.title_icon" v-text="opts.title_icon" class="mr-2" />
+            <span v-text="_.result(record, opts.key_title)" />
+            <v-btn icon class="detail-action" :class="{'theme--dark': opts.theme_dark}" link
+                    v-if="opts.on_title_action || opts.title_action_field"
+                    @click="opts.on_title_action ? opts.on_title_action(record): on_detail_action(record, opts.title_action_field)">
+                <btn-info-icon v-if="!opts.title_action_icon"/>
+                <v-icon v-if="opts.title_action_icon">{{ opts.title_action_icon }}</v-icon>
+
+            </v-btn>
+        </slot>
+    </v-card-title>
+    <v-card-subtitle v-if="$slots.subtitle">
+        <slot name="subtitle"></slot>
+    </v-card-subtitle>
+    <slot name="details">
+        <!-- TODO: this loop is the same in list-item => make it a component -->
+        <v-card-text class="details" v-if="opts.fields.length">
+            <div v-for="(field, index) in opts.fields" :class="'field-detail ' + field.path.replace('.', '-') + ' ' + (field.klass || '')">
+                <div v-if="raw_value(record, field) || field.display_no_value">
+                    <span v-if="field.label" class="label">{{ field.label }}:</span>
+                    <component
+                        v-if="field.render_component"
+                        :is="field.render_component"
+                        :options="field.render_options ? field.render_options(record) : {}"
+                        v-bind="field.render_props ? field.render_props(record) : {}"
+                        :record="record"
+                        :key="make_component_key([field.render_component, 'list', index, record.id])"
+                        />
+                    <span v-else>
+                        {{ render_field_value(record, field) }}
+                    </span>
+                    <v-btn icon class="detail-action"
+                            v-if="has_detail_action(record, field)"
+                            @click="on_detail_action(record, field, opts)">
+                        <btn-info-icon />
+                    </v-btn>
+                </div>
+            </div>
+        </v-card-text>
+    </slot>
+    <slot name="after_details"></slot>
+`;
+
 Vue.component("item-detail-card", {
     mixins: [ItemDetailMixin],
     props: ["card_color"],
-    template: `
+    template:
+        `
     <div :class="wrapper_klass">
-        <v-card :color="card_color" tile :class="{'theme--dark': opts.theme_dark, 'main': opts.main, 'no-outline': opts.no_outline}" v-if="!_.isEmpty(record)">
-            <v-card-title v-if="!opts.no_title">
-                <slot name="title">
-                    <v-icon v-if="opts.title_icon" v-text="opts.title_icon" class="mr-2" />
-                    <span v-text="_.result(record, opts.key_title)" />
-                    <v-btn icon class="detail-action" :class="{'theme--dark': opts.theme_dark}" link
-                            v-if="opts.on_title_action || opts.title_action_field"
-                            @click="opts.on_title_action ? opts.on_title_action(record): on_detail_action(record, opts.title_action_field)">
-                        <btn-info-icon v-if="!opts.title_action_icon"/>
-                        <v-icon v-if="opts.title_action_icon">{{ opts.title_action_icon }}</v-icon>
-
-                    </v-btn>
-                </slot>
-            </v-card-title>
-            <v-card-subtitle v-if="$slots.subtitle">
-                <slot name="subtitle"></slot>
-            </v-card-subtitle>
-            <slot name="details">
-                <!-- TODO: this loop is the same in list-item => make it a component -->
-                <v-card-text class="details" v-if="opts.fields.length">
-                    <div v-for="(field, index) in opts.fields" :class="'field-detail ' + field.path.replace('.', '-') + ' ' + (field.klass || '')">
-                        <div v-if="raw_value(record, field) || field.display_no_value">
-                            <span v-if="field.label" class="label">{{ field.label }}:</span>
-                            <component
-                                v-if="field.render_component"
-                                :is="field.render_component"
-                                :options="field.render_options ? field.render_options(record) : {}"
-                                v-bind="field.render_props ? field.render_props(record) : {}"
-                                :record="record"
-                                :key="make_component_key([field.render_component, 'list', index, record.id])"
-                                />
-                            <span v-else>
-                                {{ render_field_value(record, field) }}
-                            </span>
-                            <v-btn icon class="detail-action"
-                                    v-if="has_detail_action(record, field)"
-                                    @click="on_detail_action(record, field, opts)">
-                                <btn-info-icon />
-                            </v-btn>
-                        </div>
-                    </div>
-                </v-card-text>
-            </slot>
-            <slot name="after_details"></slot>
-        </v-card>
+        <div v-if="!_.isEmpty(record)">
+            <v-card v-if="!opts.action_box && !opts.on_card_click" :color="card_color" tile :class="{'theme--dark': opts.theme_dark, 'main': opts.main, 'no-outline': opts.no_outline}">
+        ` +
+        v_card_content +
+        `
+            </v-card>
+            <v-card v-if="!opts.action_box && opts.on_card_click" :color="card_color" tile :class="{'theme--dark': opts.theme_dark, 'main': opts.main, 'no-outline': opts.no_outline}" @click="opts.on_card_click(record)">
+        ` +
+        v_card_content +
+        `
+            </v-card>
+            <v-card v-if="opts.action_box" :color="card_color" tile :class="{'theme--dark': opts.theme_dark, 'main': opts.main, 'no-outline': opts.no_outline}">
+          <div v-if="!opts.on_card_click" class="v-card-inner-content">
+                ` +
+        v_card_content +
+        `
+          </div>
+                <div v-if="opts.on_card_click" class="v-card-inner-content" @click="opts.on_card_click(record)">
+                ` +
+        v_card_content +
+        `
+          </div>
+          <div class="v-card-inner-box" @click="opts.action_box.on_click(record)" v-html="opts.action_box.inner_html"/>
+      </v-card>
+  </div>
         <p v-if="_.isEmpty(record)">
             No detail record to display.
         </p>

--- a/shopfloor_mobile_base/static/wms/src/components/detail/detail_mixin.js
+++ b/shopfloor_mobile_base/static/wms/src/components/detail/detail_mixin.js
@@ -79,6 +79,7 @@ export var ItemDetailMixin = {
                 this.opts.loud ? "loud" : "",
                 this.opts.loud_labels ? "loud-labels" : "",
                 this.opts.klass || "",
+                this.opts.action_box ? "detail-with-action-box" : "",
             ].join(" ");
         },
         opts() {

--- a/shopfloor_mobile_base/static/wms/src/css/main.css
+++ b/shopfloor_mobile_base/static/wms/src/css/main.css
@@ -472,6 +472,22 @@ main.v-content > .v-content__wrap > .header .container {
     margin-right: 1.2em;
 }
 
+.detail-with-action-box .v-card {
+    display: flex;
+}
+.detail-with-action-box .v-card .v-card-inner-content {
+    float: left;
+    width: 80%;
+}
+.detail-with-action-box .v-card .v-card-inner-box {
+    margin: auto;
+    text-align: center;
+    float: left;
+    width: 20%;
+    max-width: 20%;
+    cursor: pointer;
+}
+
 @media screen and (max-width: 320px) {
     #app header.has-main-doc .app-bar-actions {
         display: none;

--- a/shopfloor_reception/__manifest__.py
+++ b/shopfloor_reception/__manifest__.py
@@ -5,7 +5,7 @@
     "development_status": "Beta",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp, MT Software, Odoo Community Association (OCA)",
     "maintainers": ["mmequignon", "JuMiSanAr"],
     "license": "AGPL-3",
     "installable": True,

--- a/shopfloor_reception/data/shopfloor_scenario_data.xml
+++ b/shopfloor_reception/data/shopfloor_scenario_data.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2022 Camptocamp SA
+     Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo noupdate="1">
 
@@ -8,7 +9,8 @@
       <field name="key">reception</field>
       <field name="options_edit">
 {
-  "auto_post_line": true
+  "auto_post_line": true,
+  "select_move_by_click": true
 }
       </field>
   </record>

--- a/shopfloor_reception/models/shopfloor_menu.py
+++ b/shopfloor_reception/models/shopfloor_menu.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import api, fields, models
 
@@ -17,13 +18,25 @@ class ShopfloorMenu(models.Model):
         default=False,
         help=AUTO_POST_LINE,
     )
-    auto_post_line_is_possible = fields.Boolean(
-        compute="_compute_auto_post_line_is_possible"
+    auto_post_line_is_possible = fields.Boolean(compute="_compute_scenario_options")
+
+    select_move_by_click = fields.Boolean(
+        string="Select move by click",
+        default=False,
+        help="If this option is checked: "
+        "The moves are selectable by a user click, "
+        "this means you don't have to scan a barcode",
+    )
+    select_move_by_click_is_possible = fields.Boolean(
+        compute="_compute_scenario_options"
     )
 
     @api.depends("scenario_id")
-    def _compute_auto_post_line_is_possible(self):
+    def _compute_scenario_options(self):
         for menu in self:
             menu.auto_post_line_is_possible = bool(
                 menu.scenario_id.has_option("auto_post_line")
+            )
+            menu.select_move_by_click_is_possible = bool(
+                menu.scenario_id.has_option("select_move_by_click")
             )

--- a/shopfloor_reception/tests/common.py
+++ b/shopfloor_reception/tests/common.py
@@ -70,14 +70,14 @@ class CommonCase(BaseCommonCase):
             res.append(self._data_for_picking_with_line(picking))
         return res
 
-    def _data_for_picking_with_moves(self, picking):
-        picking_data = self._data_for_picking(picking)
+    def _data_for_picking_with_moves(self, picking, with_progress=True):
+        picking_data = self._data_for_picking(picking, with_progress)
         moves_data = self._data_for_moves(picking.move_lines)
         picking_data.update({"moves": moves_data})
         return picking_data
 
-    def _data_for_picking(self, picking):
-        return self.data.picking(picking, with_progress=True)
+    def _data_for_picking(self, picking, with_progress=True):
+        return self.data.picking(picking, with_progress=with_progress)
 
     def _data_for_pickings(self, pickings):
         res = []
@@ -93,6 +93,14 @@ class CommonCase(BaseCommonCase):
         for move in moves:
             res.append(self._data_for_move(move))
         return res
+
+    def _data_for_select_move(self, picking, with_progress=True):
+        picking_data = self._data_for_picking_with_moves(picking, with_progress)
+        data = {
+            "picking": picking_data,
+            "select_move_by_click": self.menu.sudo().select_move_by_click,
+        }
+        return data
 
     def setUp(self):
         super().setUp()

--- a/shopfloor_reception/tests/test_reception_done.py
+++ b/shopfloor_reception/tests/test_reception_done.py
@@ -45,7 +45,7 @@ class TestSelectDestPackage(CommonCase):
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": self._data_for_picking_with_moves(picking)},
+            data=self._data_for_select_move(picking),
             message={
                 "message_type": "warning",
                 "body": "No quantity has been processed, unable to complete the transfer.",

--- a/shopfloor_reception/tests/test_select_dest_package.py
+++ b/shopfloor_reception/tests/test_select_dest_package.py
@@ -58,7 +58,7 @@ class TestSelectDestPackage(CommonCase):
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": self._data_for_picking_with_moves(picking)},
+            data=self._data_for_select_move(picking),
         )
 
     def test_scan_not_empty_package(self):
@@ -127,5 +127,5 @@ class TestSelectDestPackage(CommonCase):
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": self._data_for_picking_with_moves(picking)},
+            data=self._data_for_select_move(picking),
         )

--- a/shopfloor_reception/tests/test_select_document.py
+++ b/shopfloor_reception/tests/test_select_document.py
@@ -35,7 +35,7 @@ class TestSelectDocument(CommonCase):
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": self._data_for_picking_with_moves(picking)},
+            data=self._data_for_select_move(picking),
         )
 
     def test_scan_picking_origin_multiple_pickings(self):
@@ -78,7 +78,7 @@ class TestSelectDocument(CommonCase):
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": self._data_for_picking_with_moves(picking_today)},
+            data=self._data_for_select_move(picking_today),
         )
 
     def test_scan_picking_origin_one_picking(self):
@@ -92,7 +92,7 @@ class TestSelectDocument(CommonCase):
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": self._data_for_picking_with_moves(picking)},
+            data=self._data_for_select_move(picking),
         )
 
     def test_scan_packaging_single_picking(self):

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -17,12 +17,10 @@ class TestSelectLine(CommonCase):
         response = self.service.dispatch(
             "scan_line", params={"picking_id": picking.id, "barcode": "NOPE"}
         )
-        data = self.data.picking(picking, with_progress=True)
-        data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": data},
+            data=self._data_for_select_move(picking),
             message={"message_type": "error", "body": "Barcode not found"},
         )
 
@@ -148,12 +146,10 @@ class TestSelectLine(CommonCase):
             params={"picking_id": picking.id, "barcode": self.product_c.barcode},
         )
         error_msg = "Product not found in the current transfer or already in a package."
-        data = self.data.picking(picking, with_progress=True)
-        data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": data},
+            data=self._data_for_select_move(picking),
             message={"message_type": "warning", "body": error_msg},
         )
 
@@ -170,12 +166,10 @@ class TestSelectLine(CommonCase):
         error_msg = (
             "Packaging not found in the current transfer or already in a package."
         )
-        data = self.data.picking(picking, with_progress=True)
-        data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": data},
+            data=self._data_for_select_move(picking),
             message={"message_type": "warning", "body": error_msg},
         )
 

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -38,12 +38,10 @@ class TestSetDestination(CommonCase):
             },
         )
         self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
-        data = self.data.picking(picking, with_progress=True)
-        data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": data},
+            data=self._data_for_select_move(picking),
         )
 
     def test_scan_location_child_of_pick_type_dest_location(self):
@@ -91,12 +89,10 @@ class TestSetDestination(CommonCase):
             },
         )
         self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
-        data = self.data.picking(picking, with_progress=True)
-        data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",
-            data={"picking": data},
+            data=self._data_for_select_move(picking),
         )
 
     def test_scan_location_not_child_of_dest_locations(self):

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -201,9 +201,9 @@ class TestSetQuantity(CommonCase):
             self.package_with_location_child_of_dest,
         )
         self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
-        data = self.data.picking(picking, with_progress=True)
-        data.update({"moves": self.data.moves(picking.move_lines)})
-        self.assert_response(response, next_state="select_move", data={"picking": data})
+        self.assert_response(
+            response, next_state="select_move", data=self._data_for_select_move(picking)
+        )
 
     def test_scan_package_with_destination_not_child_of_dest_location(self):
         # next step is set_quantity with error
@@ -275,9 +275,9 @@ class TestSetQuantity(CommonCase):
             },
         )
         self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
-        data = self.data.picking(picking, with_progress=True)
-        data.update({"moves": self.data.moves(picking.move_lines)})
-        self.assert_response(response, next_state="select_move", data={"picking": data})
+        self.assert_response(
+            response, next_state="select_move", data=self._data_for_select_move(picking)
+        )
 
     def test_scan_location_not_child_of_dest_location(self):
         picking = self._create_picking()

--- a/shopfloor_reception/views/shopfloor_menu.xml
+++ b/shopfloor_reception/views/shopfloor_menu.xml
@@ -12,6 +12,13 @@
                   <field name="auto_post_line_is_possible" invisible="1" />
                   <field name="auto_post_line" />
               </group>
+              <group
+                    name="select_move_by_click"
+                    attrs="{'invisible': [('select_move_by_click_is_possible', '=', False)]}"
+                >
+                  <field name="select_move_by_click_is_possible" invisible="1" />
+                  <field name="select_move_by_click" />
+              </group>
             </group>
         </field>
     </record>

--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -75,7 +75,7 @@ const Reception = {
                     v-for="record in ordered_moves"
                     :card_color="move_card_color(record)"
                     :record="record"
-                    :options="picking_detail_options_for_select_move()"
+                    :options="picking_detail_options_for_select_move(record)"
                     :key="make_state_component_key(['reception-moves-select-move', record.id])"
                 />
                 <div class="button-list button-vertical-list full">
@@ -338,8 +338,15 @@ const Reception = {
                 ],
             };
         },
-        picking_detail_options_for_select_move: function () {
-            return {
+        on_select_move_click: function (record) {
+            this.wait_call(
+                this.odoo.call("on_select_move_click", {
+                    move_id: record.id,
+                })
+            );
+        },
+        picking_detail_options_for_select_move: function (record) {
+            var result = {
                 key_title: "product.display_name",
                 fields: [
                     {
@@ -357,6 +364,10 @@ const Reception = {
                     },
                 ],
             };
+            if (this.state.data.select_move_by_click) {
+                result["on_card_click"] = this.on_select_move_click;
+            }
+            return result;
         },
         picking_detail_options_for_set_destination: function () {
             return {


### PR DESCRIPTION
Add possiblity to make the item-detail-card clickable
And to a box on the right of the item-detail-card which i also clickable

Shopfloor Reception: new config to make the move selectable by a user click