### PR TITLE
[14.0][FIX] shopfloor_mobile_base: fix searchbar focus

### DIFF
--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -7,6 +7,8 @@
 import {ScenarioBaseMixin} from "/shopfloor_mobile_base/static/wms/src/scenario/mixins.js";
 import {process_registry} from "/shopfloor_mobile_base/static/wms/src/services/process_registry.js";
 
+// TODO: consider replacing the dynamic "autofocus" in the searchbar by an event.
+// At the moment, we need autofocus to be disabled if there's a user popup.
 const ClusterPicking = {
     mixins: [ScenarioBaseMixin],
     template: `
@@ -18,6 +20,7 @@ const ClusterPicking = {
                 v-if="state.on_scan"
                 v-on:found="on_scan"
                 :input_placeholder="search_input_placeholder"
+                :autofocus="!screen_info.user_popup"
                 />
             <get-work
                 v-if="state_is('start')"

--- a/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/location_content_transfer.js
@@ -7,6 +7,8 @@
 import {ScenarioBaseMixin} from "/shopfloor_mobile_base/static/wms/src/scenario/mixins.js";
 import {process_registry} from "/shopfloor_mobile_base/static/wms/src/services/process_registry.js";
 
+// TODO: consider replacing the dynamic "autofocus" in the searchbar by an event.
+// At the moment, we need autofocus to be disabled if there's a user popup.
 const LocationContentTransfer = {
     mixins: [ScenarioBaseMixin],
     template: `
@@ -18,6 +20,7 @@ const LocationContentTransfer = {
                 v-if="state.on_scan"
                 v-on:found="on_scan"
                 :input_placeholder="search_input_placeholder"
+                :autofocus="!screen_info.user_popup"
                 />
             <template v-if="state_in(['scan_location']) && state.data.location">
                 <item-detail-card

--- a/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
+++ b/shopfloor_mobile/static/wms/src/scenario/single_pack_transfer.js
@@ -60,6 +60,8 @@ export var SinglePackStatesMixin = {
     },
 };
 
+// TODO: consider replacing the dynamic "autofocus" in the searchbar by an event.
+// At the moment, we need autofocus to be disabled if there's a user popup.
 const SinglePackTransfer = {
     mixins: [ScenarioBaseMixin, SinglePackStatesMixin],
     template: `
@@ -67,8 +69,19 @@ const SinglePackTransfer = {
             <template v-slot:header>
                 <state-display-info :info="state.display_info" v-if="state.display_info"/>
             </template>
-            <searchbar v-if="state_is(initial_state_key)" v-on:found="on_scan" :input_placeholder="search_input_placeholder"></searchbar>
-            <searchbar v-if="state_is('scan_location')" v-on:found="on_scan" :input_placeholder="search_input_placeholder" :input_data_type="'location'"></searchbar>
+            <searchbar
+                v-if="state_is(initial_state_key)"
+                v-on:found="on_scan"
+                :autofocus="!screen_info.user_popup"
+                :input_placeholder="search_input_placeholder"
+            ></searchbar>
+            <searchbar
+                v-if="state_is('scan_location')"
+                v-on:found="on_scan"
+                :autofocus="!screen_info.user_popup"
+                :input_placeholder="search_input_placeholder"
+                :input_data_type="'location'"
+            ></searchbar>
             <div v-if="state.key != 'show_completion_info' && _.result(state, 'data.picking')">
                 <item-detail-card
                     :key="make_state_component_key(['package', state.data.id])"

--- a/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/zone_picking.js
@@ -7,6 +7,8 @@
 import {ScenarioBaseMixin} from "/shopfloor_mobile_base/static/wms/src/scenario/mixins.js";
 import {process_registry} from "/shopfloor_mobile_base/static/wms/src/services/process_registry.js";
 
+// TODO: consider replacing the dynamic "autofocus" in the searchbar by an event.
+// At the moment, we need autofocus to be disabled if there's a user popup.
 const template_mobile = `
     <Screen :screen_info="screen_info">
         <template v-slot:header>
@@ -16,6 +18,7 @@ const template_mobile = `
             v-if="state.on_scan"
             v-on:found="on_scan"
             :input_placeholder="search_input_placeholder"
+            :autofocus="!screen_info.user_popup"
             />
 
         <div v-if="state_is('scan_location')">

--- a/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
+++ b/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
@@ -115,7 +115,15 @@ export var Searchbar = Vue.component("searchbar", {
     },
     methods: {
         capture_focus: function () {
-            if (this.autofocus) this.$refs.searchbar.focus();
+            if (this.autofocus && this.$refs.searchbar) {
+                // We need to use both "focus" and "click" in combination
+                // to make sure that the searchbar is fully focused and ready for scanning
+                // without having to manually tap on it.
+                // Using simply one or the other is not enough
+                // to always be able to input any scanned text.
+                this.$refs.searchbar.focus();
+                this.$refs.searchbar.click();
+            }
         },
         show_virtual_keyboard: function (elem) {
             elem.inputMode = this.input_inputmode;


### PR DESCRIPTION
The searchbar wasn't always ready for scanned inputs unless the user manually clicked on it.
Using `focus()` is not enough, but combining it with `click()` did work in our tests.

ref: cos-4175  & cos-4242