### PR TITLE
[14.0][FIX] shopfloor_reception: Fix qty todo computation

### DIFF
--- a/shopfloor_base/tests/__init__.py
+++ b/shopfloor_base/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_actions_data
+from . import test_actions_lock
 from . import test_menu_service
 from . import test_profile_service
 from . import test_scan_anything_service

--- a/shopfloor_base/tests/test_actions_lock.py
+++ b/shopfloor_base/tests/test_actions_lock.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+from contextlib import closing
+
+from .common import CommonCase
+
+
+class ActionsLockCase(CommonCase):
+    @classmethod
+    def setUpClassBaseData(cls):
+        super().setUpClassBaseData()
+        cls.partner = cls.env.ref("base.res_partner_12")
+        with cls.work_on_actions(cls) as work:
+            cls.lock = work.component(usage="lock")
+
+    def test_select_for_update_skip_locked_ok(self):
+        """Check the lock is obtained and True is returned."""
+        result = self.lock.for_update(self.partner, skip_locked=True)
+        self.assertTrue(result)
+
+    def test_select_for_update_skip_locked_not_ok(self):
+        """Check the lock is NOT obtained and False is returned."""
+        with closing(self.registry.cursor()) as cr:
+            # Simulate another user locked a row
+            cr.execute(
+                "SELECT id FROM res_partner WHERE id=%s FOR UPDATE", (self.partner.id,)
+            )
+            result = self.lock.for_update(self.partner, skip_locked=True)
+            self.assertFalse(result)

--- a/shopfloor_reception/data/shopfloor_scenario_data.xml
+++ b/shopfloor_reception/data/shopfloor_scenario_data.xml
@@ -9,7 +9,8 @@
       <field name="options_edit">
 {
       "auto_post_line": true,
-      "allow_return": true
+      "allow_return": true,
+      "scan_location_or_pack_first": true
 }
       </field>
   </record>

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1301,6 +1301,17 @@ class Reception(Component):
         new_move._action_confirm(merge=False)
         new_move._recompute_state()
         new_move._action_assign()
+        # Set back the quantity to do on one of the lines
+        line = fields.first(
+            move.move_line_ids.filtered(
+                lambda line: line.state not in ("cancel", "done")
+            )
+        )
+        if line:
+            move_quantity = move.product_uom._compute_quantity(
+                move.product_uom_qty, line[0].product_uom_id
+            )
+            line.product_uom_qty = move_quantity
         move._recompute_state()
         new_move.extract_and_action_done()
 

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -257,12 +257,7 @@ class Reception(Component):
             )
         )
         if not line:
-            qty_todo_remaining = max(
-                0,
-                move.product_uom_qty
-                - sum(move.move_line_ids.mapped("product_uom_qty")),
-            )
-            values = move._prepare_move_line_vals(quantity=qty_todo_remaining)
+            values = move._prepare_move_line_vals()
             line = self.env["stock.move.line"].create(values)
         return self._scan_line__assign_user(picking, line, qty_done)
 
@@ -1249,6 +1244,7 @@ class Reception(Component):
         return self._response_for_set_destination(picking, selected_line)
 
     def _post_line(self, selected_line):
+        selected_line.product_uom_qty = selected_line.qty_done
         if (
             selected_line.picking_id.is_shopfloor_created
             and self.work.menu.allow_return

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1164,6 +1164,22 @@ class Reception(Component):
             )
         return self._response_for_set_quantity(picking, selected_line)
 
+    def set_quantity__cancel_action(self, picking_id, selected_line_id):
+        picking = self.env["stock.picking"].browse(picking_id)
+        selected_line = self.env["stock.move.line"].browse(selected_line_id)
+        message = self._check_picking_status(picking)
+        if message:
+            return self._response_for_set_quantity(
+                picking, selected_line, message=message
+            )
+        if selected_line.exists():
+            if selected_line.product_uom_qty:
+                stock = self._actions_for("stock")
+                stock.unmark_move_line_as_picked(selected_line)
+            else:
+                selected_line.unlink()
+        return self._response_for_select_move(picking)
+
     def _set_quantity__process__set_qty_and_split(self, picking, line, quantity):
         move = line.move_id
         sum(move.move_line_ids.mapped("qty_done"))
@@ -1442,6 +1458,16 @@ class ShopfloorReceptionValidator(Component):
             "confirmation": {"type": "string", "nullable": True},
         }
 
+    def set_quantity__cancel_action(self):
+        return {
+            "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
+            "selected_line_id": {
+                "coerce": to_int,
+                "type": "integer",
+                "required": True,
+            },
+        }
+
     def process_with_existing_pack(self):
         return {
             "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
@@ -1573,6 +1599,9 @@ class ShopfloorReceptionValidatorResponse(Component):
     def _set_quantity_next_states(self):
         return {"set_quantity", "select_move", "set_destination"}
 
+    def _set_quantity__cancel_action_next_states(self):
+        return {"set_quantity", "select_move"}
+
     def _set_destination_next_states(self):
         return {"set_destination", "select_move"}
 
@@ -1654,6 +1683,16 @@ class ShopfloorReceptionValidatorResponse(Component):
         }
 
     @property
+    def _schema_set_quantity__cancel_action(self):
+        return {
+            "selected_move_line": {
+                "type": "list",
+                "schema": {"type": "dict", "schema": self.schemas.move_line()},
+            },
+            "picking": {"type": "dict", "schema": self.schemas.picking()},
+        }
+
+    @property
     def _schema_set_destination(self):
         return {
             "selected_move_line": {
@@ -1729,6 +1768,11 @@ class ShopfloorReceptionValidatorResponse(Component):
 
     def set_quantity(self):
         return self._response_schema(next_states=self._set_quantity_next_states())
+
+    def set_quantity__cancel_action(self):
+        return self._response_schema(
+            next_states=self._set_quantity__cancel_action_next_states()
+        )
 
     def process_with_existing_pack(self):
         return self._response_schema(

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1283,10 +1283,12 @@ class Reception(Component):
             lambda line: line.state not in ("cancel", "done")
             and line.product_uom_qty > 0
         )
+        move = selected_line.move_id
+        lock = self._actions_for("lock")
+        lock.for_update(move)
         if lines_with_qty_todo:
             lines_with_qty_todo.product_uom_qty = 0
 
-        move = selected_line.move_id
         move_quantity = move.product_uom._compute_quantity(
             move.product_uom_qty, selected_line.product_uom_id
         )
@@ -1299,8 +1301,6 @@ class Reception(Component):
         new_move._action_confirm(merge=False)
         new_move._recompute_state()
         new_move._action_assign()
-        lock = self._actions_for("lock")
-        lock.for_update(move)
         move._recompute_state()
         new_move.extract_and_action_done()
 

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -137,12 +137,10 @@ class Reception(Component):
         return self._response_for_select_move(picking)
 
     def _response_for_select_move(self, picking, message=None):
-        self._assign_user_to_picking(picking)
         data = {"picking": self._data_for_stock_picking(picking, with_lines=True)}
         return self._response(next_state="select_move", data=data, message=message)
 
     def _response_for_confirm_done(self, picking, message=None):
-        self._assign_user_to_picking(picking)
         data = {"picking": self._data_for_stock_picking(picking, with_lines=True)}
         return self._response(next_state="confirm_done", data=data, message=message)
 
@@ -161,7 +159,6 @@ class Reception(Component):
     def _select_document_from_move_lines(self, move_lines, msg_func):
         pickings = move_lines.move_id.picking_id
         if len(pickings) == 1:
-            self._assign_user_to_picking(pickings)
             if (
                 move_lines.product_id.tracking not in ("lot", "serial")
                 or move_lines.lot_id
@@ -263,7 +260,6 @@ class Reception(Component):
 
     def _scan_line__assign_user(self, picking, line, qty_done):
         product = line.product_id
-        self._assign_user_to_picking(picking)
         self._assign_user_to_line(line)
         line.qty_done += qty_done
         if product.tracking not in ("lot", "serial") or (line.lot_id or line.lot_name):
@@ -328,7 +324,6 @@ class Reception(Component):
                 < today_end
             )
             if len(picking_filter_result_due_today) == 1:
-                self._assign_user_to_picking(picking_filter_result_due_today)
                 return self._select_picking(picking_filter_result_due_today)
             if len(picking_filter_result) > 1:
                 return self._response_for_select_document(
@@ -681,9 +676,6 @@ class Reception(Component):
             response = handler(*args, **kwargs)
             if response:
                 return response
-
-    def _assign_user_to_picking(self, picking):
-        picking.user_id = self.env.user
 
     def _assign_user_to_line(self, line):
         line.shopfloor_user_id = self.env.user
@@ -1404,7 +1396,6 @@ class Reception(Component):
                 return response
             return self._response_for_select_move(picking)
         message = self.msg_store.create_new_pack_ask_confirmation(barcode)
-        self._assign_user_to_picking(picking)
         return self._response_for_confirm_new_package(
             picking, selected_line, new_package_name=barcode, message=message
         )

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -851,7 +851,12 @@ class Reception(Component):
     def _scan_document__get_handlers_by_type(self):
         return {
             "picking": self._scan_document__by_picking,
-            "product": self._scan_document__by_product,
+            # only add the handler if scan_location_or_pack_first is disabled
+            "product": (
+                self._scan_document__by_product
+                if not self.work.menu.scan_location_or_pack_first
+                else None
+            ),
             "packaging": self._scan_document__by_packaging,
             "lot": self._scan_document__by_lot,
             "origin_move": self._scan_document__by_origin_move,

--- a/shopfloor_reception/tests/common.py
+++ b/shopfloor_reception/tests/common.py
@@ -138,3 +138,30 @@ class CommonCase(BaseCommonCase):
             ],
             order="scheduled_date ASC",
         )
+
+    def assertMessage(self, response, expected_message):
+        message = response.get("message")
+        for key, value in expected_message.items():
+            self.assertEqual(message.get(key), value)
+
+    @classmethod
+    def _get_move_ids_from_response(cls, response):
+        state = response.get("next_state")
+        data = response["data"][state]
+        picking_data = data.get("pickings") or [data.get("picking")]
+        moves_data = []
+        for picking in picking_data:
+            moves_data.extend(picking["moves"])
+        return [move["id"] for move in moves_data]
+
+    def _get_service_for_user(self, user):
+        user_env = self.env(user=user)
+        return self.get_service(
+            "reception", menu=self.menu, profile=self.profile, env=user_env
+        )
+
+    @classmethod
+    def _shopfloor_manager_values(cls):
+        vals = super()._shopfloor_manager_values()
+        vals["groups_id"] = [(6, 0, [cls.env.ref("stock.group_stock_user").id])]
+        return vals

--- a/shopfloor_reception/tests/test_return_scan_line.py
+++ b/shopfloor_reception/tests/test_return_scan_line.py
@@ -88,15 +88,18 @@ class TestScanLineReturn(CommonCaseReturn):
                 "barcode": self.product_a_packaging.barcode,
             },
         )
-        data = self.data.picking(return_picking)
         selected_move_line = self.get_new_move_lines()
+        move_line_data = self.data.move_lines(selected_move_line)
+        move_line_data[0]["quantity"] = 20.0
+        # Displayed qtu todo is modified by _align_display_product_uom_qty
+        data = self.data.picking(return_picking)
         self.assert_response(
             response,
             next_state="set_quantity",
             data={
                 "confirmation_required": None,
                 "picking": data,
-                "selected_move_line": self.data.move_lines(selected_move_line),
+                "selected_move_line": move_line_data,
             },
         )
         self.assertEqual(selected_move_line.qty_done, self.product_a_packaging.qty)

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -209,9 +209,20 @@ class TestSelectLine(CommonCase):
         self.assertEqual(other_move_line.shopfloor_user_id.id, False)
 
     def test_create_new_line_none_available(self):
-        # If all lines for a product are already assigned to a different user
-        # and there's still qty todo remaining
-        # a new line will be created for that qty todo.
+        # If there's already a move line for a given incoming move,
+        # we assigned the whole move's product_uom_qty to it.
+        # The reason for that is that when recomputing states for a given move
+        # if sum(move.move_line_ids.product_uom_qty) != move.product_uom_qty,
+        # then it's state won't be assigned.
+        # For instance:
+        #   - user 1 selects line1
+        #   - user 2 selected line1 too
+        #   - user 1 posts 20/40 goods
+        #   - user 2 tries to process any qty, and it fails, because posting
+        #     a move triggers the recompute of move's state
+        # To avoid that, the first created line gets
+        # product_uom_qty = move.product_uom_qty
+        # The next ones are getting 0.
         picking = self._create_picking()
         self.assertEqual(len(picking.move_line_ids), 2)
         selected_move_line = picking.move_line_ids.filtered(
@@ -233,9 +244,11 @@ class TestSelectLine(CommonCase):
                 "barcode": self.product_a.barcode,
             },
         )
+        # A new line has been created
         self.assertEqual(len(picking.move_line_ids), 3)
         created_line = picking.move_line_ids[2]
-        self.assertEqual(created_line.product_uom_qty, 7)
+        # And its product_uom_qty is 0
+        self.assertEqual(created_line.product_uom_qty, 0.0)
         self.assertEqual(created_line.shopfloor_user_id.id, self.env.uid)
 
     def test_done_action(self):

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -176,18 +176,6 @@ class TestSelectLine(CommonCase):
             message={"message_type": "warning", "body": error_msg},
         )
 
-    def test_assign_user_to_picking(self):
-        picking = self._create_picking()
-        self.assertEqual(picking.user_id.id, False)
-        self.service.dispatch(
-            "scan_line",
-            params={
-                "picking_id": picking.id,
-                "barcode": self.product_a.barcode,
-            },
-        )
-        self.assertEqual(picking.user_id.id, self.env.uid)
-
     def test_assign_shopfloor_user_to_line(self):
         picking = self._create_picking()
         for line in picking.move_line_ids:

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -145,11 +145,10 @@ class TestSetDestination(CommonCase):
         self.assertEqual(selected_move_line.picking_id.state, "done")
 
         # The line that remained in the original picking
-        # for that product has a product_uom_qty of 7
-        # and a qty_done of 0.
         line_in_picking = picking.move_line_ids.filtered(
             lambda l: l.product_id == selected_move_line.product_id
         )
-        self.assertEqual(line_in_picking.product_uom_qty, 7)
+        # New created line always quantity to do at zero
+        self.assertEqual(line_in_picking.product_uom_qty, 0)
         self.assertEqual(line_in_picking.qty_done, 0)
         self.assertEqual(picking.state, "assigned")

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -148,7 +148,54 @@ class TestSetDestination(CommonCase):
         line_in_picking = picking.move_line_ids.filtered(
             lambda l: l.product_id == selected_move_line.product_id
         )
-        # New created line always quantity to do at zero
-        self.assertEqual(line_in_picking.product_uom_qty, 0)
+        self.assertEqual(line_in_picking.product_uom_qty, 7)
         self.assertEqual(line_in_picking.qty_done, 0)
         self.assertEqual(picking.state, "assigned")
+
+    def test_auto_posting_concurent_work(self):
+        """Check 2 users working on the same move.
+
+        With the auto post line option On.
+
+        """
+        self.menu.sudo().auto_post_line = True
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        move = picking.move_lines
+        # User 1 starts working
+        service_u1 = self.service
+        res_u1 = service_u1.dispatch(
+            "manual_select_move",
+            params={"move_id": move.id},
+        )
+        # User 2 starts working on the same move
+        service_u2 = self._get_service_for_user(self.shopfloor_manager)
+        service_u2.dispatch(
+            "manual_select_move",
+            params={"move_id": move.id},
+        )
+        self.assertEqual(len(move.move_line_ids), 2)
+        # User 1 finishes his work
+        move_line_data = res_u1["data"]["set_quantity"]["selected_move_line"][0]
+        line_id_u1 = move_line_data["id"]
+        qty_done_u1 = move_line_data["qty_done"]
+        res_u1 = service_u1.dispatch(
+            "process_without_pack",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": line_id_u1,
+                "quantity": qty_done_u1,
+            },
+        )
+        res_u1 = service_u1.dispatch(
+            "set_destination",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": line_id_u1,
+                "location_name": self.dispatch_location.name,
+            },
+        )
+        # With the auto post line option
+        # The work done is moved and done in a specific transfer
+        self.assertEqual(picking.state, "assigned")
+        # So the quantity left to do on the current move has decreased
+        self.assertEqual(move.product_uom_qty, 9)

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -730,15 +730,13 @@ class TestSetQuantity(CommonCase):
         )
         # After move_line is posted, its state is done, and its qty_done is 1.0
         self.assertEqual(move_line_user_1.state, "done")
-
         # The remaining one is still to be done
-        self.assertEqual(move_line_user_2.state, "confirmed")
+        self.assertEqual(move_line_user_2.state, "assigned")
         # As well as the new one
         self.assertEqual(len(lines_after), 1)
-        # The total remaining qty to be done on line is always zero
-        # Because it is computed in the frontend
+        # The quantity to do is set on 1 of the lines
         self.assertEqual(lines_after.product_uom_qty, 0)
-        self.assertEqual(move_line_user_2.product_uom_qty, 0)
+        self.assertEqual(move_line_user_2.product_uom_qty, 9)
 
     def test_move_states(self):
         # as only assigned moves can be posted, we need to ensure that

--- a/shopfloor_reception/tests/test_set_quantity_action.py
+++ b/shopfloor_reception/tests/test_set_quantity_action.py
@@ -84,3 +84,93 @@ class TestSetQuantityAction(CommonCase):
             },
         )
         self.assertFalse(self.selected_move_line.result_package_id)
+
+    def test_cancel_action(self):
+        picking = self._create_picking()
+        move_product_a = picking.move_lines.filtered(
+            lambda l: l.product_id == self.product_a
+        )
+        # User 1 and 2 selects the same picking
+        service_user_1 = self.service
+        service_user_1.dispatch("scan_document", params={"barcode": picking.name})
+        user2 = self.shopfloor_manager
+        service_user_2 = self._get_service_for_user(user2)
+        response = service_user_2.dispatch(
+            "scan_document", params={"barcode": picking.name}
+        )
+        # both users selects the same move
+        service_user_1.dispatch(
+            "scan_line",
+            params={"picking_id": picking.id, "barcode": self.product_a.barcode},
+        )
+        move_line_user_1 = move_product_a.move_line_ids
+        service_user_2.dispatch(
+            "scan_line",
+            params={"picking_id": picking.id, "barcode": self.product_a.barcode},
+        )
+        move_line_user_2 = move_product_a.move_line_ids - move_line_user_1
+        # And both sets the qty done to 10
+        service_user_1.dispatch(
+            "set_quantity",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": move_line_user_1.id,
+                "quantity": 10,
+            },
+        )
+        service_user_2.dispatch(
+            "set_quantity",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": move_line_user_2.id,
+                "quantity": 10,
+            },
+        )
+        # Users are blocked, product_uom_qty is 10, but both users have qty_done=10
+        # on their move line, therefore, none of them can confirm
+        expected_message = {
+            "body": "You cannot process that much units.",
+            "message_type": "error",
+        }
+        response = service_user_1.dispatch(
+            "process_with_new_pack",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": move_line_user_1.id,
+                "quantity": 10.0,
+            },
+        )
+        self.assertMessage(response, expected_message)
+        response = service_user_2.dispatch(
+            "process_with_new_pack",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": move_line_user_2.id,
+                "quantity": 10.0,
+            },
+        )
+        self.assertMessage(response, expected_message)
+        # make user1 cancel
+        service_user_1.dispatch(
+            "set_quantity__cancel_action",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": move_line_user_1.id,
+            },
+        )
+        # Since we reused the move line created by odoo for the first user, we only
+        # reset the line
+        self.assertTrue(move_line_user_1.exists())
+        self.assertFalse(move_line_user_1.shopfloor_user_id)
+        self.assertEqual(move_line_user_1.qty_done, 0)
+        self.assertEqual(move_line_user_1.product_uom_qty, 10)
+        # make user cancel
+        service_user_2.dispatch(
+            "set_quantity__cancel_action",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": move_line_user_2.id,
+            },
+        )
+        # This line has been created by shopfloor, therefore, we unlinked it
+        self.assertFalse(move_line_user_2.exists())

--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -154,6 +154,9 @@ const Reception = {
                             <v-col class="text-center" cols="12">
                                 <btn-back/>
                             </v-col>
+                            <v-col class="text-center" cols="12">
+                                <cancel-button/>
+                            </v-col>
                         </v-row>
                     </div>
                 </div>

--- a/shopfloor_reception_mobile/static/src/scenario/reception_states.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception_states.js
@@ -171,6 +171,7 @@ export const reception_states = function () {
             events: {
                 qty_edit: "on_qty_edit",
                 go_back: "on_back",
+                cancel: "on_cancel",
             },
             on_qty_edit: (qty) => {
                 this.scan_destination_qty = parseInt(qty, 10);
@@ -188,14 +189,12 @@ export const reception_states = function () {
                 );
             },
             on_cancel: () => {
-                // TODO: this endpoing is currently missing in the backend,
-                // and it's currently in the roadmap.
-                // Once it's implemented, uncomment this call.
-                // this.wait_call(
-                //     this.odoo.call("cancel", {
-                //         package_level_id: this.state.data.id,
-                //     })
-                // );
+                this.wait_call(
+                    this.odoo.call("set_quantity__cancel_action", {
+                        picking_id: this.state.data.picking.id,
+                        selected_line_id: this.line_being_handled.id,
+                    })
+                );
             },
             on_add_to_existing_pack: () => {
                 this.wait_call(


### PR DESCRIPTION
We had a concurrent update introduced here https://github.com/OCA/wms/pull/672

Updating product uom qties were causing issues.
This is basically fixed by modifying the product_qty in responses instead of updating the move lines qties.