### PR TITLE
[14.0][IMP] shopfloor: zone picking is package not valid

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -126,6 +126,14 @@ class MessageAction(Component):
             "body": _("Package {} is already used.").format(package.name),
         }
 
+    def package_different_picking_type(self, package, picking_type):
+        return {
+            "message_type": "warning",
+            "body": _(
+                "Package {} contains already lines from a different operation type {}"
+            ).format(package.name, picking_type.name),
+        }
+
     def dest_package_required(self):
         return {
             "message_type": "warning",


### PR DESCRIPTION
- a package is now also not valid if it already contains move lines from an other picking type

cc @jbaudoux 

Maybe we should consider to check the unload_package_at_destination configuration, 
because it only would make problems if there is a difference in the shopfloor menu configuration of unload_package_at_destination