### PR TITLE
[14.0] shopfloor_checkout: ask to select child destination when marking as done

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -28,8 +28,8 @@ class DataAction(Component):
             data.update({"operation_progress": operation_progress})
         return data
 
-    def locations(self, record, **kw):
-        return self.location(record, multi=True)
+    def locations(self, records, **kw):
+        return [self.location(rec, **kw) for rec in records]
 
     @property
     def _location_parser(self):

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -26,6 +26,7 @@ class ShopfloorSchemaAction(Component):
             "ship_carrier": self._schema_dict_of(self._simple_record(), required=False),
             "scheduled_date": {"type": "string", "nullable": False, "required": True},
             "progress": {"type": "float", "nullable": True},
+            "location_dest": self._schema_dict_of(self.location(), required=False),
         }
 
     def move_line(self, with_packaging=False, with_picking=False):

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -71,6 +71,17 @@ class Checkout(Component):
             message=message,
         )
 
+    def _response_for_select_child_location(self, picking, message=None):
+        return self._response(
+            next_state="select_child_location",
+            data={
+                "picking": self._data_for_stock_picking(
+                    picking, done=True, with_lines=False, with_location=True
+                ),
+            },
+            message=message,
+        )
+
     def _response_for_select_document(self, message=None):
         data = {"restrict_scan_first": self.work.menu.scan_location_or_pack_first}
         return self._response(next_state="select_document", message=message, data=data)
@@ -315,17 +326,22 @@ class Checkout(Component):
     def _data_for_delivery_packaging(self, packaging, **kw):
         return self.data.delivery_packaging_list(packaging, **kw)
 
-    def _data_for_stock_picking(self, picking, done=False):
+    def _data_for_stock_picking(
+        self, picking, done=False, with_lines=True, with_location=False
+    ):
         data = self.data.picking(picking)
         line_picker = self._lines_checkout_done if done else self._lines_to_pack
-        data.update(
-            {
-                "move_lines": self._data_for_move_lines(
-                    self._lines_prepare(picking, line_picker(picking)),
-                    with_packaging=done,
-                )
-            }
-        )
+        if with_lines:
+            data.update(
+                {
+                    "move_lines": self._data_for_move_lines(
+                        self._lines_prepare(picking, line_picker(picking)),
+                        with_packaging=done,
+                    )
+                }
+            )
+        if with_location:
+            data.update({"location_dest": self.data.location(picking.location_dest_id)})
         return data
 
     def _lines_checkout_done(self, picking):
@@ -1334,6 +1350,7 @@ class Checkout(Component):
         * summary: in case of error
         * select_document: after done, goes back to start
         * confirm_done: confirm a partial
+        * select_child_location: there are child destination locations
         """
         picking = self.env["stock.picking"].browse(picking_id)
         message = self._check_picking_status(picking)
@@ -1356,8 +1373,54 @@ class Checkout(Component):
                         "body": _("Remaining raw product not packed, proceed anyway?"),
                     },
                 )
-        stock = self._actions_for("stock")
         lines_done = self._lines_checkout_done(picking)
+        dest_location = picking.location_dest_id
+        child_locations = self.env["stock.location"].search(
+            [("id", "child_of", dest_location.id), ("usage", "!=", "view")]
+        )
+        if len(child_locations) > 0 and child_locations != dest_location:
+            return self._response_for_select_child_location(
+                picking,
+            )
+        stock = self._actions_for("stock")
+        stock.validate_moves(lines_done.move_id)
+        return self._response_for_select_document(
+            message=self.msg_store.transfer_done_success(lines_done.picking_id)
+        )
+
+    def scan_dest_location(self, picking_id, barcode):
+        """Select a location destination
+
+        When setting the move as done, if the destination location
+        has children locations, ask the user to scan one of them.
+
+        Transitions:
+        * select_document: after done, goes back to start
+        * select_child_location: in case of error
+        """
+        picking = self.env["stock.picking"].browse(picking_id)
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_select_document(message=message)
+        search = self._actions_for("search")
+        scanned_location = search.location_from_scan(barcode)
+        if not scanned_location:
+            return self._response_for_select_child_location(
+                picking,
+                message=self.msg_store.location_not_found(),
+            )
+        allowed_locations = self.env["stock.location"].search(
+            [("id", "child_of", picking.location_dest_id.id), ("usage", "!=", "view")]
+        )
+        if scanned_location not in allowed_locations:
+            return self._response_for_select_child_location(
+                picking,
+                message=self.msg_store.dest_location_not_allowed(),
+            )
+        lines_done = self._lines_checkout_done(picking)
+        for line in lines_done:
+            line.update({"location_dest_id": scanned_location.id})
+        stock = self._actions_for("stock")
         stock.validate_moves(lines_done.move_id)
         return self._response_for_select_document(
             message=self.msg_store.transfer_done_success(lines_done.picking_id)
@@ -1539,6 +1602,12 @@ class ShopfloorCheckoutValidator(Component):
             "confirmation": {"type": "boolean", "nullable": True, "required": False},
         }
 
+    def scan_dest_location(self):
+        return {
+            "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
+            "barcode": {"required": True, "type": "string"},
+        }
+
 
 class ShopfloorCheckoutValidatorResponse(Component):
     """Validators for the Checkout endpoints responses"""
@@ -1574,6 +1643,7 @@ class ShopfloorCheckoutValidatorResponse(Component):
             "summary": self._schema_summary,
             "change_packaging": self._schema_select_packaging,
             "confirm_done": self._schema_confirm_done,
+            "select_child_location": self._schema_select_child_location,
         }
 
     @property
@@ -1616,6 +1686,12 @@ class ShopfloorCheckoutValidatorResponse(Component):
     @property
     def _schema_confirm_done(self):
         return self._schema_stock_picking(lines_with_packaging=True)
+
+    @property
+    def _schema_select_child_location(self):
+        return {
+            "picking": {"type": "dict", "schema": self.schemas.picking()},
+        }
 
     @property
     def _schema_selection_list(self):
@@ -1759,4 +1835,11 @@ class ShopfloorCheckoutValidatorResponse(Component):
         return self._response_schema(next_states={"summary", "select_line"})
 
     def done(self):
-        return self._response_schema(next_states={"summary", "confirm_done"})
+        return self._response_schema(
+            next_states={"summary", "confirm_done", "select_child_location"}
+        )
+
+    def scan_dest_location(self):
+        return self._response_schema(
+            next_states={"confirm_done", "select_document", "select_child_location"}
+        )

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -26,6 +26,7 @@ from . import test_checkout_select
 from . import test_checkout_scan_line
 from . import test_checkout_scan_line_no_prefill_qty
 from . import test_checkout_scan_line_base
+from . import test_checkout_scan_dest_location
 from . import test_checkout_select_line
 from . import test_checkout_select_package_base
 from . import test_checkout_set_qty

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -23,8 +23,15 @@ class CheckoutCommonCase(CommonCase):
             "checkout", menu=self.menu, profile=self.profile
         )
 
-    def _stock_picking_data(self, picking, **kw):
-        return self.service._data_for_stock_picking(picking, **kw)
+    def _stock_picking_data(
+        self, picking, done=False, with_lines=True, with_location=False, **kw
+    ):
+        return self.service._data_for_stock_picking(
+            picking, done, with_lines, with_location, **kw
+        )
+
+    def _stock_locations_data(self, locations, **kw):
+        return self.service._data_for_locations(locations, **kw)
 
     # we test the methods that structure data in test_actions_data.py
     def _picking_summary_data(self, picking):

--- a/shopfloor/tests/test_checkout_done.py
+++ b/shopfloor/tests/test_checkout_done.py
@@ -39,6 +39,13 @@ class CheckoutDonePartialCase(CheckoutCommonCase):
         cls.line1.write({"qty_done": 10, "shopfloor_checkout_done": True})
         cls.line2.write({"qty_done": 2, "shopfloor_checkout_done": True})
 
+        cls.dest_location = picking.location_dest_id
+        cls.child_location = (
+            cls.env["stock.location"]
+            .sudo()
+            .create({"name": "Child Location", "location_id": cls.dest_location.id})
+        )
+
     def test_done_partial(self):
         # line is done
         response = self.service.dispatch("done", params={"picking_id": self.picking.id})
@@ -57,18 +64,17 @@ class CheckoutDonePartialCase(CheckoutCommonCase):
         response = self.service.dispatch(
             "done", params={"picking_id": self.picking.id, "confirmation": True}
         )
-        # as they are all the lines that relate to the picking, they didn't have
-        # been extracted in a separate transfer. An usual backorder has been
-        # created for the unprocessed qty.
-        self.assertRecordValues(self.picking, [{"state": "done"}])
-        self.assertTrue(self.picking.backorder_ids)
-        self.assertEqual(self.picking.backorder_ids.move_line_ids.product_uom_qty, 8)
+
+        self.assertRecordValues(self.picking, [{"state": "assigned"}])
 
         self.assert_response(
             response,
-            next_state="select_document",
-            message=self.service.msg_store.transfer_done_success(self.picking),
-            data={"restrict_scan_first": False},
+            next_state="select_child_location",
+            data={
+                "picking": self._stock_picking_data(
+                    self.picking, done=True, with_lines=False, with_location=True
+                ),
+            },
         )
 
 

--- a/shopfloor/tests/test_checkout_scan_dest_location.py
+++ b/shopfloor/tests/test_checkout_scan_dest_location.py
@@ -1,0 +1,96 @@
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from .test_checkout_base import CheckoutCommonCase
+
+
+class CheckoutSelectChildLocationCase(CheckoutCommonCase):
+    @classmethod
+    def setUpClassBaseData(cls):
+        super().setUpClassBaseData()
+        cls.picking = picking = cls._create_picking(
+            lines=[(cls.product_a, 10), (cls.product_b, 10)]
+        )
+        cls._fill_stock_for_moves(picking.move_lines)
+        picking.action_assign()
+        cls.line1 = picking.move_line_ids[0]
+        cls.line2 = picking.move_line_ids[1]
+        cls.line1.write({"qty_done": 10, "shopfloor_checkout_done": True})
+        cls.line2.write({"qty_done": 2, "shopfloor_checkout_done": True})
+
+        cls.dest_location = picking.location_dest_id
+        cls.child_location = (
+            cls.env["stock.location"]
+            .sudo()
+            .create({"name": "Child Location", "location_id": cls.dest_location.id})
+        )
+        cls.child_location_view = (
+            cls.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "name": "Child Location View",
+                    "location_id": cls.dest_location.id,
+                    "usage": "view",
+                }
+            )
+        )
+
+    def test_scan_dest_location_ok(self):
+        response = self.service.dispatch(
+            "scan_dest_location",
+            params={
+                "picking_id": self.picking.id,
+                "barcode": self.child_location.name,
+            },
+        )
+
+        self.assertRecordValues(self.picking, [{"state": "done"}])
+        self.assertTrue(self.picking.backorder_ids)
+        self.assertEqual(self.picking.backorder_ids.move_line_ids.product_uom_qty, 8)
+
+        self.assert_response(
+            response,
+            next_state="select_document",
+            data={"restrict_scan_first": False},
+            message=self.service.msg_store.transfer_done_success(self.picking),
+        )
+
+    def test_scan_dest_location_not_found(self):
+        response = self.service.dispatch(
+            "scan_dest_location",
+            params={
+                "picking_id": self.picking.id,
+                "barcode": "not-a-location",
+            },
+        )
+
+        self.assert_response(
+            response,
+            next_state="select_child_location",
+            data={
+                "picking": self._stock_picking_data(
+                    self.picking, done=True, with_lines=False, with_location=True
+                ),
+            },
+            message=self.service.msg_store.location_not_found(),
+        )
+
+    def test_scan_dest_location_not_allowed(self):
+        response = self.service.dispatch(
+            "scan_dest_location",
+            params={
+                "picking_id": self.picking.id,
+                "barcode": self.child_location_view.name,
+            },
+        )
+
+        self.assert_response(
+            response,
+            next_state="select_child_location",
+            data={
+                "picking": self._stock_picking_data(
+                    self.picking, done=True, with_lines=False, with_location=True
+                ),
+            },
+            message=self.service.msg_store.dest_location_not_allowed(),
+        )

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -234,6 +234,21 @@ const Checkout = {
                     </v-row>
                 </div>
             </div>
+            <div v-if="state_is('select_child_location')">
+                <item-detail-card
+                    :key="make_state_component_key(['picking'])"
+                    :record="state.data.picking"
+                    :options="{key_title: 'location_dest.name'}"
+                    :card_color="utils.colors.color_for('screen_step_todo')"
+                />
+                <div class="button-list button-vertical-list full">
+                    <v-row align="center">
+                        <v-col class="text-center" cols="12">
+                            <btn-back />
+                        </v-col>
+                    </v-row>
+                </div>
+            </div>
         </Screen>
         `,
     computed: {

--- a/shopfloor_mobile/static/wms/src/scenario/checkout_states.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout_states.js
@@ -376,5 +376,26 @@ export const checkout_states = function ($instance) {
                 $instance.reset_notification();
             },
         },
+        select_child_location: {
+            display_info: {
+                title: "Set destination location",
+                scan_placeholder: "Scan location",
+            },
+            events: {
+                go_back: "on_back",
+            },
+            on_scan: (scanned) => {
+                $instance.wait_call(
+                    $instance.odoo.call("scan_dest_location", {
+                        picking_id: $instance.state.data.picking.id,
+                        barcode: scanned.text,
+                    })
+                );
+            },
+            on_back: () => {
+                $instance.state_to("summary");
+                $instance.reset_notification();
+            },
+        },
     };
 };


### PR DESCRIPTION
In the checkout scenario, when clicking mark as done, if the destination location has children locations we now show an extra screen asking for the destination location.
This location will serve as destination location for all the processed lines.

ref: rau-143