### PR TITLE
[14.0][IMP] shopfloor: do not compute move_line_count by default for package data

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -102,7 +102,7 @@ class DataAction(Component):
             ]
             operation_progress = self._get_operation_progress(domain)
             data.update({"operation_progress": operation_progress})
-        if data and picking:
+        if kw.get("with_package_move_line_count") and data and picking:
             move_line_count = self.env["stock.move.line"].search_count(
                 [
                     ("picking_id.picking_type_id", "=", picking.picking_type_id.id),

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -136,6 +136,7 @@ class Checkout(Component):
             packages.with_context(picking_id=picking.id).sorted(),
             picking=picking,
             with_packaging=True,
+            with_package_move_line_count=True,
         )
         return self._response(
             next_state="select_dest_package",

--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -83,6 +83,28 @@ class ActionsDataCase(ActionsDataCaseBase):
         expected = {
             "id": package.id,
             "name": package.name,
+            "packaging": self._expected_packaging(package.packaging_id),
+            "storage_type": self._expected_storage_type(
+                package.package_storage_type_id
+            ),
+            "weight": 20.0,
+        }
+        self.assertDictEqual(data, expected)
+
+    def test_data_package_with_move_line_count(self):
+        package = self.move_a.move_line_ids.package_id
+        package.packaging_id = self.packaging.id
+        package.package_storage_type_id = self.storage_type_pallet
+        data = self.data.package(
+            package,
+            picking=self.picking,
+            with_packaging=True,
+            with_package_move_line_count=True,
+        )
+        self.assert_schema(self.schema.package(with_packaging=True), data)
+        expected = {
+            "id": package.id,
+            "name": package.name,
             "move_line_count": 2,
             "packaging": self._expected_packaging(package.packaging_id),
             "storage_type": self._expected_storage_type(
@@ -202,14 +224,12 @@ class ActionsDataCase(ActionsDataCaseBase):
             "package_src": {
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
-                "move_line_count": 1,
                 "weight": 20.0,
                 "storage_type": None,
             },
             "package_dest": {
                 "id": result_package.id,
                 "name": result_package.name,
-                "move_line_count": 1,
                 "weight": 6.0,
                 "storage_type": None,
             },
@@ -218,6 +238,10 @@ class ActionsDataCase(ActionsDataCaseBase):
             "priority": "1",
             "progress": 30.0,
         }
+        self.assertDictEqual(data, expected)
+        data = self.data.move_line(move_line, with_package_move_line_count=True)
+        expected["package_src"]["move_line_count"] = 1
+        expected["package_dest"]["move_line_count"] = 1
         self.assertDictEqual(data, expected)
 
     def test_data_move_line_lot(self):
@@ -263,14 +287,12 @@ class ActionsDataCase(ActionsDataCaseBase):
             "package_src": {
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
-                "move_line_count": 2,
                 "weight": 30,
                 "storage_type": None,
             },
             "package_dest": {
                 "id": move_line.result_package_id.id,
                 "name": move_line.result_package_id.name,
-                "move_line_count": 2,
                 "weight": 0,
                 "storage_type": None,
             },
@@ -279,6 +301,11 @@ class ActionsDataCase(ActionsDataCaseBase):
             "priority": "1",
             "progress": 0.0,
         }
+        self.assertDictEqual(data, expected)
+        data = self.data.move_line(move_line, with_package_move_line_count=True)
+        self.assert_schema(self.schema.move_line(), data)
+        expected["package_src"]["move_line_count"] = 2
+        expected["package_dest"]["move_line_count"] = 2
         self.assertDictEqual(data, expected)
 
     def test_data_move_line_raw(self):

--- a/shopfloor/tests/test_actions_data_detail.py
+++ b/shopfloor/tests/test_actions_data_detail.py
@@ -80,7 +80,6 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "name": package.location_id.display_name,
             },
             "name": package.name,
-            "move_line_count": 2,
             "packaging": self.data_detail.packaging(package.packaging_id),
             "weight": 20.0,
             "pickings": self.data_detail.pickings(pickings),
@@ -90,6 +89,11 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "name": self.storage_type_pallet.name,
             },
         }
+        self.assertDictEqual(data, expected)
+        data = self.data_detail.package_detail(
+            package, picking=self.picking, with_package_move_line_count=True
+        )
+        expected.update({"move_line_count": 2})
         self.assertDictEqual(data, expected)
 
     def test_data_picking(self):
@@ -185,14 +189,12 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "package_src": {
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
-                "move_line_count": 1,
                 "weight": 20.0,
                 "storage_type": None,
             },
             "package_dest": {
                 "id": result_package.id,
                 "name": result_package.name,
-                "move_line_count": 1,
                 "weight": 6.0,
                 "storage_type": None,
             },
@@ -201,6 +203,10 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "priority": "1",
             "progress": 30.0,
         }
+        self.assertDictEqual(data, expected)
+        data = self.data_detail.move_line(move_line, with_package_move_line_count=True)
+        expected["package_src"]["move_line_count"] = 1
+        expected["package_dest"]["move_line_count"] = 1
         self.assertDictEqual(data, expected)
 
     def test_data_move_line_lot(self):
@@ -247,14 +253,12 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "package_src": {
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
-                "move_line_count": 2,
                 "weight": 30.0,
                 "storage_type": None,
             },
             "package_dest": {
                 "id": move_line.result_package_id.id,
                 "name": move_line.result_package_id.name,
-                "move_line_count": 2,
                 "weight": 0.0,
                 "storage_type": None,
             },
@@ -263,6 +267,10 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "priority": "1",
             "progress": 0.0,
         }
+        self.assertDictEqual(data, expected)
+        data = self.data_detail.move_line(move_line, with_package_move_line_count=True)
+        expected["package_src"]["move_line_count"] = 2
+        expected["package_dest"]["move_line_count"] = 2
         self.assertDictEqual(data, expected)
 
     def test_data_move_line_raw(self):

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -40,8 +40,10 @@ class CheckoutCommonCase(CommonCase):
     def _move_line_data(self, move_line):
         return self.data.move_line(move_line)
 
-    def _package_data(self, package, picking):
-        return self.data.package(package, picking=picking, with_packaging=True)
+    def _package_data(self, package, picking, **kwargs):
+        return self.data.package(
+            package, picking=picking, with_packaging=True, **kwargs
+        )
 
     def _packaging_data(self, packaging):
         return self.data.packaging(packaging)

--- a/shopfloor/tests/test_checkout_list_package.py
+++ b/shopfloor/tests/test_checkout_list_package.py
@@ -26,7 +26,9 @@ class SelectDestPackageMixin:
                 "picking": picking_data,
                 "packages": [
                     self._package_data(
-                        package.with_context(picking_id=picking.id), picking
+                        package.with_context(picking_id=picking.id),
+                        picking,
+                        with_package_move_line_count=True,
                     )
                     for package in packages
                 ],

--- a/shopfloor_dangerous_goods/tests/test_actions_data.py
+++ b/shopfloor_dangerous_goods/tests/test_actions_data.py
@@ -62,7 +62,6 @@ class ActionsDataBase(ActionsDataCaseBase):
         expected = {
             "id": package.id,
             "name": package.name,
-            "move_line_count": 2,
             "packaging": self._expected_packaging(package.packaging_id),
             "storage_type": self._expected_storage_type(
                 package.package_storage_type_id


### PR DESCRIPTION
If you want to get the data for a package it always computes the move_line_count.
This is very bad for example for the zone picking scenario where can have a long list of moves with packages.
Where this isn't used at all.

The only scenario which is using the move_line_count from the package data is the checkout.
So i think it is convenient to not compute it by default only if it is really needed.

~~The unittest are not updated for this fix yet.~~
cc @jbaudoux