### PR TITLE
[14.0][FIX] stock_dynamic_routing: merge moves

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -486,8 +486,11 @@ class StockMove(models.Model):
     def _after_release_assign_moves(self):
         move_ids = []
         for origin_moves in self._get_chained_moves_iterator("move_orig_ids"):
-            move_ids += origin_moves.ids
-        self.env["stock.move"].browse(move_ids)._action_assign()
+            move_ids += origin_moves.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            ).ids
+        moves = self.browse(move_ids)
+        moves._action_assign()
 
     def _release_split(self, remaining_qty):
         """Split move and put remaining_qty to a backorder move."""

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -462,10 +462,10 @@ class StockMove(models.Model):
             )
         self.env["procurement.group"].run_defer(procurement_requests)
 
-        released_moves._after_release_assign_moves()
-        released_moves._after_release_update_chain()
+        assigned_moves = released_moves._after_release_assign_moves()
+        assigned_moves._after_release_update_chain()
 
-        return released_moves
+        return assigned_moves
 
     def _before_release(self):
         """Hook that aims to be overridden."""
@@ -491,6 +491,7 @@ class StockMove(models.Model):
             ).ids
         moves = self.browse(move_ids)
         moves._action_assign()
+        return moves
 
     def _release_split(self, remaining_qty):
         """Split move and put remaining_qty to a backorder move."""

--- a/stock_available_to_promise_release_dynamic_routing/__init__.py
+++ b/stock_available_to_promise_release_dynamic_routing/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_available_to_promise_release_dynamic_routing/__manifest__.py
+++ b/stock_available_to_promise_release_dynamic_routing/__manifest__.py
@@ -3,7 +3,8 @@
 {
     "name": "Available to Promise Release - Dynamic Routing",
     "summary": "Glue between moves release and dynamic routing",
-    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "author": "Camptocamp,BCIM,Odoo Community Association (OCA)",
+    "maintainers": ["jbaudoux"],
     "website": "https://github.com/OCA/wms",
     "category": "Warehouse Management",
     "version": "14.0.1.0.0",

--- a/stock_available_to_promise_release_dynamic_routing/models/__init__.py
+++ b/stock_available_to_promise_release_dynamic_routing/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_move

--- a/stock_available_to_promise_release_dynamic_routing/models/stock_move.py
+++ b/stock_available_to_promise_release_dynamic_routing/models/stock_move.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from itertools import groupby
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _after_release_assign_moves(self):
+        # Trigger the dynamic routing
+        moves = super()._after_release_assign_moves()
+        # Check if moves can be merged. We do this after the call to
+        # _action_assign in super as this could delete some records in self
+        sorted_moves_by_rule = sorted(moves, key=lambda m: m.picking_id.id)
+        moves_to_rereserve_ids = []
+        new_moves = self.browse()
+        for _picking_id, move_list in groupby(
+            sorted_moves_by_rule, key=lambda m: m.picking_id.id
+        ):
+            moves = self.browse(m.id for m in move_list)
+            merged_moves = moves._merge_moves()
+            new_moves |= merged_moves
+            if moves != merged_moves:
+                for move in merged_moves:
+                    if not move.quantity_done:
+                        moves_to_rereserve_ids.append(move.id)
+        if moves_to_rereserve_ids:
+            moves_to_rereserve = self.browse(moves_to_rereserve_ids)
+            moves_to_rereserve._do_unreserve()
+            moves_to_rereserve.with_context(
+                exclude_apply_dynamic_routing=True
+            )._action_assign()
+        return new_moves

--- a/stock_available_to_promise_release_dynamic_routing/readme/CONTRIBUTORS.rst
+++ b/stock_available_to_promise_release_dynamic_routing/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * `Trobz <https://trobz.com>`_:
   * Dung Tran <dungtd@trobz.com>


### PR DESCRIPTION
When a move is reassigned to a different picking, we need to try to merge it with another pre-existing move. Exactly like what odoo standard is doing when you confirm a new move inside a picking.

cc @mt-software-de @TDu @sebalix @mmequignon 

TODO: add a unit test for this case