### PR TITLE
[14.0][PERF] stock_available_to_promise_release priority

### DIFF
--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -6,6 +6,7 @@
     "version": "14.0.2.1.1",
     "summary": "Release Operations based on available to promise",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
+    "maintainers": ["jbaudoux"],
     "website": "https://github.com/OCA/wms",
     "category": "Stock Management",
     "depends": ["stock"],

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -514,7 +514,9 @@ class StockMove(models.Model):
         super()._assign_picking_post_process(new)
         priorities = self.mapped("move_dest_ids.picking_id.priority")
         if priorities:
-            self.picking_id.write({"priority": max(priorities)})
+            self.picking_id.with_context(tracking_disable=True).write(
+                {"priority": max(priorities)}
+            )
 
     def _get_chained_moves_iterator(self, chain_field):
         """Return an iterator on the moves of the chain.


### PR DESCRIPTION
Prevent odoo to try to compute if a state change must be tracked when the priority is changed. As many moves can be released at the same time this useless computation is not neglectable.

cc @mt-software-de 