### PR TITLE
[14.0][FIX] shopfloor: fix scan anything for packaging

### DIFF
--- a/shopfloor/components/scan_handler_product.py
+++ b/shopfloor/components/scan_handler_product.py
@@ -16,6 +16,8 @@ class ProductHandler(Component):
 
     def search(self, identifier):
         res = self._search.find(identifier, types=("product", "packaging"))
+        if res.record and res.type == "packaging":
+            return res.record.product_id
         return res.record if res.record else self.env["product.product"]
 
     @property

--- a/shopfloor/tests/test_scan_anything.py
+++ b/shopfloor/tests/test_scan_anything.py
@@ -47,3 +47,10 @@ class ScanAnythingCase(ActionsDataDetailCaseBase, ScanAnythingTestMixin):
         identifier = record.name
         data = self.data_detail.picking_detail(record)
         self._test_response_ok(rec_type, data, identifier)
+
+    def test_scan_packaging(self):
+        record = self.product_a_packaging
+        rec_type = "product"
+        identifier = record.barcode
+        data = self.data_detail.product_detail(record.product_id)
+        self._test_response_ok(rec_type, data, identifier)


### PR DESCRIPTION
When scanning a packaging barcode, the backend crashes because it tries to generate the data for a packaging using the function designed for products.

I guess it is by design that when scanning a packaging barcode, it is its content (the product) that is returned to the frontend.

ref.: rau-232