### PR TITLE
[FIX] stock_storage_type: fix max_weight references

### DIFF
--- a/stock_storage_type/demo/product_packaging.xml
+++ b/stock_storage_type/demo/product_packaging.xml
@@ -19,6 +19,6 @@
         <field name="packaging_length">1200</field>
         <field name="width">800</field>
         <field name="height">1500</field>
-        <field name="max_weight">60</field>
+        <field name="weight">60</field>
     </record>
 </odoo>

--- a/stock_storage_type/i18n/it.po
+++ b/stock_storage_type/i18n/it.po
@@ -529,7 +529,7 @@ msgid ""
 "Storage Category {storage_category} defines max height of {max_h} but the "
 "package is bigger: {height}."
 msgstr ""
-"La categoria stccaggio {storage_category} ha una altezza massima di {max_h} "
+"La categoria stoccaggio {storage_category} ha una altezza massima di {max_h} "
 "ma il pacco è più grande: {height}."
 
 #. module: stock_storage_type
@@ -540,7 +540,7 @@ msgid ""
 "Storage Category {storage_category} defines max weight of {max_w} but the "
 "package is heavier: {weight_kg}."
 msgstr ""
-"La categoria stccaggio {storage_category} ha un peso massimo di {max_h} ma "
+"La categoria stoccaggio {storage_category} ha un peso massimo di {max_w} ma "
 "il pacco è più pesante: {weight_kg}."
 
 #. module: stock_storage_type


### PR DESCRIPTION
There are 2 issues come out related 2 commits recently:
- stock_storage_type/i18n/it.po:539 Translation string couldn't be parsed correctly using str.format KeyError('max_h') - [po-python-parse-format]:
  - https://github.com/OCA/wms/commit/ec3b031b2f4c5f9456e9b3a4b249b8a2ea24a5b0#diff-08494f72247cee4b042e36b2ef54fcc955ffbff080c17c7b36184b81f37ca409R543
- ValueError: Invalid field 'max_weight' on model 'product.packaging'
   - https://github.com/OCA/product-attribute/commit/e44cd81ef2198eb5dd7d0bd02d081518a1feec37
