### PR TITLE
[14.0] shopfloor zone_picking: block scanning of destination packages

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "14.0.3.11.0",
+    "version": "14.0.4.0.0",
     "development_status": "Beta",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -883,10 +883,11 @@ class MessageAction(Component):
             "body": _("No line to pack found."),
         }
 
-    def package_not_allowed_scan_location(self):
+    def package_transfer_not_allowed_scan_location(self):
         return {
             "message_type": "warning",
             "body": _(
-                "Scanning a package is not allowed, please scan a location instead."
+                "Transferring to a different package is not allowed, "
+                "please scan a location instead."
             ),
         }

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -882,3 +882,11 @@ class MessageAction(Component):
             "message_type": "warning",
             "body": _("No line to pack found."),
         }
+
+    def package_not_allowed_scan_location(self):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "Scanning a package is not allowed, please scan a location instead."
+            ),
+        }

--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -20,7 +20,8 @@
     "unload_package_at_destination": true,
     "multiple_move_single_pack": true,
     "no_prefill_qty": true,
-    "scan_location_or_pack_first": true
+    "scan_location_or_pack_first": true,
+    "allow_alternative_destination_package": true
 }
         </field>
     </record>

--- a/shopfloor/migrations/14.0.4.0.0/post-migration.py
+++ b/shopfloor/migrations/14.0.4.0.0/post-migration.py
@@ -1,0 +1,43 @@
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import json
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    zone_picking_scenario = env["shopfloor.scenario"].search(
+        [("name", "=", "Zone Picking")]
+    )
+    _update_scenario_options(zone_picking_scenario)
+    zone_picking_menus = env["shopfloor.menu"].search(
+        [("scenario_id", "=", zone_picking_scenario.id)]
+    )
+    _enable_option_in_menus(zone_picking_menus)
+
+
+def _update_scenario_options(scenario):
+    options = scenario.options
+    options["allow_alternative_destination_package"] = True
+    options_edit = json.dumps(options or {}, indent=4, sort_keys=True)
+    scenario.write({"options_edit": options_edit})
+    _logger.info(
+        "Option allow_alternative_destination_package added to scenario Zone Picking"
+    )
+
+
+def _enable_option_in_menus(menus):
+    for menu in menus:
+        menu.allow_alternative_destination_package = True
+        _logger.info(
+            "Option allow_alternative_destination_package enabled for menu {}".format(
+                menu.name
+            )
+        )

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -46,7 +46,7 @@ A new move will be added as a return of the delivery,
 decreasing the delivered quantity of the related SO line.
 """
 
-ALLOW_SCAN_DESTINATION_PACKAGE_HELP = """
+ALLOW_ALTERNATIVE_DESTINATION_PACKAGE_HELP = """
 When moving a whole package, the user normally scans
 a destination location.
 If enabled, they will also be allowed
@@ -218,13 +218,13 @@ class ShopfloorMenu(models.Model):
     auto_post_line_is_possible = fields.Boolean(
         compute="_compute_auto_post_line_is_possible"
     )
-    allow_scan_destination_package = fields.Boolean(
-        string="Allow to scan a destination package",
+    allow_alternative_destination_package = fields.Boolean(
+        string="Allow to change the destination package",
         default=False,
-        help=ALLOW_SCAN_DESTINATION_PACKAGE_HELP,
+        help=ALLOW_ALTERNATIVE_DESTINATION_PACKAGE_HELP,
     )
-    allow_scan_destination_package_is_possible = fields.Boolean(
-        compute="_compute_allow_scan_destination_package_is_possible"
+    allow_alternative_destination_package_is_possible = fields.Boolean(
+        compute="_compute_allow_alternative_destination_package_is_possible"
     )
 
     @api.onchange("unload_package_at_destination")
@@ -449,8 +449,9 @@ class ShopfloorMenu(models.Model):
         for menu in self:
             menu.allow_return_is_possible = menu.scenario_id.has_option("allow_return")
 
-    def _compute_allow_scan_destination_package_is_possible(self):
+    @api.depends("scenario_id")
+    def _compute_allow_alternative_destination_package_is_possible(self):
         for menu in self:
-            menu.allow_scan_destination_package_is_possible = (
-                menu.scenario_id.has_option("allow_scan_destination_package")
+            menu.allow_alternative_destination_package_is_possible = (
+                menu.scenario_id.has_option("allow_alternative_destination_package")
             )

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -46,6 +46,13 @@ A new move will be added as a return of the delivery,
 decreasing the delivered quantity of the related SO line.
 """
 
+ALLOW_SCAN_DESTINATION_PACKAGE_HELP = """
+When moving a whole package, the user normally scans
+a destination location.
+If enabled, they will also be allowed
+to scan a destination package.
+"""
+
 
 class ShopfloorMenu(models.Model):
     _inherit = "shopfloor.menu"
@@ -210,6 +217,14 @@ class ShopfloorMenu(models.Model):
     )
     auto_post_line_is_possible = fields.Boolean(
         compute="_compute_auto_post_line_is_possible"
+    )
+    allow_scan_destination_package = fields.Boolean(
+        string="Allow to scan a destination package",
+        default=False,
+        help=ALLOW_SCAN_DESTINATION_PACKAGE_HELP,
+    )
+    allow_scan_destination_package_is_possible = fields.Boolean(
+        compute="_compute_allow_scan_destination_package_is_possible"
     )
 
     @api.onchange("unload_package_at_destination")
@@ -433,3 +448,9 @@ class ShopfloorMenu(models.Model):
     def _compute_allow_return_is_possible(self):
         for menu in self:
             menu.allow_return_is_possible = menu.scenario_id.has_option("allow_return")
+
+    def _compute_allow_scan_destination_package_is_possible(self):
+        for menu in self:
+            menu.allow_scan_destination_package_is_possible = (
+                menu.scenario_id.has_option("allow_scan_destination_package")
+            )

--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -33,7 +33,7 @@ by scanning a product or product packaging EAN to increase the quantity
 (i.e. +1 Unit or +1 Box)
 """
 
-AUTO_POST_LINE = """
+AUTO_POST_LINE_HELP = """
 When setting result pack & destination,
 automatically post the corresponding line
 if this option is checked.
@@ -206,7 +206,7 @@ class ShopfloorMenu(models.Model):
     auto_post_line = fields.Boolean(
         string="Automatically post line",
         default=False,
-        help=AUTO_POST_LINE,
+        help=AUTO_POST_LINE_HELP,
     )
     auto_post_line_is_possible = fields.Boolean(
         compute="_compute_auto_post_line_is_possible"
@@ -422,6 +422,7 @@ class ShopfloorMenu(models.Model):
                 "auto_post_line"
             )
 
+    @api.depends("scenario_id")
     def _compute_allow_alternative_destination_is_possible(self):
         for menu in self:
             menu.allow_alternative_destination_is_possible = (

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1097,7 +1097,14 @@ class ZonePicking(Component):
 
         pkg_moved = False
         search = self._actions_for("search")
-        accept_only_package = not self._move_line_full_qty(move_line, quantity)
+        # Only allow scanning a destination package if this option is enabled.
+        allow_package = self.work.menu.allow_scan_destination_package
+        # If scanning a destination package is allowed,
+        # and the scanned qty isn't equal to the qty todo,
+        # we force the user to scan a package.
+        accept_only_package = allow_package and not self._move_line_full_qty(
+            move_line, quantity
+        )
 
         response = self._set_destination_update_quantity(move_line, quantity, barcode)
         if response:
@@ -1146,6 +1153,11 @@ class ZonePicking(Component):
 
         # When the barcode is a package
         package = search.package_from_scan(barcode)
+        if package and not allow_package:
+            message = self.msg_store.package_not_allowed_scan_location()
+            return self._response_for_set_line_destination(
+                move_line, message=message, qty_done=quantity
+            )
         if package:
             if self._pick_pack_same_time():
                 (

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -228,6 +228,9 @@ class ZonePicking(Component):
         data = self._data_for_move_line(move_line)
         data["move_line"].update(kw)
         data["confirmation_required"] = confirmation_required
+        data[
+            "allow_scan_destination_package"
+        ] = self.work.menu.allow_scan_destination_package
         return self._response(
             next_state="set_line_destination", data=data, message=message
         )
@@ -1913,6 +1916,11 @@ class ShopfloorZonePickingValidatorResponse(Component):
             },
             "product_id": {
                 "type": "integer",
+                "nullable": True,
+                "required": False,
+            },
+            "allow_scan_destination_package": {
+                "type": "boolean",
                 "nullable": True,
                 "required": False,
             },

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -259,7 +259,7 @@ class ZonePickingCommonCase(CommonCase):
             current_zone_location=self.zone_location,
             current_picking_type=self.picking_type,
         )
-        self.menu.sudo().allow_scan_destination_package = True
+        self.menu.sudo().allow_alternative_destination_package = True
 
     def _assert_response_select_zone(self, response, zone_locations, message=None):
         data = {"zones": self.service._data_for_select_zone(zone_locations)}
@@ -381,7 +381,9 @@ class ZonePickingCommonCase(CommonCase):
         expected_move_line = self.data.move_line(move_line, with_picking=True)
         if qty_done is not None:
             expected_move_line["qty_done"] = qty_done
-        allow_scan_destination_package = self.menu.allow_scan_destination_package
+        allow_alternative_destination_package = (
+            self.menu.allow_alternative_destination_package
+        )
         self.assert_response(
             response,
             next_state=state,
@@ -390,7 +392,7 @@ class ZonePickingCommonCase(CommonCase):
                 "picking_type": self.data.picking_type(picking_type),
                 "move_line": expected_move_line,
                 "confirmation_required": confirmation_required,
-                "allow_scan_destination_package": allow_scan_destination_package,
+                "allow_alternative_destination_package": allow_alternative_destination_package,
             },
             message=message,
         )

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -259,6 +259,7 @@ class ZonePickingCommonCase(CommonCase):
             current_zone_location=self.zone_location,
             current_picking_type=self.picking_type,
         )
+        self.menu.sudo().allow_scan_destination_package = True
 
     def _assert_response_select_zone(self, response, zone_locations, message=None):
         data = {"zones": self.service._data_for_select_zone(zone_locations)}
@@ -380,6 +381,7 @@ class ZonePickingCommonCase(CommonCase):
         expected_move_line = self.data.move_line(move_line, with_picking=True)
         if qty_done is not None:
             expected_move_line["qty_done"] = qty_done
+        allow_scan_destination_package = self.menu.allow_scan_destination_package
         self.assert_response(
             response,
             next_state=state,
@@ -388,6 +390,7 @@ class ZonePickingCommonCase(CommonCase):
                 "picking_type": self.data.picking_type(picking_type),
                 "move_line": expected_move_line,
                 "confirmation_required": confirmation_required,
+                "allow_scan_destination_package": allow_scan_destination_package,
             },
             message=message,
         )

--- a/shopfloor/tests/test_zone_picking_set_line_destination_package_not_allowed.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination_package_not_allowed.py
@@ -1,0 +1,59 @@
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from .test_zone_picking_base import ZonePickingCommonCase
+
+
+class ZonePickingSetLineDestinationPackageNotAllowedCase(ZonePickingCommonCase):
+    """Tests for endpoint used from set_line_destination
+
+    With the allow scan destination package option disabled
+
+    * /set_destination
+
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+        self.menu.sudo().allow_scan_destination_package = False
+
+    def test_set_destination_package_not_allowed_scan_package(self):
+        move_line = self.picking1.move_line_ids[0]
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.free_package.name,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": False,
+            },
+        )
+        self.assert_response_set_line_destination(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            move_line=move_line,
+            qty_done=10.0,
+            message=self.service.msg_store.package_not_allowed_scan_location(),
+        )
+
+    def test_set_destination_package_not_allowed_scan_location(self):
+        move_line = self.picking1.move_line_ids[0]
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.packing_location.barcode,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": False,
+            },
+        )
+        move_lines = self.service._find_location_move_lines()
+        move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
+        self.assert_response_select_line(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            move_lines=move_lines,
+            message=self.service.msg_store.confirm_pack_moved(),
+        )

--- a/shopfloor/tests/test_zone_picking_set_line_destination_package_not_allowed.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination_package_not_allowed.py
@@ -15,9 +15,14 @@ class ZonePickingSetLineDestinationPackageNotAllowedCase(ZonePickingCommonCase):
     def setUp(self):
         super().setUp()
         self.service.work.current_picking_type = self.picking1.picking_type_id
-        self.menu.sudo().allow_scan_destination_package = False
+        self.menu.sudo().allow_alternative_destination_package = False
 
-    def test_set_destination_package_not_allowed_scan_package(self):
+    def test_set_destination_alternative_package_not_allowed_scan_package_whole_qty(
+        self,
+    ):
+        # If option allow_alternative_destination_package is not allowed
+        # and the user scans a whole package,
+        # they should not be allowed to do the move.
         move_line = self.picking1.move_line_ids[0]
         response = self.service.dispatch(
             "set_destination",
@@ -34,10 +39,40 @@ class ZonePickingSetLineDestinationPackageNotAllowedCase(ZonePickingCommonCase):
             picking_type=self.picking_type,
             move_line=move_line,
             qty_done=10.0,
-            message=self.service.msg_store.package_not_allowed_scan_location(),
+            message=self.service.msg_store.package_transfer_not_allowed_scan_location(),
         )
 
-    def test_set_destination_package_not_allowed_scan_location(self):
+    def test_set_destination_alternative_package_not_allowed_scan_package_partial_qty(
+        self,
+    ):
+        # If option allow_alternative_destination_package is not allowed
+        # and the user scans a partial package,
+        # they should be allowed to do the move.
+        move_line = self.picking1.move_line_ids[0]
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.free_package.name,
+                "quantity": 1.0,
+                "confirmation": False,
+            },
+        )
+        move_lines = self.service._find_location_move_lines()
+        move_lines = move_lines.sorted(lambda l: l.move_id.priority, reverse=True)
+        self.assert_response_set_line_destination(
+            response,
+            zone_location=self.zone_location,
+            picking_type=self.picking_type,
+            move_line=move_line,
+            qty_done=1.0,
+            message=self.service.msg_store.package_transfer_not_allowed_scan_location(),
+        )
+
+    def test_set_destination_alternative_package_not_allowed_scan_location(self):
+        # If option allow_alternative_destination_package is not allowed,
+        # and the user scans a location,
+        # they should be allowed to do the move.
         move_line = self.picking1.move_line_ids[0]
         response = self.service.dispatch(
             "set_destination",

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -158,6 +158,16 @@
                   <field name="allow_return_is_possible" invisible="1" />
                   <field name="allow_return" />
               </group>
+              <group
+                    name="allow_scan_destination_package"
+                    attrs="{'invisible': [('allow_scan_destination_package_is_possible', '=', False)]}"
+                >
+                    <field
+                        name="allow_scan_destination_package_is_possible"
+                        invisible="1"
+                    />
+                    <field name="allow_scan_destination_package" />
+                </group>
             </group>
         </field>
     </record>

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -159,14 +159,14 @@
                   <field name="allow_return" />
               </group>
               <group
-                    name="allow_scan_destination_package"
-                    attrs="{'invisible': [('allow_scan_destination_package_is_possible', '=', False)]}"
+                    name="allow_alternative_destination_package"
+                    attrs="{'invisible': [('allow_alternative_destination_package_is_possible', '=', False)]}"
                 >
                     <field
-                        name="allow_scan_destination_package_is_possible"
+                        name="allow_alternative_destination_package_is_possible"
                         invisible="1"
                     />
-                    <field name="allow_scan_destination_package" />
+                    <field name="allow_alternative_destination_package" />
                 </group>
             </group>
         </field>

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -658,21 +658,50 @@ const ZonePicking = {
                     },
                 },
                 set_line_destination: {
+                    enter: () => {
+                        // When entering this screen, we show a different message if:
+                        // - We only allow scanning locations.
+                        // - We allow scanning locations and packages.
+                        const is_scan_package_allowed = this.state.data
+                            .allow_scan_destination_package;
+                        const placeholder = is_scan_package_allowed
+                            ? this.state.display_info.scan_placeholder_full
+                            : this.state.display_info.scan_placeholder_location;
+                        this.state.display_info.scan_placeholder = placeholder;
+                    },
                     display_info: {
                         title: "Set destination",
                         scan_placeholder: "Scan location or package",
                         scan_placeholder_full: "Scan location or package",
-                        scan_placeholder_partial: "Scan package",
+                        scan_placeholder_package: "Scan package",
+                        scan_placeholder_location: "Scan location",
                     },
                     events: {
                         qty_edit: "on_qty_update",
                     },
                     on_qty_update: (qty) => {
                         this.scan_destination_qty = parseInt(qty, 10);
-                        if (this.state.data.move_line.quantity != qty) {
-                            this.state.display_info.scan_placeholder = this.state.display_info.scan_placeholder_partial;
+
+                        // Display different placeholder messages (package / location / both).
+                        const is_scan_package_allowed = this.state.data
+                            .allow_scan_destination_package;
+                        const full_qty = this.state.data.move_line.quantity === qty;
+
+                        const display_info = this.state.display_info;
+                        if (!is_scan_package_allowed) {
+                            // Only locations are allowed.
+                            display_info.scan_placeholder =
+                                display_info.scan_placeholder_location;
                         } else {
-                            this.state.display_info.scan_placeholder = this.state.display_info.scan_placeholder_full;
+                            if (!full_qty) {
+                                // Only packages are allowed.
+                                display_info.scan_placeholder =
+                                    display_info.scan_placeholder_package;
+                            } else {
+                                // Both are allowed.
+                                display_info.scan_placeholder =
+                                    display_info.scan_placeholder_full;
+                            }
                         }
                     },
                     on_scan: (scanned) => {

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -663,7 +663,7 @@ const ZonePicking = {
                         // - We only allow scanning locations.
                         // - We allow scanning locations and packages.
                         const is_scan_package_allowed = this.state.data
-                            .allow_scan_destination_package;
+                            .allow_alternative_destination_package;
                         const placeholder = is_scan_package_allowed
                             ? this.state.display_info.scan_placeholder_full
                             : this.state.display_info.scan_placeholder_location;
@@ -684,7 +684,7 @@ const ZonePicking = {
 
                         // Display different placeholder messages (package / location / both).
                         const is_scan_package_allowed = this.state.data
-                            .allow_scan_destination_package;
+                            .allow_alternative_destination_package;
                         const full_qty = this.state.data.move_line.quantity === qty;
 
                         const display_info = this.state.display_info;


### PR DESCRIPTION
When scanning a source package in the zone picking scenario, we then have to scan either a destination location or a destination package.
However, scanning a destination package should be prevented if needed.

This PR adds an option to not allow scanning destination packages, prompting the user to scan a location instead.

ref: rau-167