### PR TITLE
[14.0][FIX] shopfloor zone picking set destination package concurent update

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -973,6 +973,7 @@ class ZonePicking(Component):
             )
             return (package_changed, response)
         stock = self._actions_for("stock")
+        self._lock_lines(move_line)
         try:
             stock.mark_move_line_as_picked(
                 move_line, quantity, package, check_user=True


### PR DESCRIPTION
The destination can be a location or a package.
When the destination is a location the lines are already locked by `write_destination_on_lines`.

But when the destination is a package, no locks were applied.

ref.: rau-204