### PR TITLE
[14.0] shopfloor_mobile: display only qty reserved for picking in picking-detail

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/detail/detail_transfer.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_transfer.js
@@ -60,12 +60,12 @@ Vue.component("detail-transfer", {
                 },
                 {path: "lot.name", label: "Lot", action_val_path: "lot.name"},
                 {
-                    path: "product.qty_reserved",
+                    path: "quantity",
                     label: "Qty reserved",
                     render_component: "packaging-qty-picker-display",
                     render_props: function (record) {
                         return self.utils.wms.move_line_qty_picker_props(record, {
-                            qtyInit: record.product.qty_reserved,
+                            qtyInit: record.quantity,
                         });
                     },
                 },


### PR DESCRIPTION
The picking-detail component used to display the information of the picking was taking the "qty reserved" from the total amount of reserved qty for that product, regardless of the picking.

Now, we only display the reserved amount for the specific move.

ref: cos-4149