### PR TITLE
[14.0] shopfloor: fix scan_destination not returning done qty

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -688,6 +688,7 @@ class ClusterPicking(Component):
             return self._response_for_scan_destination(
                 move_line,
                 message=self.msg_store.unable_to_pick_more(move_line.product_uom_qty),
+                qty_done=quantity,
             )
 
         search = self._actions_for("search")
@@ -716,6 +717,7 @@ class ClusterPicking(Component):
                         "The destination bin {} is not empty, please take another."
                     ).format(bin_package.name),
                 },
+                qty_done=quantity,
             )
         move_line.write({"qty_done": quantity, "result_package_id": bin_package.id})
 

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -958,7 +958,7 @@ class ClusterPicking(Component):
         ]
         return domain
 
-    def change_pack_lot(self, picking_batch_id, move_line_id, barcode):
+    def change_pack_lot(self, picking_batch_id, move_line_id, barcode, quantity=None):
         """Change the expected pack or the lot for a line
 
         If the expected lot is at the very bottom of the location or a stock
@@ -994,13 +994,18 @@ class ClusterPicking(Component):
                 move_line, lot, response_ok_func, response_error_func
             )
             if response:
+                if "scan_destination" in response["data"]:
+                    response["data"]["scan_destination"].update({"qty_done": quantity})
                 return response
 
         package = search.package_from_scan(barcode)
         if package:
-            return change_package_lot.change_package(
+            response = change_package_lot.change_package(
                 move_line, package, response_ok_func, response_error_func
             )
+            if "scan_destination" in response["data"]:
+                response["data"]["scan_destination"].update({"qty_done": quantity})
+            return response
 
         return self._response_for_change_pack_lot(
             move_line,
@@ -1310,6 +1315,7 @@ class ShopfloorClusterPickingValidator(Component):
             "picking_batch_id": {"coerce": to_int, "required": True, "type": "integer"},
             "move_line_id": {"coerce": to_int, "required": True, "type": "integer"},
             "barcode": {"required": True, "type": "string"},
+            "quantity": {"required": False, "type": "float"},
         }
 
     def set_destination_all(self):

--- a/shopfloor/tests/test_cluster_picking_base.py
+++ b/shopfloor/tests/test_cluster_picking_base.py
@@ -24,7 +24,7 @@ class ClusterPickingCommonCase(CommonCase, PickingBatchMixin):
             "cluster_picking", menu=self.menu, profile=self.profile
         )
 
-    def _line_data(self, move_line, qty=None, package_dest=False, **kw):
+    def _line_data(self, move_line, qty=None, package_dest=False, qty_done=None, **kw):
         picking = move_line.picking_id
         # A package exists on the move line, because the quant created
         # by ``_simulate_batch_selected`` has a package.
@@ -33,6 +33,8 @@ class ClusterPickingCommonCase(CommonCase, PickingBatchMixin):
             data["package_dest"] = None
         if qty:
             data["quantity"] = qty
+        if qty_done:
+            data["qty_done"] = qty_done
         data.update(
             {
                 "batch": self.data.picking_batch(picking.batch_id),

--- a/shopfloor/tests/test_cluster_picking_change_pack_lot.py
+++ b/shopfloor/tests/test_cluster_picking_change_pack_lot.py
@@ -26,6 +26,7 @@ class ClusterPickingChangePackLotCase(ClusterPickingCommonCase):
                 "picking_batch_id": batch.id,
                 "move_line_id": line.id,
                 "barcode": barcode,
+                "quantity": line.qty_done,
             },
         )
         if success:

--- a/shopfloor/tests/test_cluster_picking_scan_destination.py
+++ b/shopfloor/tests/test_cluster_picking_scan_destination.py
@@ -144,7 +144,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         self.assert_response(
             response,
             next_state="scan_destination",
-            data=self._line_data(line),
+            data=self._line_data(line, qty_done=10.0),
             message={
                 "message_type": "error",
                 "body": "The destination bin {} is not empty,"
@@ -228,7 +228,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
         self.assert_response(
             response,
             next_state="scan_destination",
-            data=self._line_data(line),
+            data=self._line_data(line, qty_done=11.0),
             message={
                 "message_type": "error",
                 "body": "You must not pick more than {} units.".format(

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -418,11 +418,15 @@ const ClusterPicking = {
                         ),
                     },
                     on_scan: (scanned) => {
+                        const quantity =
+                            this.scan_destination ||
+                            this.state_get_data("start_line").quantity;
                         this.wait_call(
                             this.odoo.call("change_pack_lot", {
                                 picking_batch_id: this.current_batch().id,
                                 move_line_id: this.state.data.id,
                                 barcode: scanned.text,
+                                quantity: quantity,
                             })
                         );
                     },


### PR DESCRIPTION
Endpoint "scan_location" was not returning any qty_done if certain conditions were met, which means that the qty-picker was being reset to 0.

ref: cos-4039