### PR TITLE
[14.0][FIX] stock_warehouse_flow: fix RollbackException on write

### DIFF
--- a/stock_warehouse_flow/models/stock_warehouse_flow.py
+++ b/stock_warehouse_flow/models/stock_warehouse_flow.py
@@ -10,6 +10,10 @@ from odoo.tools.safe_eval import safe_eval
 logger = logging.getLogger(__name__)
 
 
+class ForceRollback(Exception):
+    pass
+
+
 class StockWarehouseFlow(models.Model):
     _name = "stock.warehouse.flow"
     _description = "Stock Warehouse Routing Flow"
@@ -297,14 +301,16 @@ class StockWarehouseFlow(models.Model):
                         }
                     )
                 wh_vals["out_type_id"] = self.to_picking_type_id.id
-                self.warehouse_id.write(wh_vals)
+                self.warehouse_id.with_context(do_not_check_quant=True).write(wh_vals)
                 vals = self.warehouse_id.delivery_route_id.copy_data()[0]
-                raise Exception()
-        except Exception:
+                raise ForceRollback()
+
+        except ForceRollback:
             logger.info(
                 f"Routing flow {self.name}: delivery route data generated "
                 f"from WH {self.warehouse_id.name}"
             )
+
         vals.update(
             {
                 "name": f"{self.warehouse_id.name}: {self.name}",


### PR DESCRIPTION
In order to avoid UserError (_('You still have some product in locations %s') coming from stock module https://github.com/odoo/odoo/blob/076baeacbbdf92ae1b500e6716fd95d32acc4a53/addons/stock/models/stock_location.py#L114

Plus, fixes the exception handling to get real exceptions that were badly catched.