### PR TITLE
[14.0][FIX] shopfloor: checkout fix asking destination location

### DIFF
--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -1404,11 +1404,8 @@ class Checkout(Component):
                     },
                 )
         lines_done = self._lines_checkout_done(picking)
-        dest_location = picking.location_dest_id
-        child_locations = self.env["stock.location"].search(
-            [("id", "child_of", dest_location.id), ("usage", "!=", "view")]
-        )
-        if len(child_locations) > 0 and child_locations != dest_location:
+        dest_location = lines_done.move_id.location_dest_id
+        if len(dest_location) != 1 or dest_location.usage == "view":
             return self._response_for_select_child_location(
                 picking,
             )

--- a/shopfloor/tests/test_checkout_done.py
+++ b/shopfloor/tests/test_checkout_done.py
@@ -65,8 +65,34 @@ class CheckoutDonePartialCase(CheckoutCommonCase):
             "done", params={"picking_id": self.picking.id, "confirmation": True}
         )
 
-        self.assertRecordValues(self.picking, [{"state": "assigned"}])
+        self.assertRecordValues(self.picking, [{"state": "done"}])
 
+        self.assert_response(
+            response,
+            next_state="select_document",
+            message=self.service.msg_store.transfer_done_success(self.picking),
+            data={"restrict_scan_first": False},
+        )
+
+    def test_done_ask_destination_location(self):
+        """Check asking for destination location for view type location."""
+        view_location = (
+            self.env["stock.location"]
+            .sudo()
+            .create(
+                {
+                    "name": "Test Location Usage View",
+                    "location_id": self.picking.move_lines.location_dest_id.id,
+                    "usage": "view",
+                }
+            )
+        )
+        self.picking.move_lines.location_dest_id = view_location
+        response = self.service.dispatch(
+            "done", params={"picking_id": self.picking.id, "confirmation": True}
+        )
+
+        self.assertRecordValues(self.picking, [{"state": "assigned"}])
         self.assert_response(
             response,
             next_state="select_child_location",


### PR DESCRIPTION
Supersedes #775

There could be multiple moves with different destination The destination location could be of type `view`

For both cases, require the user to scan a new location.