### PR TITLE
[14.0][IMP] shopfloor: imp cancel on single pack transfer

### DIFF
--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -283,6 +283,12 @@ class SinglePackTransfer(Component):
             return self._response_for_start(message=self.msg_store.already_done())
 
         package_level.is_done = False
+        if package_level.picking_id.create_uid == self.env.user:
+            # Cancel the transfer when it has been created by the shopfloor user
+            moves._do_unreserve()
+            moves._recompute_state()
+            moves.picking_id.action_cancel()
+
         return self._response_for_start(
             message=self.msg_store.confirm_canceled_scan_next_pack()
         )

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -283,11 +283,16 @@ class SinglePackTransfer(Component):
             return self._response_for_start(message=self.msg_store.already_done())
 
         package_level.is_done = False
-        if package_level.picking_id.create_uid == self.env.user:
+        if (
+            self.is_allow_move_create()
+            and package_level.picking_id.create_uid == self.env.user
+        ):
             # Cancel the transfer when it has been created by the shopfloor user
-            moves._do_unreserve()
-            moves._recompute_state()
             moves.picking_id.action_cancel()
+        else:
+            # Not owned only unassign the user
+            stock = self._actions_for("stock")
+            stock.unmark_move_line_as_picked(moves.move_line_ids)
 
         return self._response_for_start(
             message=self.msg_store.confirm_canceled_scan_next_pack()

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -803,6 +803,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         # setup the picking as we need, like if the move line
         # was already started by the first step (start operation)
         package_level = self._simulate_started(self.pack_a)
+        self.menu.sudo().allow_move_create = True
         self.env.user = self.shopfloor_manager
         self.assertTrue(package_level.is_done)
 
@@ -816,8 +817,8 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         )
         self.assertRecordValues(move, [{"state": "assigned"}])
         self.assertRecordValues(picking, [{"state": "assigned"}])
-        self.assertRecordValues(package_level, [{"is_done": False}])
-
+        self.assertTrue(move.move_line_ids.exists())
+        self.assertFalse(move.move_line_ids.shopfloor_user_id)
         self.assert_response(
             response,
             next_state="start",
@@ -841,6 +842,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         * The package level has is_done to False
         * The move and picking are canceled.
         """
+        self.menu.sudo().allow_move_create = True
         # setup the picking as we need, like if the move line
         # was already started by the first step (start operation)
         package_level = self._simulate_started(self.pack_a)

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -787,8 +787,10 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
             [{"location_dest_id": self.shelf2.id, "state": "done"}],
         )
 
-    def test_cancel(self):
+    def test_cancel_transfer_not_created_by_user(self):
         """Test the happy path for single pack transfer /cancel endpoint
+
+        The transfer was not created by the shopfloor user.
 
         The pre-conditions:
 
@@ -797,6 +799,47 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         Expected result:
 
         * The package level has is_done to False
+        """
+        # setup the picking as we need, like if the move line
+        # was already started by the first step (start operation)
+        package_level = self._simulate_started(self.pack_a)
+        self.env.user = self.shopfloor_manager
+        self.assertTrue(package_level.is_done)
+
+        # keep references for later checks
+        move = package_level.move_line_ids.move_id
+        picking = move.picking_id
+
+        # now, call the service to cancel
+        response = self.service.dispatch(
+            "cancel", params={"package_level_id": package_level.id}
+        )
+        self.assertRecordValues(move, [{"state": "assigned"}])
+        self.assertRecordValues(picking, [{"state": "assigned"}])
+        self.assertRecordValues(package_level, [{"is_done": False}])
+
+        self.assert_response(
+            response,
+            next_state="start",
+            message={
+                "message_type": "success",
+                "body": "Canceled, you can scan a new pack.",
+            },
+        )
+
+    def test_cancel_transfer_created_by_user(self):
+        """Test the happy path for single pack transfer /cancel endpoint
+
+        The transfer was created by the shopfloor user.
+
+        The pre-conditions:
+
+        * /start has been called
+
+        Expected result:
+
+        * The package level has is_done to False
+        * The move and picking are canceled.
         """
         # setup the picking as we need, like if the move line
         # was already started by the first step (start operation)
@@ -811,8 +854,8 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         response = self.service.dispatch(
             "cancel", params={"package_level_id": package_level.id}
         )
-        self.assertRecordValues(move, [{"state": "assigned"}])
-        self.assertRecordValues(picking, [{"state": "assigned"}])
+        self.assertRecordValues(move, [{"state": "cancel"}])
+        self.assertRecordValues(picking, [{"state": "cancel"}])
         self.assertRecordValues(package_level, [{"is_done": False}])
 
         self.assert_response(


### PR DESCRIPTION
Before the package level was only set as not done, when calling the cancel route.

Now if the package level has been created by the
current shopfloor user, its related transfer is also canceled.

ref.: rau-229