### PR TITLE
[14.0] shopfloor_single_pack_transfer: display all products in pack

### DIFF
--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -23,16 +23,16 @@ class SinglePackTransfer(Component):
     _description = __doc__
 
     def _data_after_package_scanned(self, package_level):
-        move_line = package_level.move_line_ids[0]
+        move_lines = package_level.move_line_ids
         package = package_level.package_id
         # TODO use data.package_level (but the "name" moves in "package.name")
         return {
             "id": package_level.id,
             "name": package.name,
-            "location_src": self.data.location(move_line.location_id),
+            "location_src": self.data.location(package.location_id),
             "location_dest": self.data.location(package_level.location_dest_id),
-            "product": self.data.product(move_line.product_id),
-            "picking": self.data.picking(move_line.picking_id),
+            "products": self.data.products(move_lines.product_id),
+            "picking": self.data.picking(move_lines.picking_id),
         }
 
     def _response_for_start(self, message=None, popup=None):
@@ -349,7 +349,10 @@ class SinglePackTransferValidatorResponse(Component):
             "name": {"type": "string", "nullable": False, "required": required},
             "location_src": {"type": "dict", "schema": self.schemas.location()},
             "location_dest": {"type": "dict", "schema": self.schemas.location()},
-            "product": {"type": "dict", "schema": self.schemas.product()},
+            "products": {
+                "type": "list",
+                "schema": {"type": "dict", "schema": self.schemas.product()},
+            },
             "picking": {"type": "dict", "schema": self.schemas.picking()},
         }
 

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -80,7 +80,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
             "location_src": self.data.location(package_level.location_id),
             "location_dest": self.data.location(package_level.location_dest_id),
             "picking": self.data.picking(self.picking),
-            "product": self.data.product(self.product_a),
+            "products": self.data.products(self.product_a),
         }
 
     def test_start(self):
@@ -192,7 +192,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
                 self.picking_type.default_location_dest_id
             ),
             "picking": self.data.picking(package_level.picking_id),
-            "product": self.data.product(self.product_a),
+            "products": self.data.products(self.product_a),
             "confirmation_required": False,
         }
 

--- a/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
@@ -74,19 +74,21 @@ const SinglePackTransfer = {
                     :key="make_state_component_key(['package', state.data.id])"
                     :record="state.data"
                     :card_color="utils.colors.color_for('screen_step_done')"
-                    />
-                <item-detail-card
-                    :key="make_state_component_key(['product', state.data.id])"
-                    :record="state.data"
-                    :options="utils.wms.move_line_product_detail_options()"
-                    :card_color="utils.colors.color_for('screen_step_done')"
-                    />
+                >
+                    <template v-slot:after_details>
+                        <v-card-text class="details pt-0">
+                            <div v-for="product in state.data.products" class="field-detail">
+                                {{ product.display_name}}
+                            </div>
+                        </v-card-text>
+                    </template>
+                </item-detail-card>
                 <item-detail-card
                     :key="make_state_component_key(['destination', state.data.id])"
                     :record="state.data"
                     :options="{main: true, key_title: 'location_dest.name', title_action_field:  {action_val_path: 'location_dest.barcode'}}"
                     :card_color="utils.colors.color_for('screen_step_todo')"
-                    />
+                />
             </div>
             <last-operation v-if="state_is('show_completion_info')" v-on:confirm="state.on_confirm"></last-operation>
             <cancel-button v-on:cancel="on_cancel" v-if="show_cancel_button"></cancel-button>


### PR DESCRIPTION
We need to display all products in the scanned package, and not just the first one.

ref: rau-79