### PR TITLE
[14.0][FIX] shopfloor action validate_moves

### DIFF
--- a/shopfloor/tests/test_actions_stock.py
+++ b/shopfloor/tests/test_actions_stock.py
@@ -45,3 +45,8 @@ class TestActionsStock(CommonCase):
         self.assertTrue(self.picking.move_line_ids.shopfloor_user_id)
         self.assertFalse(picking_not_assigned.move_line_ids.shopfloor_user_id)
         self.assertFalse(picking_not_assigned.user_id)
+
+    def test_validate_moves(self):
+        # TODO: add test with a package with 2 products. Each product is
+        # reserved by a move but the moves are in different pickings
+        pass


### PR DESCRIPTION
When a package with 2 moves in 2 different pickings has to be replenished, then the 2 pickings must be validated together otherwise you get the error "You cannot move the same package content more than once in the same transfer or split the same package into two location".

cc @mt-software-de 