### PR TITLE
[FIX] stock_release_channel: Filter on queue job counts

### DIFF
--- a/stock_release_channel/tests/test_assign_job.py
+++ b/stock_release_channel/tests/test_assign_job.py
@@ -13,10 +13,11 @@ class TestReleaseChannel(ReleaseChannelCase):
         move.picking_id.priority = "1"
         move2 = self._create_single_move(self.product2, 10)
         with trap_jobs() as trap:
-            (move + move2).picking_id._delay_assign_release_channel()
-            trap.assert_jobs_count(
-                2, only=self.env["stock.picking"].assign_release_channel
-            )
+            picking1 = move.picking_id
+            picking2 = move2.picking_id
+            (picking1 + picking2)._delay_assign_release_channel()
+            trap.assert_jobs_count(1, only=picking1.assign_release_channel)
+            trap.assert_jobs_count(1, only=picking1.assign_release_channel)
             trap.perform_enqueued_jobs()
             self.assertEqual(f"{message}", trap.enqueued_jobs[0].result)
         self.assertEqual(move.picking_id.release_channel_id, expected)
@@ -45,10 +46,8 @@ class TestReleaseChannel(ReleaseChannelCase):
                 f"Transfer {picking.name} could not be assigned to a "
                 "channel, you should add a final catch-all rule\n"
             )
-            move.picking_id._delay_assign_release_channel()
-            trap.assert_jobs_count(
-                1, only=self.env["stock.picking"].assign_release_channel
-            )
+            picking._delay_assign_release_channel()
+            trap.assert_jobs_count(1, only=picking.assign_release_channel)
             trap.perform_enqueued_jobs()
             self.assertEqual(message, trap.enqueued_jobs[0].result)
         move = self._create_single_move(self.product2, 10)
@@ -58,9 +57,7 @@ class TestReleaseChannel(ReleaseChannelCase):
                 f"Transfer {picking.name} could not be assigned to a "
                 "channel, you should add a final catch-all rule\n"
             )
-            move.picking_id._delay_assign_release_channel()
-            trap.assert_jobs_count(
-                1, only=self.env["stock.picking"].assign_release_channel
-            )
+            picking._delay_assign_release_channel()
+            trap.assert_jobs_count(1, only=picking.assign_release_channel)
             trap.perform_enqueued_jobs()
             self.assertEqual(message, trap.enqueued_jobs[0].result)


### PR DESCRIPTION
Due to commit:

https://github.com/OCA/queue/commit/936f81ffaf145334723dbb7ae40da12cd741acbf

Queue jobs tests methods are more restrictive to count effective jobs.