### PR TITLE
[14.0][IMP] shopfloor: zone picking handle complete mix package

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -128,6 +128,10 @@ class DataAction(Component):
             "name",
             "shopfloor_weight:weight",
             ("package_storage_type_id:storage_type", ["id", "name"]),
+            (
+                "quant_ids:total_quantity",
+                lambda rec, fname: sum(rec.quant_ids.mapped("quantity")),
+            ),
         ]
 
     @property

--- a/shopfloor/actions/packaging.py
+++ b/shopfloor/actions/packaging.py
@@ -51,3 +51,13 @@ class PackagingAction(Component):
 
     def package_has_several_lots(self, package):
         return len(package.quant_ids.lot_id) > 1
+
+    def is_complete_mix_pack(self, package):
+        """Check if a package is mixed and completely reserved.
+
+        Will return true if the package has multiple distinct products and
+        all the package quantities are reserved.
+        """
+        return self.package_has_several_products(package) and all(
+            quant.quantity == quant.reserved_quantity for quant in package.quant_ids
+        )

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -100,6 +100,7 @@ class ShopfloorSchemaAction(Component):
                     "to_do": {"type": "float", "required": False},
                 },
             },
+            "total_quantity": {"required": False, "type": "float"},
         }
         if with_packaging:
             schema["packaging"] = self._schema_dict_of(self.packaging())

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -61,6 +61,7 @@ from . import test_location_content_transfer_set_destination_package_or_line
 from . import test_location_content_transfer_putaway
 from . import test_location_content_transfer_mix
 from . import test_zone_picking_base
+from . import test_zone_picking_complete_mix_pack_flux
 from . import test_zone_picking_start
 from . import test_zone_picking_select_picking_type
 from . import test_zone_picking_select_line

--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -87,6 +87,7 @@ class ActionsDataCase(ActionsDataCaseBase):
             "storage_type": self._expected_storage_type(
                 package.package_storage_type_id
             ),
+            "total_quantity": 10.0,
             "weight": 20.0,
         }
         self.assertDictEqual(data, expected)
@@ -111,6 +112,7 @@ class ActionsDataCase(ActionsDataCaseBase):
                 package.package_storage_type_id
             ),
             "weight": 20.0,
+            "total_quantity": sum(package.quant_ids.mapped("quantity")),
         }
         self.assertDictEqual(data, expected)
 
@@ -226,12 +228,16 @@ class ActionsDataCase(ActionsDataCaseBase):
                 "name": move_line.package_id.name,
                 "weight": 20.0,
                 "storage_type": None,
+                "total_quantity": sum(
+                    move_line.package_id.quant_ids.mapped("quantity")
+                ),
             },
             "package_dest": {
                 "id": result_package.id,
                 "name": result_package.name,
                 "weight": 6.0,
                 "storage_type": None,
+                "total_quantity": sum(result_package.quant_ids.mapped("quantity")),
             },
             "location_src": self._expected_location(move_line.location_id),
             "location_dest": self._expected_location(move_line.location_dest_id),
@@ -289,12 +295,18 @@ class ActionsDataCase(ActionsDataCaseBase):
                 "name": move_line.package_id.name,
                 "weight": 30,
                 "storage_type": None,
+                "total_quantity": sum(
+                    move_line.package_id.quant_ids.mapped("quantity")
+                ),
             },
             "package_dest": {
                 "id": move_line.result_package_id.id,
                 "name": move_line.result_package_id.name,
                 "weight": 0,
                 "storage_type": None,
+                "total_quantity": sum(
+                    move_line.result_package_id.quant_ids.mapped("quantity")
+                ),
             },
             "location_src": self._expected_location(move_line.location_id),
             "location_dest": self._expected_location(move_line.location_dest_id),

--- a/shopfloor/tests/test_actions_data_base.py
+++ b/shopfloor/tests/test_actions_data_base.py
@@ -175,6 +175,7 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
             "name": record.name,
             "weight": record.pack_weight or record.estimated_pack_weight_kg,
             "storage_type": None,
+            "total_quantity": sum(record.quant_ids.mapped("quantity")),
         }
         data.update(kw)
         return data

--- a/shopfloor/tests/test_actions_data_detail.py
+++ b/shopfloor/tests/test_actions_data_detail.py
@@ -88,6 +88,7 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "id": self.storage_type_pallet.id,
                 "name": self.storage_type_pallet.name,
             },
+            "total_quantity": sum(package.quant_ids.mapped("quantity")),
         }
         self.assertDictEqual(data, expected)
         data = self.data_detail.package_detail(
@@ -191,12 +192,18 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "name": move_line.package_id.name,
                 "weight": 20.0,
                 "storage_type": None,
+                "total_quantity": sum(
+                    move_line.package_id.quant_ids.mapped("quantity")
+                ),
             },
             "package_dest": {
                 "id": result_package.id,
                 "name": result_package.name,
                 "weight": 6.0,
                 "storage_type": None,
+                "total_quantity": sum(
+                    move_line.result_package_id.quant_ids.mapped("quantity")
+                ),
             },
             "location_src": self._expected_location(move_line.location_id),
             "location_dest": self._expected_location(move_line.location_dest_id),
@@ -255,12 +262,18 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "name": move_line.package_id.name,
                 "weight": 30.0,
                 "storage_type": None,
+                "total_quantity": sum(
+                    move_line.package_id.quant_ids.mapped("quantity")
+                ),
             },
             "package_dest": {
                 "id": move_line.result_package_id.id,
                 "name": move_line.result_package_id.name,
                 "weight": 0.0,
                 "storage_type": None,
+                "total_quantity": sum(
+                    move_line.result_package_id.quant_ids.mapped("quantity")
+                ),
             },
             "location_src": self._expected_location(move_line.location_id),
             "location_dest": self._expected_location(move_line.location_dest_id),

--- a/shopfloor/tests/test_actions_packaging.py
+++ b/shopfloor/tests/test_actions_packaging.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# from odoo.tests.common import Form
+
+from .common import CommonCase
+
+
+class TestActionsPackaging(CommonCase):
+    """Tests covering methods to work on product packaging."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with cls.work_on_actions(cls) as work:
+            cls.packaging = work.component(usage="packaging")
+        cls.picking = cls._create_picking(
+            lines=[(cls.product_a, 10), (cls.product_b, 10)], confirm=True
+        )
+        cls.move0 = cls.picking.move_lines[0]
+        cls.move1 = cls.picking.move_lines[1]
+        cls._fill_stock_for_moves(
+            cls.picking.move_lines, in_package=True, same_package=True
+        )
+        cls.picking.action_assign()
+        cls.package1 = cls.move0.move_line_ids.package_id
+
+    @classmethod
+    def setUpClassVars(cls):
+        super().setUpClassVars()
+        cls.wh = cls.env.ref("stock.warehouse0")
+        cls.picking_type = cls.wh.out_type_id
+
+    def test_package_is_complete_mix_pack(self):
+        self.assertTrue(self.packaging.is_complete_mix_pack(self.package1))
+
+    def test_package_partially_reserved(self):
+        # Package has 2 products from pick 1 reserved
+        pick2 = self._create_picking(lines=[(self.product_c, 10)], confirm=True)
+        # But adding 1 more product from pick 2 that is not yet reserved
+        self._fill_stock_for_moves(pick2.move_lines, in_package=self.package1)
+        self.assertFalse(self.packaging.is_complete_mix_pack(self.package1))

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -330,6 +330,9 @@ class ZonePickingCommonCase(CommonCase):
             data_move_line[
                 "location_will_be_empty"
             ] = move_line.location_id.planned_qty_in_location_is_empty(move_line)
+            data_move_line[
+                "handle_complete_mix_pack"
+            ] = self.service._handle_complete_mix_pack(move_line.package_id)
         self.assert_response(
             response,
             next_state=state,
@@ -377,6 +380,7 @@ class ZonePickingCommonCase(CommonCase):
         message=None,
         confirmation_required=False,
         qty_done=None,
+        handle_complete_mix_pack=False,
     ):
         expected_move_line = self.data.move_line(move_line, with_picking=True)
         if qty_done is not None:
@@ -393,6 +397,7 @@ class ZonePickingCommonCase(CommonCase):
                 "move_line": expected_move_line,
                 "confirmation_required": confirmation_required,
                 "allow_alternative_destination_package": allow_alternative_destination_package,
+                "handle_complete_mix_pack": handle_complete_mix_pack,
             },
             message=message,
         )
@@ -406,6 +411,7 @@ class ZonePickingCommonCase(CommonCase):
         message=None,
         confirmation_required=False,
         qty_done=None,
+        handle_complete_mix_pack=False,
     ):
         self._assert_response_set_line_destination(
             "set_line_destination",
@@ -416,6 +422,7 @@ class ZonePickingCommonCase(CommonCase):
             message=message,
             confirmation_required=confirmation_required,
             qty_done=qty_done,
+            handle_complete_mix_pack=handle_complete_mix_pack,
         )
 
     def _assert_response_zero_check(

--- a/shopfloor/tests/test_zone_picking_complete_mix_pack_flux.py
+++ b/shopfloor/tests/test_zone_picking_complete_mix_pack_flux.py
@@ -1,0 +1,59 @@
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from .test_zone_picking_base import ZonePickingCommonCase
+
+
+class ZonePickingCompleteMixPackageFluxCase(ZonePickingCommonCase):
+    """Tests for the flux of complete mix packages."""
+
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
+    def test_scan_source_and_set_destination_on_mixed_package(self):
+        package = self.picking5.package_level_ids[0].package_id
+        self.assertTrue(len(package.move_line_ids.product_id) > 1)
+        response = self.service.dispatch(
+            "scan_source",
+            params={"barcode": package.name},
+        )
+        self.assertTrue(
+            response["data"]["set_line_destination"]["handle_complete_mix_pack"]
+        )
+        move_lines = self.service._find_location_move_lines(
+            package=package,
+        )
+        move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
+        move_line = move_lines[0]
+        self.assert_response_set_line_destination(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            move_line=move_line,
+            qty_done=0,
+            handle_complete_mix_pack=True,
+        )
+        # Lets move this pack somwehere...
+        move_line.location_dest_id = self.shelf1
+        quantity_done = move_line.product_uom_qty
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.packing_location.barcode,
+                "quantity": quantity_done,
+                "confirmation": True,
+                "handle_complete_mix_pack": True,
+            },
+        )
+        # Check response
+        move_lines = self.service._find_location_move_lines()
+        move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            move_lines=move_lines,
+            message=self.service.msg_store.confirm_pack_moved(),
+        )

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -255,7 +255,11 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
     def test_scan_source_package_many_products(self):
         """Scan source: scanned package that several product, aborting
         next step 'select_line expected.
+
+        This is only when no prefill quantity option is enabled. If not
+        the related package will be move in one step.
         """
+        self.menu.sudo().no_prefill_qty = True
         pack = self.picking1.package_level_ids[0].package_id
         self._update_qty_in_location(pack.location_id, self.product_b, 2, pack)
         response = self.service.dispatch(

--- a/shopfloor/tests/test_zone_picking_select_line_first_scan_location.py
+++ b/shopfloor/tests/test_zone_picking_select_line_first_scan_location.py
@@ -134,14 +134,19 @@ class ZonePickingSelectLineFirstScanLocationCase(ZonePickingCommonCase):
 
     def test_scan_source_scan_package_first_with_two_product(self):
         """Scan a package with two product and then scan a product."""
-        pickingA = self._create_picking(
-            lines=[(self.product_a, 13), (self.product_b, 5)]
-        )
+        pickingA = self._create_picking(lines=[(self.product_a, 13)])
         self._fill_stock_for_moves(
             pickingA.move_lines, in_package=True, location=self.zone_sublocation1
         )
         pickingA.action_assign()
         package = pickingA.package_level_ids[0].package_id
+
+        pickingB = self._create_picking(lines=[(self.product_b, 5)])
+        self._fill_stock_for_moves(
+            pickingB.move_lines, in_package=package, location=self.zone_sublocation1
+        )
+        # If all products in package are reserved, it will be handle as a full package
+        # pickingB.action_assign()
         response = self.service.dispatch(
             "scan_source",
             params={

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -642,7 +642,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
             qty_done=move_line.product_uom_qty,
         )
 
-    def test_set_destination_error_concurent_work(self):
+    def test_set_destination_package_error_concurent_work(self):
         """Scanned barcode is the destination package.
 
         Move line is already being worked on by someone else
@@ -658,6 +658,40 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
             params={
                 "move_line_id": move_line.id,
                 "barcode": self.free_package.name,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": False,
+            },
+        )
+        # Check response
+        self.assert_response_set_line_destination(
+            response,
+            zone_location,
+            picking_type,
+            move_line,
+            message={
+                "message_type": "error",
+                "body": "Someone is already working on these transfers",
+            },
+            qty_done=move_line.product_uom_qty,
+        )
+
+    def test_set_destination_location_error_concurent_work(self):
+        """Scanned barcode is the destination location.
+
+        Move line is already being worked on by someone else
+        """
+        zone_location = self.zone_location
+        picking_type = self.picking1.picking_type_id
+        picking_type.sudo().shopfloor_zero_check = True
+        self.assertEqual(len(self.picking1.move_line_ids), 1)
+        move_line = self.picking1.move_line_ids
+        move_line.picking_id.user_id = self.shopfloor_manager
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "package_id": self.free_package.id,
+                "barcode": self.packing_location.barcode,
                 "quantity": move_line.product_uom_qty,
                 "confirmation": False,
             },

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -58,7 +58,7 @@ const template_mobile = `
         <div v-if="state_is('select_line')">
             <item-detail-card
                 v-if="device_mode == 'mobile'"
-                v-for="line in state.data.move_lines"
+                v-for="line in select_line_detail_card_items()"
                 :key="make_state_component_key(['line', line.id])"
                 :record="line"
                 :options="select_line_move_line_detail_options()"
@@ -118,12 +118,23 @@ const template_mobile = `
             :card_color="utils.colors.color_for('screen_step_done')"
             />
         <item-detail-card
-            v-if="state_in(['set_line_destination', 'stock_issue', 'change_pack_lot'])"
+            v-if="state_in(['set_line_destination', 'stock_issue', 'change_pack_lot']) && !hide_qty_picker()"
             :key="make_state_component_key(['detail-move-line-product', state.data.move_line.id])"
             :record="state.data.move_line"
             :options="utils.wms.move_line_product_detail_options(state.data.move_line, {fields_blacklist: ['quantity']})"
             :card_color="utils.colors.color_for(state_in(['set_line_destination']) ? 'screen_step_done': 'screen_step_todo')"
             />
+
+
+        <item-detail-card
+            v-if="hide_qty_picker()"
+            :key="make_state_component_key(['detail-move-line-dest-pack', state.data.move_line.id])"
+            :record="state.data.move_line"
+            :options="{main: true, key_title: 'package_src.name', title_action_field: {action_val_path: 'package_src.name'}}"
+            :card_color="utils.colors.color_for(state_in(['set_line_destination']) ? 'screen_step_done': 'screen_step_todo')"
+            />
+
+
         <item-detail-card
             v-if="state_in(['set_line_destination'])"
             :key="make_state_component_key(['detail-move-line-loc-dest', state.data.move_line.id])"
@@ -131,7 +142,7 @@ const template_mobile = `
             :options="{main: true, key_title: 'location_dest.name', title_action_field: {action_val_path: 'location_dest.barcode'}}"
             :card_color="utils.colors.color_for('screen_step_todo')"
             />
-        <v-card v-if="state_in(['set_line_destination', 'change_pack_lot'])"
+        <v-card v-if="state_in(['set_line_destination', 'change_pack_lot']) && !hide_qty_picker()"
                 class="pa-2" :color="utils.colors.color_for('screen_step_todo')">
             <packaging-qty-picker
                 :key="make_state_component_key(['packaging-qty-picker', state.data.move_line.id])"
@@ -384,33 +395,138 @@ const ZonePicking = {
         },
         select_line_table_items: function () {
             const self = this;
+            // For line with a complete mix package only show one line per package
+            // with the name of the package
+            var full_package_handeled = [];
             // Convert to v-data-table keys
             const items = _.map(this.state.data.move_lines, function (record) {
                 const item_data = {};
-                _.forEach(self.move_line_list_fields(true), function (field) {
-                    item_data[field.path] = _.result(record, field.path);
-                    if (field.renderer) {
-                        item_data[field.path] = field.renderer(record, field);
+                if (record.handle_complete_mix_pack) {
+                    if (full_package_handeled.includes(record.package_src.name)) {
+                        return {};
                     }
-                });
-                item_data._origin = record;
+                    full_package_handeled.push(record.package_src.name);
+                    _.forEach(self.package_list_fields(true), function (field) {
+                        item_data[field.path] = _.result(record, field.path);
+                        if (field.renderer) {
+                            item_data[field.path] = field.renderer(record, field);
+                        }
+                    });
+                    item_data._origin = record;
+                } else {
+                    _.forEach(self.move_line_list_fields(true), function (field) {
+                        item_data[field.path] = _.result(record, field.path);
+                        if (field.renderer) {
+                            item_data[field.path] = field.renderer(record, field);
+                        }
+                    });
+                    item_data._origin = record;
+                }
                 return item_data;
             });
+            return items.filter((value) => JSON.stringify(value) !== "{}");
+        },
+        select_line_detail_card_items: function () {
+            var items = [];
+            var full_package_handeled = [];
+
+            for (const line of this.state.data.move_lines) {
+                if (line.handle_complete_mix_pack) {
+                    if (full_package_handeled.includes(line.package_src.name)) {
+                        continue;
+                    }
+                    full_package_handeled.push(line.package_src.name);
+                }
+                items.push(line);
+            }
             return items;
         },
         select_line_move_line_detail_options: function () {
             const options = {
                 key_title: "location_src.name",
                 loud_labels: true,
-                title_action_field: {action_val_path: "product.barcode"},
+                title_action_field: {
+                    action_val_path: function (record, field) {
+                        return record.handle_complete_mix_pack
+                            ? "package_src.name"
+                            : "product.barcode";
+                    },
+                },
                 fields: this.move_line_list_fields(),
             };
             return options;
         },
+
+        package_list_fields: function (table_mode = false) {
+            const self = this;
+            const fields = [
+                {
+                    path: "product.display_name",
+                    label: table_mode ? "Product" : null,
+                    renderer: function (rec, field) {
+                        return "";
+                    },
+                },
+                {
+                    path: "package_src.name",
+                    label: "Pack / Lot",
+                    renderer: function (rec, field) {
+                        const pkg = _.result(rec, "package_src.name", "");
+                        const lot = _.result(rec, "lot.name", "");
+                        return lot ? pkg + "\n" + lot : pkg;
+                    },
+                },
+                {
+                    path: "quantity",
+                    label: "Qty",
+                    renderer: function (rec, field) {
+                        return rec.handle_complete_mix_pack
+                            ? rec.package_src.total_quantity
+                            : rec.quantity;
+                    },
+                },
+                {path: "package_src.weight", label: "Weight"},
+                {
+                    path: "picking.scheduled_date",
+                    label: "Date",
+                    renderer: function (rec, field) {
+                        return self.utils.display.render_field_date(rec, field);
+                    },
+                },
+                {
+                    path: "priority",
+                    label: table_mode ? "Priority" : null,
+                    render_component: "priority-widget",
+                    render_options: function (record) {
+                        return {priority: parseInt(record.priority || "0", 10)};
+                    },
+                },
+                {
+                    path: "location_will_be_empty",
+                    render_component: "empty-location-icon",
+                    display_no_value: true,
+                },
+            ];
+            if (table_mode) {
+                fields.unshift({path: "location_src.name", label: "Location"});
+            }
+            return fields;
+        },
+
         move_line_list_fields: function (table_mode = false) {
             const self = this;
             const fields = [
-                {path: "product.display_name", label: table_mode ? "Product" : null},
+                {
+                    path: "product.display_name",
+                    label: table_mode ? "Product" : null,
+                    renderer: function (rec, field) {
+                        if (rec.handle_complete_mix_pack) {
+                            return "";
+                        } else {
+                            return rec.product.display_name;
+                        }
+                    },
+                },
                 {
                     path: "package_src.name",
                     label: "Pack / Lot",
@@ -426,7 +542,9 @@ const ZonePicking = {
                     render_component: "packaging-qty-picker-display",
                     render_props: function (record) {
                         return self.utils.wms.move_line_qty_picker_props(record, {
-                            qtyInit: record.quantity,
+                            qtyInit: record.handle_complete_mix_pack
+                                ? record.package_src.total_quantity
+                                : record.quantity,
                         });
                     },
                 },
@@ -515,6 +633,12 @@ const ZonePicking = {
         },
         picking_summary_move_line_detail_fields: function () {
             return [{path: "package_src.name", klass: "loud"}];
+        },
+        hide_qty_picker: function () {
+            if ("handle_complete_mix_pack" in this.state.data) {
+                return this.state.data.handle_complete_mix_pack;
+            }
+            return false;
         },
     },
     computed: {
@@ -706,12 +830,20 @@ const ZonePicking = {
                     },
                     on_scan: (scanned) => {
                         const data = this.state.data;
+                        // When handling a complete pack the quantity picker is hidden
+                        // because all move line of the package will be handled.
+                        // So for that case we pass a positive quantity
+                        const quantity = data.handle_complete_mix_pack
+                            ? data.move_line.quantity
+                            : this.scan_destination_qty;
                         this.wait_call(
                             this.odoo.call("set_destination", {
                                 move_line_id: data.move_line.id,
                                 barcode: scanned.text,
-                                quantity: this.scan_destination_qty,
+                                quantity: quantity,
                                 confirmation: data.confirmation_required,
+                                // package_id: data.is_complete_mix_pack ? data.move_line.package_src.id : null,
+                                handle_complete_mix_pack: data.handle_complete_mix_pack,
                             })
                         );
                     },

--- a/shopfloor_mobile_base/static/wms/src/components/detail/detail_mixin.js
+++ b/shopfloor_mobile_base/static/wms/src/components/detail/detail_mixin.js
@@ -47,8 +47,15 @@ export var ItemDetailMixin = {
         _render_date(record, field) {
             return this.utils.display.format_date_display(_.result(record, field.path));
         },
+        get_action_value_path(record, field) {
+            if (typeof field.action_val_path == "function") {
+                return field.action_val_path(record);
+            } else {
+                return field.action_val_path;
+            }
+        },
         has_detail_action(record, field) {
-            return _.result(record, field.action_val_path);
+            return _.result(record, this.get_action_value_path(record, field));
         },
         on_detail_action(record, field, options = {}) {
             let handler = this.default_detail_action_handler;
@@ -58,7 +65,10 @@ export var ItemDetailMixin = {
             handler.call(this, record, field);
         },
         default_detail_action_handler(record, field) {
-            const identifier = _.result(record, field.action_val_path);
+            const identifier = _.result(
+                record,
+                this.get_action_value_path(record, field)
+            );
             if (identifier) {
                 // TODO: we should probably delegate this to a global event
                 this.$router.push({


### PR DESCRIPTION
When a package has different product in it, it will be displayed with multiple move lines in the `select_line` step. And they will need to be move one after an other.

For such package, this change allows to move such package in one step.

ref.: rau-145