### PR TITLE
[14.0][IMP] shopfloor: zone_picking scan location or pack first

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -378,6 +378,12 @@ class MessageAction(Component):
             "body": _("Please scan the location first."),
         }
 
+    def scan_the_package(self):
+        return {
+            "message_type": "warning",
+            "body": _("Please scan the package."),
+        }
+
     def product_multiple_packages_scan_package(self):
         return {
             "message_type": "warning",
@@ -635,6 +641,12 @@ class MessageAction(Component):
         return {
             "message_type": "error",
             "body": _("Location {} empty").format(location.name),
+        }
+
+    def location_empty_scan_package(self, location):
+        return {
+            "message_type": "warning",
+            "body": _("Location empty. Try scanning a package"),
         }
 
     def location_not_found(self):

--- a/shopfloor/actions/move_line_search.py
+++ b/shopfloor/actions/move_line_search.py
@@ -29,6 +29,8 @@ class MoveLineSearch(Component):
         lot=None,
         match_user=False,
         picking_ready=True,
+        # When True, adds the package in the domain even if the package is False
+        enforce_empty_package=False,
     ):
         domain = [
             ("location_id", "child_of", locations.ids),
@@ -40,8 +42,8 @@ class MoveLineSearch(Component):
             domain += [("picking_id.picking_type_id", "=", picking_type.id)]
         elif self.picking_types:
             domain += [("picking_id.picking_type_id", "in", self.picking_types.ids)]
-        if package:
-            domain += [("package_id", "=", package.id)]
+        if package or package is not None and enforce_empty_package:
+            domain += [("package_id", "=", package.id if package else False)]
         if product:
             domain += [("product_id", "=", product.id)]
         if lot:
@@ -67,6 +69,7 @@ class MoveLineSearch(Component):
         match_user=False,
         sort_keys_func=None,
         picking_ready=True,
+        enforce_empty_package=False,
     ):
         """Find lines that potentially need work in given locations."""
         move_lines = self.env["stock.move.line"].search(
@@ -78,6 +81,7 @@ class MoveLineSearch(Component):
                 lot,
                 match_user=match_user,
                 picking_ready=picking_ready,
+                enforce_empty_package=enforce_empty_package,
             )
         )
         sort_keys_func = sort_keys_func or self._sort_key_move_lines(order)

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -309,6 +309,7 @@ class ZonePickingCommonCase(CommonCase):
         product=None,
         sublocation=None,
         location_first=None,
+        package=None,
     ):
         data = {
             "zone_location": self.data.location(zone_location),
@@ -319,6 +320,8 @@ class ZonePickingCommonCase(CommonCase):
         }
         if product:
             data["product"] = self.data.product(product)
+        if package:
+            data["package"] = self.data.package(package)
         if sublocation:
             data["sublocation"] = self.data.location(sublocation)
         for data_move_line in data["move_lines"]:
@@ -346,6 +349,7 @@ class ZonePickingCommonCase(CommonCase):
         product=None,
         sublocation=None,
         location_first=False,
+        package=False,
     ):
         self._assert_response_select_line(
             "select_line",
@@ -359,6 +363,7 @@ class ZonePickingCommonCase(CommonCase):
             product=product,
             sublocation=sublocation,
             location_first=location_first,
+            package=package,
         )
 
     def _assert_response_set_line_destination(

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -218,6 +218,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         """Scan source: scanned package has no related move line,
         next step 'select_line' expected.
         """
+        self.free_package.location_id = self.zone_location
         pack_code = self.free_package.name
         response = self.service.dispatch(
             "scan_source",
@@ -270,7 +271,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             zone_location=self.zone_location,
             picking_type=self.picking_type,
             move_lines=move_lines,
-            sublocation=self.zone_sublocation1,
+            package=pack,
             message=self.service.msg_store.several_products_in_package(pack),
             location_first=False,
         )
@@ -607,7 +608,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             self.assertEqual(response["next_state"], "select_line")
             self.assertEqual(
                 response["message"],
-                self.service.msg_store.location_empty(self.zone_sublocation1),
+                self.service.msg_store.wrong_record(self.zone_sublocation1),
             )
 
     def test_prepare_unload_buffer_empty(self):

--- a/shopfloor/tests/test_zone_picking_select_line_first_scan_location.py
+++ b/shopfloor/tests/test_zone_picking_select_line_first_scan_location.py
@@ -23,7 +23,8 @@ class ZonePickingSelectLineFirstScanLocationCase(ZonePickingCommonCase):
             params={"barcode": self.product_a.barcode},
         )
         move_lines = self.service._find_location_move_lines(
-            locations=self.zone_location
+            locations=self.zone_location,
+            package=False,
         )
         self.assertTrue(response.get("data").get("select_line"))
         self.assert_response_select_line(
@@ -64,5 +65,141 @@ class ZonePickingSelectLineFirstScanLocationCase(ZonePickingCommonCase):
             move_lines=move_lines,
             product=self.product_b,
             sublocation=self.zone_sublocation2,
+            location_first=True,
+        )
+
+    def test_scan_source_can_not_select_line_with_package(self):
+        """Do not allow to scan product with package without scanning pack first."""
+        # Picking 1 with one product in a package is already in sub location 1
+        pickingA = self._create_picking(lines=[(self.product_a, 13)])
+        self._fill_stock_for_moves(
+            pickingA.move_lines[0], in_package=True, location=self.zone_sublocation1
+        )
+        pickingA.action_assign()
+        # Scanning a product after having scan a location (sublocation_id)
+        response = self.service.dispatch(
+            "scan_source",
+            params={
+                "barcode": self.product_a.barcode,
+                "sublocation_id": self.zone_sublocation1.id,
+            },
+        )
+        self.assertEqual(response["next_state"], "select_line")
+        move_lines = self.service._find_location_move_lines(
+            locations=self.zone_sublocation1, package=False, product=self.product_a
+        )
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            sublocation=self.zone_sublocation1,
+            picking_type=self.picking_type,
+            message=self.service.msg_store.product_not_found_in_pickings(),
+            move_lines=move_lines,
+            location_first=True,
+        )
+
+    def test_scan_source_scan_location_no_lines_without_package(self):
+        """Check list of lines when first scanning location.
+
+        With the scan_location_or_pack_first option on. When scanning first the
+        location and no lines without package exist, ask to scan a package.
+
+        """
+        # Picking 1 with one product in a package is already in sub location 1
+        pickingA = self._create_picking(lines=[(self.product_a, 13)])
+        self._fill_stock_for_moves(
+            pickingA.move_lines[0], in_package=True, location=self.zone_sublocation1
+        )
+        pickingA.action_assign()
+        response = self.service.dispatch(
+            "scan_source",
+            params={
+                "barcode": self.zone_sublocation1.barcode,
+            },
+        )
+        move_lines = self.service._find_location_move_lines(
+            locations=self.zone_sublocation1, package=False
+        )
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            sublocation=self.zone_sublocation1,
+            picking_type=self.picking_type,
+            message=self.service.msg_store.several_packs_in_location(
+                self.zone_sublocation1
+            ),
+            move_lines=move_lines,
+            location_first=True,
+        )
+
+    def test_scan_source_scan_package_first_with_two_product(self):
+        """Scan a package with two product and then scan a product."""
+        pickingA = self._create_picking(
+            lines=[(self.product_a, 13), (self.product_b, 5)]
+        )
+        self._fill_stock_for_moves(
+            pickingA.move_lines, in_package=True, location=self.zone_sublocation1
+        )
+        pickingA.action_assign()
+        package = pickingA.package_level_ids[0].package_id
+        response = self.service.dispatch(
+            "scan_source",
+            params={
+                "barcode": package.name,
+            },
+        )
+        move_lines = self.service._find_location_move_lines(
+            locations=self.zone_sublocation1, package=package
+        )
+        self.assertTrue(len(move_lines), 2)
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            message=self.service.msg_store.several_products_in_package(package),
+            move_lines=move_lines,
+            location_first=True,
+            package=package,
+        )
+        response = self.service.dispatch(
+            "scan_source",
+            params={"barcode": self.product_a.barcode, "package_id": package.id},
+        )
+        move_line = pickingA.move_line_ids[0]
+        self.assert_response_set_line_destination(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            move_line=move_line,
+            qty_done=13.0,
+        )
+
+    def test_scan_source_scan_product_message_product_has_package(self):
+        """"""
+        # Picking 1 with one product in a package is already in sub location 1
+        pickingA = self._create_picking(lines=[(self.product_a, 13)])
+        self._fill_stock_for_moves(
+            pickingA.move_lines[0], in_package=True, location=self.zone_sublocation1
+        )
+        pickingA.action_assign()
+        # Scanning a product after having scan a location (sublocation_id)
+        response = self.service.dispatch(
+            "scan_source",
+            params={
+                "barcode": self.product_a.barcode,
+                "sublocation_id": self.zone_sublocation1.id,
+            },
+        )
+        self.assertEqual(response["next_state"], "select_line")
+        move_lines = self.service._find_location_move_lines(
+            locations=self.zone_sublocation1, package=False, product=self.product_a
+        )
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            sublocation=self.zone_sublocation1,
+            picking_type=self.picking_type,
+            message=self.service.msg_store.product_not_found_in_pickings(),
+            move_lines=move_lines,
             location_first=True,
         )

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -483,6 +483,9 @@ const ZonePicking = {
             if (this.state_is("select_line") && this.state.data.sublocation) {
                 data.sublocation_id = this.state.data.sublocation.id;
             }
+            if (this.state_is("select_line") && this.state.data.package) {
+                data.package_id = this.state.data.package.id;
+            }
             return this.wait_call(this.odoo.call("scan_source", data));
         },
         picking_summary_records_grouped(move_lines) {


### PR DESCRIPTION
With the option scan_location_or_pack_first on.
When scanning a location, only the lines without a source package are offered to be processed.
If none are found, ask for scanning a package.

ref.: rau-147