### PR TITLE
[14.0][FIX] shopfloor_dangerous_goods_mobile: fix logo

### DIFF
--- a/shopfloor_dangerous_goods_mobile/static/wms/src/css/dangerous_goods.css
+++ b/shopfloor_dangerous_goods_mobile/static/wms/src/css/dangerous_goods.css
@@ -1,10 +1,16 @@
+.detail-picking-select .has-lq-products .record-name::after,
 .detail-picking-select .has-lq-products .v-list-item__title::after {
+    /* TODO: This PR fixes a bug that made the dangerous product logo
+    not visible: https: //github.com/OCA/wms/pull/619.
+    However, we should consider improving it
+    to make it look a bit prettier. */
     display: inline-block;
-    width: 0.9em;
-    height: 0.9em;
+    width: 1.5em;
+    height: 1.5em;
     background-image: url(limited_quantity_label.png);
     background-size: cover;
     background-position: center;
     content: " ";
     margin-left: 0.3em;
+    vertical-align: middle;
 }

--- a/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_select.js
+++ b/shopfloor_mobile/static/wms/src/components/scenario_picking_detail/picking_select.js
@@ -99,6 +99,9 @@ Vue.component("picking-select-package-content", {
             return "";
         },
     },
+    // TODO: We should update the layout of this component so that it's in line
+    // with the refactor done to "picking-select-line-content":
+    // https://github.com/OCA/wms/pull/583
     template: `
     <div>
         <div :class="[record.package_dest ? 'has-pack' : 'no-pack', get_wrapper_klass(record)]">


### PR DESCRIPTION
The dangerous goods logo wasn't displayed correctly due to the fact that the content of the picking-select components changed and the CSS wasn't pointing to the new elements.

![image](https://user-images.githubusercontent.com/77412816/232994523-d105ee19-6f2e-428c-a22a-47066326b106.png)
![image](https://user-images.githubusercontent.com/77412816/232994538-ab75e485-346d-45d2-848b-a142ed8dc72b.png)


ref: cos-4038