### PR TITLE
[14.0][FIX] shopfloor: checkout fix line done with zero qty

### DIFF
--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -1137,7 +1137,10 @@ class Checkout(Component):
         if message:
             return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
-        selected_lines.write(
+        selected_lines_with_qty_done = selected_lines.filtered(
+            lambda line: line.qty_done > 0
+        )
+        selected_lines_with_qty_done.write(
             {"shopfloor_checkout_done": True, "result_package_id": False}
         )
         response = self._check_allowed_qty_done(picking, selected_lines)


### PR DESCRIPTION
Follwing this change

- https://github.com/OCA/wms/commit/b2ce1bd25f6ab05bedff577ca26ccf8ddab98a30

Multiple lines are displayed in the `select_package` state. Some could have the quantity done set to zero. In that case the lines should not be set has checkout done.

When putting lines in a package it is already handled by `_filter_lines_to_pack`