### PR TITLE
[14.0][FIX] shopfloor_checkout: fix bugs in checkout scenario

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -801,3 +801,9 @@ class MessageAction(Component):
             "message_type": "warning",
             "body": _("This location only contains packages, please scan one of them."),
         }
+
+    def no_line_to_pack(self):
+        return {
+            "message_type": "warning",
+            "body": _("No line to pack found."),
+        }

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -856,9 +856,10 @@ class Checkout(Component):
     def _pack_lines(self, picking, selected_lines, package):
         lines_to_pack = selected_lines.filtered(self._filter_lines_to_pack)
         if not lines_to_pack:
+            message = self.msg_store.no_line_to_pack()
             return self._response_for_select_line(
                 picking,
-                message=_("No line to pack found"),
+                message=message,
             )
         response = self._put_lines_in_allowed_package(picking, lines_to_pack, package)
         if response:

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -283,8 +283,10 @@ const Checkout = {
             };
         },
         handle_manual_select_highlight_on_scan: function (res) {
-            const new_selected_package_data = res.data.select_package;
-            new_selected_package_data.selected_move_lines.forEach((line) => {
+            // We need to ensure that the highlights of the detail-picking-select
+            // are updated correctly on scan.
+            const move_lines_data = this.get_move_lines_data(res);
+            move_lines_data.forEach((line) => {
                 let checked = false;
                 if (line.qty_done > 0) {
                     checked = true;
@@ -294,6 +296,23 @@ const Checkout = {
                     checked,
                 });
             });
+        },
+        get_move_lines_data: function (res) {
+            // We need to access the data object to find the move lines,
+            // and this path will vary depending on the current screen.
+            const data = res.data;
+            const state_key = res.next_state;
+            const path = this.get_move_lines_path(state_key);
+            return _.result(data, path, []);
+        },
+        get_move_lines_path: function (key) {
+            const possible_paths = {
+                summary: "picking.move_lines",
+                select_line: "picking.move_lines",
+                select_package: "selected_move_lines",
+                select_dest_package: "selected_move_lines",
+            };
+            return key + "." + possible_paths[key];
         },
         select_delivery_packaging_manual_select_options: function () {
             return {


### PR DESCRIPTION
Two bugs were found in this scenario:
- A message that was incorrectly implemented, throwing an error in the backend.
- A method that was used in the frontend to modify the reactivity of the highlights when scanning a package type, which didn't work for some screens.

ref: -rau-169