### PR TITLE
[14.0]  shopfloor_reception: take into account backorders qty done if auto_post is enabled

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -245,8 +245,8 @@ class DataAction(Component):
                     ("product_id", "=", record.product_id.id),
                 ]
             )
-            qty_done = sum(related_moves.mapped("quantity_done"))
-            data.update({"backorders_quantity_done": qty_done})
+            backorders_qty_done = sum(related_moves.mapped("quantity_done"))
+            data["quantity_done"] += backorders_qty_done
         return data
 
     def moves(self, records, **kw):

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -66,7 +66,6 @@ class ShopfloorSchemaAction(Component):
             "location_src": self._schema_dict_of(self.location()),
             "location_dest": self._schema_dict_of(self.location()),
             "progress": {"type": "float", "nullable": True},
-            "backorders_quantity_done": {"type": "float", "nullable": True},
         }
 
     def product(self):

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -66,6 +66,7 @@ class ShopfloorSchemaAction(Component):
             "location_src": self._schema_dict_of(self.location()),
             "location_dest": self._schema_dict_of(self.location()),
             "progress": {"type": "float", "nullable": True},
+            "backorders_quantity_done": {"type": "float", "nullable": True},
         }
 
     def product(self):

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -700,7 +700,14 @@ class Reception(Component):
             kw["with_progress"] = True
         data = self.data.picking(picking, **kw)
         if with_lines:
-            data.update({"moves": self._data_for_moves(picking.move_lines)})
+            data.update(
+                {
+                    "moves": self._data_for_moves(
+                        picking.move_lines,
+                        auto_post_enabled=self.work.menu.auto_post_line,
+                    )
+                }
+            )
         return data
 
     def _data_for_stock_pickings(self, pickings, with_lines=False):

--- a/shopfloor_reception/tests/common.py
+++ b/shopfloor_reception/tests/common.py
@@ -81,7 +81,7 @@ class CommonCase(BaseCommonCase):
         return res
 
     def _data_for_move(self, move):
-        return self.data.move(move)
+        return self.data.move(move, auto_post_enabled=self.menu.auto_post_line)
 
     def _data_for_moves(self, moves):
         res = []

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -17,6 +17,8 @@ class TestSelectLine(CommonCase):
         response = self.service.dispatch(
             "scan_line", params={"picking_id": picking.id, "barcode": "NOPE"}
         )
+        data = self.data.picking(picking, with_progress=True)
+        data.update({"moves": self._data_for_moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",
@@ -149,6 +151,8 @@ class TestSelectLine(CommonCase):
             params={"picking_id": picking.id, "barcode": self.product_c.barcode},
         )
         error_msg = "Product not found in the current transfer or already in a package."
+        data = self.data.picking(picking, with_progress=True)
+        data.update({"moves": self._data_for_moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",
@@ -169,6 +173,8 @@ class TestSelectLine(CommonCase):
         error_msg = (
             "Packaging not found in the current transfer or already in a package."
         )
+        data = self.data.picking(picking, with_progress=True)
+        data.update({"moves": self._data_for_moves(picking.move_lines)})
         self.assert_response(
             response,
             next_state="select_move",


### PR DESCRIPTION
For reception, in the select_move screen, we were displaying the qty done for each move in the picking.
However, this would always be 0 if auto posting was enabled.

Now, it will display the qty done for the move (if it hasn't been posted elsewhere) + the qty done for that product in all related backorders.

ref: rau-120