### PR TITLE
[16.0][FIX] stock_release_channel: Ensure moves still exist after release

### DIFF
--- a/stock_release_channel/models/stock_move.py
+++ b/stock_release_channel/models/stock_move.py
@@ -13,7 +13,10 @@ class StockMove(models.Model):
         # as we may release only partially, the channel may
         # change
         res = super().release_available_to_promise()
-        self.picking_id.assign_release_channel()
+        # As moves can be merged (and then unlinked), we should ensure
+        # they still exist.
+        moves = self.exists()
+        moves.picking_id.assign_release_channel()
         return res
 
     def _action_confirm(self, merge=True, merge_into=False):


### PR DESCRIPTION
As release will run stock rules, some existing moves can be merged with new ones and then be deleted. We ensure that they still exist when assigning release channel.