### PR TITLE
[14.0][FIX] stock_release_channel: _pickings_sort_key 

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -649,7 +649,12 @@ class StockReleaseChannel(models.Model):
 
     @staticmethod
     def _pickings_sort_key(picking):
-        return (-int(picking.priority or 1), picking.date_priority, picking.id)
+        return (
+            -int(picking.priority or 1),
+            picking.scheduled_date,
+            picking.date_priority or picking.create_date,
+            picking.id,
+        )
 
     def _get_next_pickings(self):
         return getattr(self, "_get_next_pickings_{}".format(self.auto_release))()


### PR DESCRIPTION
uses now as fallback the picking.scheduled_date field

The date_priority field of a stock.picking can be null, that's why with need a fallback field. The scheduled_date is a required field of a stock.move, which means it is also always computed on the a stock.picking