### PR TITLE
[14.0] shopfloor_mobile_base: fix headers extension

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -147,7 +147,7 @@ new Vue({
     },
     methods: {
         getOdoo: function (odoo_params) {
-            let params = _.defaults({}, odoo_params, {
+            let params = {
                 debug: this.demo_mode,
                 base_url: this.app_info.base_url,
                 headers: {
@@ -155,7 +155,8 @@ new Vue({
                     "APP-VERSION": this.app_info.version,
                     "APP-USER-ID": this.user.id,
                 },
-            });
+            };
+            params = _.merge({}, params, odoo_params);
             let OdooClass = null;
             if (this.demo_mode) {
                 OdooClass = OdooMocked;


### PR DESCRIPTION
Before this change all the default headers (lang, version, uid) were not passing when 'headers' were declared in 'odoo_params'. Basically all the calls from sf_mobile's scenario were missing them.