### PR TITLE
[IMP] stock_available_to_promise_release: Make previous sql hookable

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -146,28 +146,39 @@ class StockMove(models.Model):
             GROUP BY move.id;
         """
 
+    def _previous_promised_qty_sql_moves_before_matches(self):
+        return "COALESCE(m.need_release, False) = COALESCE(move.need_release, False)"
+
     def _previous_promised_qty_sql_moves_before(self):
         sql = """
-            m.priority > move.priority
-            OR
-            (
-                m.priority = move.priority
-                AND m.date_priority < move.date_priority
+            {moves_matches}
+            AND (
+                m.priority > move.priority
+                OR
+                (
+                    m.priority = move.priority
+                    AND m.date_priority < move.date_priority
+                )
+                OR (
+                    m.priority = move.priority
+                    AND m.date_priority = move.date_priority
+                    AND m.picking_type_id = move.picking_type_id
+                    AND m.id < move.id
+                )
+                OR (
+                    m.priority = move.priority
+                    AND m.date_priority = move.date_priority
+                    AND m.picking_type_id != move.picking_type_id
+                    AND m.id > move.id
+                )
             )
-            OR (
-                m.priority = move.priority
-                AND m.date_priority = move.date_priority
-                AND m.picking_type_id = move.picking_type_id
-                AND m.id < move.id
-            )
-            OR (
-                m.priority = move.priority
-                AND m.date_priority = move.date_priority
-                AND m.picking_type_id != move.picking_type_id
-                AND m.id > move.id
-            )
-        """
+        """.format(
+            moves_matches=self._previous_promised_qty_sql_moves_before_matches()
+        )
         return sql
+
+    def _previous_promised_qty_sql_moves_no_release(self):
+        return "m.need_release IS false OR m.need_release IS null"
 
     def _previous_promised_qty_sql_lateral_where(self):
         locations = self._ordered_available_to_promise_locations()
@@ -177,20 +188,18 @@ class StockMove(models.Model):
                 AND p_type.code = 'outgoing'
                 AND loc.parent_path LIKE ANY(%(location_paths)s)
                 AND (
-                    COALESCE(m.need_release, False) = COALESCE(move.need_release, False)
-                    AND (
-                        {moves_before}
-                    )
+                    {moves_before}
                     OR (
                         move.need_release IS true
-                        AND (m.need_release IS false OR m.need_release IS null)
+                        AND ({moves_no_release})
                     )
                 )
                 AND m.state IN (
                     'waiting', 'confirmed', 'partially_available', 'assigned'
                 )
         """.format(
-            moves_before=self._previous_promised_qty_sql_moves_before()
+            moves_before=self._previous_promised_qty_sql_moves_before(),
+            moves_no_release=self._previous_promised_qty_sql_moves_no_release(),
         )
         params = {
             "location_paths": [


### PR DESCRIPTION
In order to make the computation of the previous to promised sql hookable.
I move the need_release check into a own method. 
This would makes it easier to add other moves to the where. 

cc @jbaudoux 