### PR TITLE
[14.0][FIX] shopfloor: fix bug in checkout if there are two lines with the same article

### DIFF
--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -970,6 +970,18 @@ class Checkout(Component):
             ),
         )
 
+    def _find_line_to_increment(self, product_lines):
+        """Find which line should have its qty incremented.
+
+        Return the first line for the scanned product
+        which still has some qty todo.
+        If none are found, return the first line for that product.
+        """
+        return next(
+            (line for line in product_lines if line.qty_done < line.product_uom_qty),
+            fields.first(product_lines),
+        )
+
     def _scan_package_action_from_product(
         self, picking, selected_lines, product, packaging=None, **kw
     ):
@@ -985,7 +997,7 @@ class Checkout(Component):
             return self._increment_custom_qty(
                 picking,
                 selected_lines,
-                fields.first(product_lines),
+                self._find_line_to_increment(product_lines),
                 quantity_increment,
             )
         return self._switch_line_qty_done(picking, selected_lines, product_lines)
@@ -1001,7 +1013,7 @@ class Checkout(Component):
         lot_lines = selected_lines.filtered(lambda l: l.lot_id == lot)
         if self.work.menu.no_prefill_qty:
             return self._increment_custom_qty(
-                picking, selected_lines, fields.first(lot_lines), 1
+                picking, selected_lines, self._find_line_to_increment(lot_lines), 1
             )
         return self._switch_line_qty_done(picking, selected_lines, lot_lines)
 

--- a/shopfloor/tests/test_checkout_scan_package_action_no_prefill_qty.py
+++ b/shopfloor/tests/test_checkout_scan_package_action_no_prefill_qty.py
@@ -38,6 +38,8 @@ class CheckoutScanPackageActionCaseNoPrefillQty(
         """Scan a product which is present in two lines.
 
         Only one line should have its quantity incremented.
+        If one line has been fully processed,
+        then the second line will have its quantity incremented.
 
         """
         picking = self._create_picking(
@@ -61,6 +63,20 @@ class CheckoutScanPackageActionCaseNoPrefillQty(
             move_lines,
             {move_lines[0]: 1, move_lines[1]: 0},
         )
+
+        # First line is fully processed,
+        # so we expect the second line to be incremented.
+        move_lines[0].qty_done = 3.0
+        self.service.dispatch(
+            "scan_package_action",
+            params={
+                "picking_id": picking.id,
+                "selected_line_ids": move_lines.ids,
+                "barcode": self.product_a.barcode,
+            },
+        )
+        self.assertEqual(move_lines[0].qty_done, 3.0)
+        self.assertEqual(move_lines[1].qty_done, 1.0)
 
     def test_scan_package_action_scan_lot_to_increment_qty(self):
         """ """


### PR DESCRIPTION
If you had the same article from on two different locations in the `select_package` screen, you were only able to increment the qty done of the first one when scanning a barcode.

Now, you will:
- Increment the first line that hasn't been fully processed yet (`qty_done < product_uom_qty`).
- If all lines have been processed, increment the first one found.

ref: rau-216