### PR TITLE
[14.0][FIX] shopfloor: Fix product/lot not found message

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -412,13 +412,7 @@ class MessageAction(Component):
     def product_not_found_in_pickings(self):
         return {
             "message_type": "warning",
-            "body": _("No product found among current transfers."),
-        }
-
-    def product_not_found_in_picking(self):
-        return {
-            "message_type": "warning",
-            "body": _("Product not found in the current transfer."),
+            "body": _("No transfer found for this product."),
         }
 
     def x_not_found_or_already_in_dest_package(self, message_code):
@@ -494,16 +488,10 @@ class MessageAction(Component):
             "body": _("This lot is part of multiple packages, please scan a package."),
         }
 
-    def lot_not_found(self):
-        return {
-            "message_type": "error",
-            "body": _("This lot does not exist anymore."),
-        }
-
     def lot_not_found_in_pickings(self):
         return {
             "message_type": "warning",
-            "body": _("No lot found among current transfers."),
+            "body": _("No transfer found for this lot."),
         }
 
     def batch_transfer_complete(self):

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -666,7 +666,7 @@ class ZonePicking(Component):
             response = self._list_move_lines(
                 sublocation or self.zone_location, sublocation=sublocation
             )
-            message = self.msg_store.product_not_found()
+            message = self.msg_store.product_not_found_in_pickings()
         return response, message
 
     def _scan_source_lot(
@@ -696,7 +696,7 @@ class ZonePicking(Component):
                 )
             return response, message
         response = self._list_move_lines(sublocation or self.zone_location)
-        message = self.msg_store.lot_not_found()
+        message = self.msg_store.lot_not_found_in_pickings()
         return response, message
 
     def scan_source(

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -359,7 +359,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             zone_location=self.zone_location,
             picking_type=self.picking_type,
             move_lines=move_lines,
-            message=self.service.msg_store.product_not_found(),
+            message=self.service.msg_store.product_not_found_in_pickings(),
         )
 
     def test_scan_source_barcode_product_multiple_moves_different_location(self):
@@ -550,7 +550,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             zone_location=self.zone_location,
             picking_type=self.picking_type,
             move_lines=move_lines,
-            message=self.service.msg_store.lot_not_found(),
+            message=self.service.msg_store.lot_not_found_in_pickings(),
         )
 
     def test_scan_source_barcode_not_found(self):

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -186,6 +186,10 @@ class Reception(Component):
                 pickings=pickings,
                 message=self.msg_store.multiple_picks_found_select_manually(),
             )
+        return self._response_for_select_document(
+            pickings=pickings,
+            message=self.msg_store.product_not_found_in_pickings(),
+        )
 
     def _select_document_from_packaging(self, packaging):
         """Select the document by packaging
@@ -203,6 +207,10 @@ class Reception(Component):
                 pickings=pickings,
                 message=self.msg_store.multiple_picks_found_select_manually(),
             )
+        return self._response_for_select_document(
+            pickings=pickings,
+            message=self.msg_store.product_not_found_in_pickings(),
+        )
 
     def _select_document_from_lot(self, lot):
         """Select the document by lot
@@ -220,6 +228,10 @@ class Reception(Component):
                 pickings=pickings,
                 message=self.msg_store.multiple_picks_found_select_manually(),
             )
+        return self._response_for_select_document(
+            pickings=pickings,
+            message=self.msg_store.lot_not_found_in_pickings(),
+        )
 
     def _select_line(self, picking, line, move, increase_qty_done_by=1):
         product = line.product_id

--- a/shopfloor_reception/tests/test_select_document.py
+++ b/shopfloor_reception/tests/test_select_document.py
@@ -134,12 +134,12 @@ class TestSelectDocument(CommonCase):
         response = self.service.dispatch(
             "scan_document", params={"barcode": self.product_c.barcode}
         )
-        body = "Barcode not found"
+        message = self.service.msg_store.product_not_found_in_pickings()
         self.assert_response(
             response,
             next_state="select_document",
             data={"pickings": self._data_for_pickings(picking)},
-            message={"message_type": "error", "body": body},
+            message=message,
         )
 
     def test_scan_packaging_no_picking(self):
@@ -149,10 +149,10 @@ class TestSelectDocument(CommonCase):
         response = self.service.dispatch(
             "scan_document", params={"barcode": self.product_c_packaging.barcode}
         )
-        body = "Barcode not found"
+        message = self.service.msg_store.product_not_found_in_pickings()
         self.assert_response(
             response,
             next_state="select_document",
             data={"pickings": self._data_for_pickings(picking)},
-            message={"message_type": "error", "body": body},
+            message=message,
         )


### PR DESCRIPTION
Rephrasing the error message when a product or a lot has been found for a barcode. But there is no picking that matches it in the current context.

ref.: rau-138