### PR TITLE
[16.0][FIX] stock_available_to_promise_release: add tagged to test

### DIFF
--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -2,9 +2,10 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import fields
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
+@tagged("post_install", "-at_install")
 class PromiseReleaseCommonCase(common.TransactionCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
add tagged post_install and "-at_install to run the module test the last one