### PR TITLE
[14.0][FIX] shopfloor_reception: improve scenario

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -580,12 +580,15 @@ class Reception(Component):
             message=message,
         )
 
-    def _response_for_set_quantity(self, picking, line, message=None):
+    def _response_for_set_quantity(
+        self, picking, line, message=None, asking_confirmation=False
+    ):
         return self._response(
             next_state="set_quantity",
             data={
                 "selected_move_line": self._data_for_move_lines(line),
                 "picking": self.data.picking(picking),
+                "confirmation_required": asking_confirmation,
             },
             message=message,
         )
@@ -880,6 +883,7 @@ class Reception(Component):
                     picking,
                     selected_line,
                     message=self.msg_store.create_new_pack_ask_confirmation(barcode),
+                    asking_confirmation=True,
                 )
             package = self.env["stock.quant.package"].create({"name": barcode})
             quantity = selected_line.qty_done
@@ -1340,6 +1344,11 @@ class ShopfloorReceptionValidatorResponse(Component):
                 "schema": {"type": "dict", "schema": self.schemas.move_line()},
             },
             "picking": {"type": "dict", "schema": self.schemas.picking()},
+            "confirmation_required": {
+                "type": "boolean",
+                "nullable": True,
+                "required": False,
+            },
         }
 
     @property

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -501,11 +501,11 @@ class Reception(Component):
         move_dest_location = selected_line.location_dest_id
         pick_type_dest_location = picking.picking_type_id.default_location_dest_id
 
-        move_dest_location_ok = move_dest_location.parent_path.startswith(
-            location.parent_path
+        move_dest_location_ok = location.parent_path.startswith(
+            move_dest_location.parent_path
         )
-        pick_type_dest_location_ok = pick_type_dest_location.parent_path.startswith(
-            location.parent_path
+        pick_type_dest_location_ok = location.parent_path.startswith(
+            pick_type_dest_location.parent_path
         )
         if move_dest_location_ok or pick_type_dest_location_ok:
             return (move_dest_location_ok, pick_type_dest_location_ok)

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -474,7 +474,7 @@ class Reception(Component):
                 if self.work.menu.auto_post_line:
                     # If option auto_post_line is active in the shopfloor menu,
                     # create a split order with this line.
-                    self._auto_post_line(selected_line, picking)
+                    self._auto_post_line(selected_line)
                 return self._response_for_select_move(picking)
             # Scanned package has no location, move to the location selection
             # screen
@@ -887,7 +887,7 @@ class Reception(Component):
             if response:
                 return response
             # Nothing found, ask user if we should create a new pack for the scanned
-            # barcode
+            # barcode.
             if not confirmation:
                 return self._response_for_set_quantity(
                     picking,
@@ -895,6 +895,7 @@ class Reception(Component):
                     message=self.msg_store.create_new_pack_ask_confirmation(barcode),
                     asking_confirmation=True,
                 )
+            # Nothing found and we already ask for confirmation, create the new package.
             package = self.env["stock.quant.package"].create({"name": barcode})
             quantity = selected_line.qty_done
             __, qty_check = selected_line._split_qty_to_be_done(
@@ -912,6 +913,10 @@ class Reception(Component):
                     ),
                 )
             selected_line.result_package_id = package
+            if self.work.menu.auto_post_line:
+                # If option auto_post_line is active in the shopfloor menu,
+                # create a split order with this line.
+                self._auto_post_line(selected_line)
             return self._response_for_set_destination(picking, selected_line)
         return self._response_for_set_quantity(
             picking, selected_line, message=self.msg_store.barcode_not_found()
@@ -984,7 +989,7 @@ class Reception(Component):
         selected_line.qty_done = quantity
         return self._response_for_set_destination(picking, selected_line)
 
-    def _auto_post_line(self, selected_line, picking):
+    def _auto_post_line(self, selected_line):
         new_move = selected_line.move_id.split_other_move_lines(
             selected_line, intersection=True
         )
@@ -1051,7 +1056,7 @@ class Reception(Component):
         if self.work.menu.auto_post_line:
             # If option auto_post_line is active in the shopfloor menu,
             # create a split order with this line.
-            self._auto_post_line(selected_line, picking)
+            self._auto_post_line(selected_line)
         return self._response_for_select_move(picking)
 
     def select_dest_package(
@@ -1096,7 +1101,7 @@ class Reception(Component):
             if self.work.menu.auto_post_line:
                 # If option auto_post_line is active in the shopfloor menu,
                 # create a split order with this line.
-                self._auto_post_line(selected_line, picking)
+                self._auto_post_line(selected_line)
             return self._response_for_select_move(picking)
         message = self.msg_store.create_new_pack_ask_confirmation(barcode)
         self._assign_user_to_picking(picking)

--- a/shopfloor_reception/tests/test_select_document.py
+++ b/shopfloor_reception/tests/test_select_document.py
@@ -151,6 +151,7 @@ class TestSelectDocument(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
 

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -89,6 +89,7 @@ class TestSelectLine(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
 
@@ -113,6 +114,7 @@ class TestSelectLine(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
 
@@ -137,6 +139,7 @@ class TestSelectLine(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
 

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -9,12 +9,7 @@ class TestSetDestination(CommonCase):
     def setUpClassBaseData(cls):
         super().setUpClassBaseData()
         cls.packing_location.sudo().active = True
-        cls.parent_location_dest = cls.env.ref("stock.stock_location_stock")
-        cls.location_dest = cls.shelf2
-        cls.another_location = cls.env["stock.location"].search(
-            [("parent_path", "not ilike", cls.parent_location_dest.parent_path)],
-            limit=1,
-        )
+        cls.location_dest = cls.env.ref("stock.stock_location_stock")
 
     @classmethod
     def _change_line_dest(cls, line):
@@ -24,7 +19,6 @@ class TestSetDestination(CommonCase):
 
     def test_scan_location_child_of_dest_location(self):
         picking = self._create_picking()
-        picking.sudo().picking_type_id.default_location_dest_id = self.another_location
         selected_move_line = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_a
         )
@@ -34,10 +28,10 @@ class TestSetDestination(CommonCase):
             params={
                 "picking_id": picking.id,
                 "selected_line_id": selected_move_line.id,
-                "location_name": self.parent_location_dest.name,
+                "location_name": self.shelf2.name,
             },
         )
-        self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
+        self.assertEqual(selected_move_line.location_dest_id, self.shelf2)
         data = self.data.picking(picking, with_progress=True)
         data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(
@@ -48,24 +42,22 @@ class TestSetDestination(CommonCase):
 
     def test_scan_location_child_of_pick_type_dest_location(self):
         picking = self._create_picking()
-        picking.sudo().picking_type_id.default_location_dest_id = self.shelf2
         selected_move_line = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_a
         )
-        selected_move_line.location_dest_id = self.another_location
+        self._change_line_dest(selected_move_line)
         response = self.service.dispatch(
             "set_destination",
             params={
                 "picking_id": picking.id,
                 "selected_line_id": selected_move_line.id,
-                "location_name": self.parent_location_dest.name,
+                "location_name": self.dispatch_location.name,
             },
         )
+
         # location is a child of the picking type's location. destination location
         # hasn't been set
-        self.assertNotEqual(
-            selected_move_line.location_dest_id, self.parent_location_dest
-        )
+        self.assertNotEqual(selected_move_line.location_dest_id, self.dispatch_location)
         # But a confirmation has been asked
         data = self.data.picking(picking)
         self.assert_response(
@@ -77,7 +69,7 @@ class TestSetDestination(CommonCase):
             },
             message={
                 "message_type": "warning",
-                "body": f"Place it in {self.parent_location_dest.name}?",
+                "body": f"Place it in {self.dispatch_location.name}?",
             },
         )
         # Send the same message with confirmation=True to confirm
@@ -86,11 +78,11 @@ class TestSetDestination(CommonCase):
             params={
                 "picking_id": picking.id,
                 "selected_line_id": selected_move_line.id,
-                "location_name": self.parent_location_dest.name,
+                "location_name": self.dispatch_location.name,
                 "confirmation": True,
             },
         )
-        self.assertEqual(selected_move_line.location_dest_id, self.parent_location_dest)
+        self.assertEqual(selected_move_line.location_dest_id, self.dispatch_location)
         data = self.data.picking(picking, with_progress=True)
         data.update({"moves": self.data.moves(picking.move_lines)})
         self.assert_response(
@@ -129,7 +121,6 @@ class TestSetDestination(CommonCase):
         selected_move_line = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_a
         )
-        self._change_line_dest(selected_move_line)
 
         # User has previously scanned a total of 3 units (with 7 still to do).
         # A new pack has been created and assigned to the line.
@@ -151,7 +142,7 @@ class TestSetDestination(CommonCase):
             params={
                 "picking_id": picking.id,
                 "selected_line_id": selected_move_line.id,
-                "location_name": self.parent_location_dest.name,
+                "location_name": self.dispatch_location.name,
             },
         )
         # The line has been moved to a different picking.

--- a/shopfloor_reception/tests/test_set_lot_confirm.py
+++ b/shopfloor_reception/tests/test_set_lot_confirm.py
@@ -61,5 +61,6 @@ class TestSetLotConfirm(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -65,6 +65,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
 
@@ -91,6 +92,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
 
@@ -116,6 +118,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
         # Scan again, and ensure qty increments
@@ -167,6 +170,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
         )
         # Scan again, and ensure qty increments
@@ -227,6 +231,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
             message={"message_type": "error", "body": "You cannot place it here"},
         )
@@ -300,6 +305,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
             message={"message_type": "error", "body": "You cannot place it here"},
         )
@@ -327,6 +333,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": False,
             },
             message={"message_type": "error", "body": "You cannot place it here"},
         )
@@ -353,6 +360,7 @@ class TestSetQuantity(CommonCase):
             data={
                 "picking": picking_data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+                "confirmation_required": True,
             },
             message={
                 "message_type": "warning",

--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -26,7 +26,7 @@ const Reception = {
                 :handler_to_update_date="get_expiration_date_from_lot"
                 v-on:date_picker_selected="state.on_date_picker_selected"
             />
-            <template v-if="state_in(['select_move', 'set_lot', 'set_quantity', 'set_destination'])">
+            <template v-if="state_is('select_move')">
                 <item-detail-card
                     :record="state.data.picking"
                     :options="operation_options()"
@@ -256,13 +256,18 @@ const Reception = {
             return {
                 title_action_field: {action_val_path: "name"},
                 fields: [
+                    {path: "origin", label: "Source Document"},
+                    {path: "partner.name", label: "Partner"},
+                    {path: "carrier"},
                     {
-                        path: "origin",
+                        path: "scheduled_date",
                         renderer: (rec, field) => {
-                            return rec.origin + " - " + rec.partner.name;
+                            return (
+                                "Scheduled Date: " +
+                                this.utils.display.render_field_date(rec, field)
+                            );
                         },
                     },
-                    {path: "carrier"},
                 ],
             };
         },
@@ -277,13 +282,20 @@ const Reception = {
                 list_item_options: {
                     key_title: "name",
                     loud_title: true,
+                    title_action_field: {
+                        action_val_path: "name",
+                    },
                     fields: [
-                        {path: "origin", action_val_path: "name"},
+                        {path: "origin", label: "Source Document"},
+                        {path: "partner.name", label: "Partner"},
                         {path: "carrier"},
                         {
                             path: "scheduled_date",
                             renderer: (rec, field) => {
-                                return this.utils.display.render_field_date(rec, field);
+                                return (
+                                    "Scheduled Date: " +
+                                    this.utils.display.render_field_date(rec, field)
+                                );
                             },
                         },
                         {path: "move_line_count", label: "Lines"},

--- a/shopfloor_reception_mobile/static/src/scenario/reception_states.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception_states.js
@@ -175,7 +175,7 @@ export const reception_states = function () {
                         selected_line_id: this.line_being_handled.id,
                         quantity: this.scan_destination_qty,
                         barcode: barcode.text,
-                        confirmation: true,
+                        confirmation: this.state.data.confirmation_required,
                     })
                 );
             },


### PR DESCRIPTION

- [X] The scan of a new package should ask for confirmation before creating the package and moving to next screen.
- [X] The location_check_ok is applied the wrong way. Fix for picking & move location check.
- [X] Improve values displayed in the UI for different screens.
- [x] When scanning a new pack, if the picking contains only 1 move with 1 move line, make sure it's posted.
- [x] At the beginning of the process, when scanning a product/lot, it should never open the reception but filter the list of valid reception containing it.

ref: rau-139