### PR TITLE
[14.0][FIX] shopfloor_single_product_transfer - set destination before posting

### DIFF
--- a/shopfloor_single_product_transfer/services/single_product_transfer.py
+++ b/shopfloor_single_product_transfer/services/single_product_transfer.py
@@ -690,7 +690,6 @@ class ShopfloorSingleProductTransfer(Component):
     def _set_quantity__by_location_handlers(self):
         return [
             self._set_quantity__check_location,
-            self._set_quantity__post_move,
         ]
 
     def _set_quantity__by_location(self, move_line, location, confirmation=False):
@@ -706,6 +705,7 @@ class ShopfloorSingleProductTransfer(Component):
         )
         if response:
             return response
+        return self._set_quantity__post_move(move_line, location)
 
     def _set_quantity__by_package(self, move_line, package, confirmation=False):
         # We're about to leave the `set_quantity` screen.
@@ -720,8 +720,10 @@ class ShopfloorSingleProductTransfer(Component):
             response = self._use_handlers(
                 handlers, move_line, location, confirmation=confirmation
             )
+            if response:
+                return response
             move_line.result_package_id = package
-            return response
+            return self._set_quantity__post_move(move_line, location)
         # Else, go to `set_location` screen
         move_line.result_package_id = package
         return self._response_for_set_location(move_line, package)

--- a/shopfloor_single_product_transfer/tests/test_set_quantity.py
+++ b/shopfloor_single_product_transfer/tests/test_set_quantity.py
@@ -750,6 +750,8 @@ class TestSetQuantity(CommonCase):
             message=expected_message,
             popup=expected_popup,
         )
+        # We moved 10 units to an existing package
+        self.assertEqual(package.quant_ids.quantity, 20.0)
         self.assertEqual(package, move_line.result_package_id)
 
     def test_set_quantity_scan_package_empty(self):


### PR DESCRIPTION
We have to set the destination before posting the move.

ping @jbaudoux @mt-software-de 

customer ref: 11061