### PR TITLE
[14.0][IMP] shopfloor: add decorator to gracefully handle exceptions on response

### DIFF
--- a/setup/shopfloor_location_package_restriction/odoo/addons/shopfloor_location_package_restriction
+++ b/setup/shopfloor_location_package_restriction/odoo/addons/shopfloor_location_package_restriction
@@ -1,0 +1,1 @@
+../../../../shopfloor_location_package_restriction

--- a/setup/shopfloor_location_package_restriction/setup.py
+++ b/setup/shopfloor_location_package_restriction/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -6,6 +6,7 @@ from odoo import fields
 
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
+from odoo.addons.shopfloor_base.utils import catch_errors
 
 
 class SinglePackTransfer(Component):
@@ -205,10 +206,18 @@ class SinglePackTransfer(Component):
     def _is_move_state_valid(self, moves):
         return all(move.state != "cancel" for move in moves)
 
+    def _validate_catch_error(
+        self, package_level_id, location_barcode, confirmation=False, message=None
+    ):
+        package_level = self.env["stock.package_level"].browse(package_level_id)
+        return self._response_for_scan_location(
+            package_level, message=message, confirmation_required=confirmation
+        )
+
+    @catch_errors(_validate_catch_error)
     def validate(self, package_level_id, location_barcode, confirmation=False):
         """Validate the transfer"""
         search = self._actions_for("search")
-
         package_level = self.env["stock.package_level"].browse(package_level_id)
         if not package_level.exists():
             return self._response_for_start(

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -2,8 +2,6 @@
 # Copyright 2020 Akretion (http://www.akretion.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import Form
-
 from .test_single_pack_transfer_base import SinglePackTransferCommonBase
 
 
@@ -45,22 +43,6 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         cls.picking = cls._create_initial_move(
             lines=[(cls.product_a, 1), (cls.product_b, 1)]
         )
-
-    @classmethod
-    def _create_initial_move(cls, lines):
-        """Create the move to satisfy the pre-condition before /start"""
-        picking_form = Form(cls.env["stock.picking"])
-        picking_form.picking_type_id = cls.picking_type
-        picking_form.location_id = cls.stock_location
-        picking_form.location_dest_id = cls.shelf2
-        for line in lines:
-            with picking_form.move_ids_without_package.new() as move:
-                move.product_id = line[0]
-                move.product_uom_qty = line[1]
-        picking = picking_form.save()
-        picking.action_confirm()
-        picking.action_assign()
-        return picking
 
     def _simulate_started(self, package):
         """Replicate what the /start endpoint would do on the given package.

--- a/shopfloor/tests/test_single_pack_transfer_base.py
+++ b/shopfloor/tests/test_single_pack_transfer_base.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # Copyright 2020 Akretion (http://www.akretion.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import Form
+
 from .common import CommonCase
 
 
@@ -28,3 +30,19 @@ class SinglePackTransferCommonBase(CommonCase):
         self.service = self.get_service(
             "single_pack_transfer", menu=self.menu, profile=self.profile
         )
+
+    @classmethod
+    def _create_initial_move(cls, lines):
+        """Create the move to satisfy the pre-condition before /start"""
+        picking_form = Form(cls.env["stock.picking"])
+        picking_form.picking_type_id = cls.picking_type
+        picking_form.location_id = cls.stock_location
+        picking_form.location_dest_id = cls.shelf2
+        for line in lines:
+            with picking_form.move_ids_without_package.new() as move:
+                move.product_id = line[0]
+                move.product_uom_qty = line[1]
+        picking = picking_form.save()
+        picking.action_confirm()
+        picking.action_assign()
+        return picking

--- a/shopfloor_base/utils.py
+++ b/shopfloor_base/utils.py
@@ -43,15 +43,18 @@ def catch_errors(response_error):
 
     def _catch_errors(fn):
         @wraps(fn)
-        def wrapper(*args, **kwargs):
+        def wrapper(self, *args, **kwargs):
+            savepoint = self._actions_for("savepoint").new()
             try:
-                res = fn(*args, **kwargs)
+                res = fn(self, *args, **kwargs)
             except ValidationError as ex:
+                savepoint.rollback()
                 message = {
                     "message_type": "error",
                     "body": ex.name,
                 }
-                return response_error(*args, **kwargs, message=message)
+                return response_error(self, *args, **kwargs, message=message)
+            savepoint.release()
             return res
 
         return wrapper

--- a/shopfloor_location_package_restriction/__manifest__.py
+++ b/shopfloor_location_package_restriction/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "Shopfloor Location Package Restriction",
+    "summary": "Glue module between shopfloor and location package restriction",
+    "version": "14.0.1.0.0",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "shopfloor",
+        # OCA/stock-logistics-warehouse
+        "stock_location_package_restriction",
+    ],
+    "auto_install": True,
+}

--- a/shopfloor_location_package_restriction/readme/CONTRIBUTORS.rst
+++ b/shopfloor_location_package_restriction/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/shopfloor_location_package_restriction/readme/DESCRIPTION.rst
+++ b/shopfloor_location_package_restriction/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+Glue module between `shopfloor` and `stock_location_package_restriction`.
+It allows to send proper error message to the frontend instead of a stack
+trace error being displayed.
+
+Finally his only use is to test.
+
+Should be removed.

--- a/shopfloor_location_package_restriction/tests/__init__.py
+++ b/shopfloor_location_package_restriction/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_single_pack_transfer_force_package
+from . import test_zone_picking_force_package

--- a/shopfloor_location_package_restriction/tests/test_single_pack_transfer_force_package.py
+++ b/shopfloor_location_package_restriction/tests/test_single_pack_transfer_force_package.py
@@ -1,0 +1,69 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.shopfloor.tests.test_single_pack_transfer_base import (
+    SinglePackTransferCommonBase,
+)
+
+
+class TestSinglePackTransferForcePackage(SinglePackTransferCommonBase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Prepare the pack and related picking has started
+        cls.pack_a = cls.env["stock.quant.package"].create(
+            {"location_id": cls.stock_location.id}
+        )
+        cls.quant_a = (
+            cls.env["stock.quant"]
+            .sudo()
+            .create(
+                {
+                    "product_id": cls.product_a.id,
+                    "location_id": cls.shelf1.id,
+                    "quantity": 1,
+                    "package_id": cls.pack_a.id,
+                }
+            )
+        )
+        cls.picking = cls._create_initial_move(lines=[(cls.product_a, 1)])
+        cls.move_line = cls.picking.move_line_ids
+        cls.package_level = cls.move_line.package_level_id
+        cls.package_level.is_done = True
+        cls.picking.move_line_ids.qty_done = 1
+        # Add restriction on destination location
+        cls.shelf2.sudo().package_restriction = "singlepackage"
+        # Add a package on the destination location
+        cls.pack_1 = cls.env["stock.quant.package"].create(
+            {"location_id": cls.shelf2.id}
+        )
+        cls._update_qty_in_location(
+            cls.shelf2,
+            cls.product_a,
+            1,
+            package=cls.pack_1,
+        )
+
+    def test_scan_location_has_restrictions(self):
+        """ """
+        response = self.service.dispatch(
+            "validate",
+            params={
+                "package_level_id": self.package_level.id,
+                "location_barcode": self.shelf2.barcode,
+            },
+        )
+        message = {
+            "message_type": "error",
+            "body": (
+                f"Only one package is allowed on the location "
+                f"{self.shelf2.display_name}.You cannot add "
+                f"the {self.move_line.package_id.name}, there is already {self.pack_1.name}."
+            ),
+        }
+        self.assert_response(
+            response,
+            next_state="scan_location",
+            data=self.ANY,
+            message=message,
+        )

--- a/shopfloor_location_package_restriction/tests/test_zone_picking_force_package.py
+++ b/shopfloor_location_package_restriction/tests/test_zone_picking_force_package.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.shopfloor.tests.test_zone_picking_base import ZonePickingCommonCase
+
+
+class TestZonePickingForcePackage(ZonePickingCommonCase):
+    def setUp(self):
+        super().setUp()
+        self.service.work.current_picking_type = self.picking1.picking_type_id
+
+    def test_set_destination_location_package_restriction(self):
+        """Check error restriction on location is properly forwarded to frontend."""
+        # Add a restriction on the location
+        self.packing_location.sudo().package_restriction = "singlepackage"
+        # Add a first package on the location
+        self.pack_1 = self.env["stock.quant.package"].create(
+            {"location_id": self.packing_location.id}
+        )
+        self._update_qty_in_location(
+            self.packing_location, self.product_a, 1, package=self.pack_1
+        )
+        picking_type = self.picking1.picking_type_id
+        move_line = self.picking1.move_lines.move_line_ids
+        move_line.qty_done = move_line.product_uom_qty
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "move_line_id": move_line.id,
+                "barcode": self.packing_location.barcode,
+                "quantity": move_line.product_uom_qty,
+                "confirmation": False,
+            },
+        )
+        message = {
+            "message_type": "error",
+            "body": (
+                f"Only one package is allowed on the location "
+                f"{self.packing_location.display_name}.You cannot add "
+                f"the {move_line.package_id.name}, there is already {self.pack_1.name}."
+            ),
+        }
+        self.assert_response_set_line_destination(
+            response,
+            self.zone_location,
+            picking_type,
+            move_line,
+            message=message,
+            qty_done=10.0,
+        )


### PR DESCRIPTION
This PR adds a decorator that can be used on any endpoint to catch some exceptions and return to the user a clean error message and not a 500 error message.

This is to solve the problem discussed on https://github.com/OCA/wms/pull/732