### PR TITLE
[14.0] shopfloor: add option to order pickings by priority

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -13,7 +13,7 @@ class DataAction(Component):
     def location(self, record, **kw):
         parser = self._location_parser
         data = self._jsonify(record.with_context(location=record.id), parser, **kw)
-        if "with_operation_progress" in kw:
+        if kw.get("with_operation_progress"):
             lines_blacklist = (
                 kw.get("progress_lines_blacklist")
                 or self.env["stock.move.line"].browse()
@@ -46,7 +46,7 @@ class DataAction(Component):
         # and it may reduce performance significatively
         # when dealing with a large number of pickings.
         # Thus, we make it optional.
-        if "with_progress" in kw:
+        if kw.get("with_progress"):
             parser.append("progress")
         return parser
 
@@ -72,6 +72,7 @@ class DataAction(Component):
             "bulk_line_count",
             "total_weight:weight",
             "scheduled_date",
+            "priority",
         ]
 
     @ensure_model("stock.quant.package")

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -27,6 +27,7 @@ class ShopfloorSchemaAction(Component):
             "scheduled_date": {"type": "string", "nullable": False, "required": True},
             "progress": {"type": "float", "nullable": True},
             "location_dest": self._schema_dict_of(self.location(), required=False),
+            "priority": {"type": "string", "nullable": True, "required": False},
         }
 
     def move_line(self, with_packaging=False, with_picking=False):

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -360,7 +360,7 @@ class Checkout(Component):
         ]
 
     def _order_for_list_stock_picking(self):
-        return "scheduled_date asc, id asc"
+        return "priority desc, scheduled_date asc, id asc"
 
     def list_stock_picking(self):
         """List stock.picking records available

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -112,6 +112,7 @@
                     name="scan_location_or_pack_first"
                     attrs="{'invisible': [('scan_location_or_pack_first_is_possible', '=', False)]}"
                 >
+                  <field name="scenario_key" invisible="1" />
                   <field name="scan_location_or_pack_first_is_possible" invisible="1" />
                   <field name="scan_location_or_pack_first" />
                   <div

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -293,6 +293,7 @@ const Checkout = {
                         {path: "origin"},
                         {path: "carrier.name", label: "Carrier"},
                         {path: "move_line_count", label: "Lines"},
+                        {path: "priority", label: "Priority"},
                     ],
                 },
             };


### PR DESCRIPTION
This PR adds an option to return the priority number of a picking to the frontend.
In the checkout scenario, we display this priority if available.

It also fixes a bug related to a missing key in shopfloor_menu.xml

ref: cos-4215