### PR TITLE
[14.0] shopfloor_checkout: show full list of products after select_line

### DIFF
--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -118,7 +118,8 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         picking.action_assign()
         first_line = picking.move_line_ids[0]
         lot = first_line.lot_id
-        self._test_scan_line_ok(lot.name, first_line)
+        related_lines = picking.move_line_ids - first_line
+        self._test_scan_line_ok(lot.name, first_line, related_lines)
 
     def test_scan_line_product_in_one_package_all_package_lines_ok(self):
         picking = self._create_picking(

--- a/shopfloor/tests/test_checkout_select_package_base.py
+++ b/shopfloor/tests/test_checkout_select_package_base.py
@@ -61,4 +61,5 @@ class CheckoutSelectPackageMixin:
             )
         for line in unselected_lines + related_lines:
             self.assertEqual(line.qty_done, 0)
-        self._assert_selected_response(response, selected_lines, message=message, **kw)
+        package_lines = selected_lines + related_lines
+        self._assert_selected_response(response, package_lines, message=message, **kw)

--- a/shopfloor_packing_info/tests/test_checkout_scan_line.py
+++ b/shopfloor_packing_info/tests/test_checkout_scan_line.py
@@ -27,5 +27,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         picking.action_assign()
         move_line = move1.move_line_ids
         self._test_scan_line_ok(
-            move_line.package_id.name, move_line, packing_info=packing_info_text
+            move_line.package_id.name,
+            move_line,
+            packing_info=packing_info_text,
         )


### PR DESCRIPTION
Before, in some cases, when scanning / selecting a line in the `select_line` screen, only the selected lines would be displayed in the `select_package` screen.

Now, all lines are displayed and the scanned lines appear as selected.

ref: rau-144