### PR TITLE
[16.0][IMP] stock_available_to_promise_release: Remove unused fields

### DIFF
--- a/stock_available_to_promise_release/__init__.py
+++ b/stock_available_to_promise_release/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizards
+from .hooks import pre_init_hook

--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -24,4 +24,5 @@
     "license": "LGPL-3",
     "application": False,
     "development_status": "Beta",
+    "pre_init_hook": "pre_init_hook",
 }

--- a/stock_available_to_promise_release/hooks.py
+++ b/stock_available_to_promise_release/hooks.py
@@ -1,0 +1,29 @@
+# Copyright 2023 ACSONE SA/NV
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+import logging
+
+from odoo.tools import sql
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    """create and initialize the date priority column on the stock move"""
+    if not sql.column_exists(cr, "stock_move", "date_priority"):
+        _logger.info("Create date_priority column")
+        cr.execute(
+            """
+            ALTER TABLE stock_move
+            ADD COLUMN date_priority timestamp;
+        """
+        )
+        _logger.info("Initialize date_priority field")
+        cr.execute(
+            """
+            UPDATE stock_move
+            SET date_priority = create_date
+            where state not in ('done', 'cancel')
+        """
+        )
+        _logger.info(f"{cr.rowcount} rows updated")

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -49,9 +49,6 @@ class StockMove(models.Model):
         search="_search_release_ready",
     )
     need_release = fields.Boolean(index=True, copy=False)
-    unrelease_allowed = fields.Boolean(compute="_compute_unrelease_allowed")
-    zip_code = fields.Char(related="partner_id.zip", store=True)
-    city = fields.Char(related="partner_id.city", store=True)
 
     @api.depends("rule_id", "rule_id.available_to_promise_defer_pull")
     def _compute_unrelease_allowed(self):

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -49,6 +49,7 @@ class StockMove(models.Model):
         search="_search_release_ready",
     )
     need_release = fields.Boolean(index=True, copy=False)
+    unrelease_allowed = fields.Boolean(compute="_compute_unrelease_allowed")
 
     @api.depends("rule_id", "rule_id.available_to_promise_defer_pull")
     def _compute_unrelease_allowed(self):

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -26,9 +26,6 @@ class StockPicking(models.Model):
         help="Date/time used to sort moves to deliver first. "
         "Used to calculate the ordered available to promise.",
     )
-    zip_code = fields.Char(related="partner_id.zip", store=True)
-    state_id = fields.Many2one(related="partner_id.state_id", store=True)
-    city = fields.Char(related="partner_id.city", store=True)
     last_release_date = fields.Datetime()
 
     @api.depends("move_ids.need_release")

--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -12,8 +12,6 @@
                 <field name="origin" optional="show" />
                 <field name="group_id" optional="show" />
                 <field name="priority" optional="show" />
-                <field name="zip_code" optional="show" string="Postcode" />
-                <field name="city" optional="show" />
             </field>
             <field name="product_uom_qty" position="after">
                 <field name="ordered_available_to_promise_uom_qty" />

--- a/stock_available_to_promise_release/views/stock_picking_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_views.xml
@@ -64,11 +64,6 @@
         <field name="inherit_id" ref="stock.vpicktree" />
         <field eval="900" name="priority" />
         <field name="arch" type="xml">
-            <field name="partner_id" position="after">
-                <field name="zip_code" optional="hide" />
-                <field name="city" optional="hide" />
-                <field name="state_id" options="{'no_open': True}" optional="hide" />
-            </field>
             <field name="origin" position="after">
                 <field name="group_id" optional="hide" />
             </field>


### PR DESCRIPTION
For some historical motivations, some informations from the partner are stored on stock.move(zip_code, city) and stock.picking (zip_code, city, state_id). We can imagines UC where these fields were used into the list views to filter pickings and/or moves to release according to one of these criteria. Nevertheless, this use of these fields is specific to some specific customers and is not justified by the way the addon works. Moreover, since these fields are defined as related on the res.partner table, any modification to one of these fields on your database where the module is installed will freeze it for a long time and most probably ends in a concurrent update exception since it will trigger an update on all the pickings and moves where this partner is referenced. Last but not least, if you install this addon on a large database with hundreds of thousands or millions of rows in the related tables, it will stuck your upgrade process for a very long time. If these fields are required for your customer it's safer to add them into a specific addon and put the necessary precautions to avoid any of the above issues