### PR TITLE
[14.0][FIX] shopfoor_mobile: fix checkout line selection

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_select.js
+++ b/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_select.js
@@ -69,6 +69,9 @@ Vue.component("picking-select-line-content", {
             opts.loud_title = true;
             return opts;
         },
+        get_wrapper_klass(record) {
+            return "";
+        },
     },
     computed: {
         pack_list_item_options() {


### PR DESCRIPTION
Fix get_wrapper_klass is not defined on checkout line selection
Fixes 52cce73848a80489f8953359da51f3be78ddc77d