### PR TITLE
[16.0][FIX] stock_release_channel: Allow to see inactive partners

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -208,6 +208,7 @@ class StockReleaseChannel(models.Model):
         column1="channel_id",
         column2="partner_id",
         string="Partners",
+        context={"active_test": False},
     )
 
     @api.depends("state")


### PR DESCRIPTION
As the filter to assign channel will take into account void partner_ids field (allow all) or filled in (allow only those ones), the resulting query take into account inactive partners. Debug is difficult as form will show void partners even if relation table contain records.