### PR TITLE
[14.0]  shopfloor_mobile: display pickings by priority in checkout

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -13,7 +13,7 @@ class DataAction(Component):
     def location(self, record, **kw):
         parser = self._location_parser
         data = self._jsonify(record.with_context(location=record.id), parser, **kw)
-        if "with_operation_progress" in kw:
+        if kw.get("with_operation_progress"):
             lines_blacklist = (
                 kw.get("progress_lines_blacklist")
                 or self.env["stock.move.line"].browse()
@@ -46,7 +46,7 @@ class DataAction(Component):
         # and it may reduce performance significatively
         # when dealing with a large number of pickings.
         # Thus, we make it optional.
-        if "with_progress" in kw:
+        if kw.get("with_progress"):
             parser.append("progress")
         return parser
 
@@ -72,6 +72,7 @@ class DataAction(Component):
             "bulk_line_count",
             "total_weight:weight",
             "scheduled_date",
+            "priority",
         ]
 
     @ensure_model("stock.quant.package")

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -27,6 +27,7 @@ class ShopfloorSchemaAction(Component):
             "scheduled_date": {"type": "string", "nullable": False, "required": True},
             "progress": {"type": "float", "nullable": True},
             "location_dest": self._schema_dict_of(self.location(), required=False),
+            "priority": {"type": "string", "nullable": True, "required": False},
         }
 
     def move_line(self, with_packaging=False, with_picking=False):

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -360,7 +360,7 @@ class Checkout(Component):
         ]
 
     def _order_for_list_stock_picking(self):
-        return "scheduled_date asc, id asc"
+        return "priority desc, scheduled_date asc, id asc"
 
     def list_stock_picking(self):
         """List stock.picking records available

--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -155,6 +155,7 @@ class ActionsDataCase(ActionsDataCaseBase):
             "partner": {"id": self.customer.id, "name": self.customer.name},
             "carrier": {"id": carrier.id, "name": carrier.name},
             "ship_carrier": None,
+            "priority": "0",
         }
         self.assertEqual(data.pop("scheduled_date").split("T")[0], "2020-08-03")
         self.assertDictEqual(data, expected)
@@ -179,6 +180,7 @@ class ActionsDataCase(ActionsDataCaseBase):
             "carrier": {"id": carrier.id, "name": carrier.name},
             "ship_carrier": None,
             "progress": 0.0,
+            "priority": "0",
         }
         self.assertEqual(data.pop("scheduled_date").split("T")[0], "2020-08-03")
         self.assertDictEqual(data, expected)

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -112,6 +112,7 @@
                     name="scan_location_or_pack_first"
                     attrs="{'invisible': [('scan_location_or_pack_first_is_possible', '=', False)]}"
                 >
+                  <field name="scenario_key" invisible="1" />
                   <field name="scan_location_or_pack_first_is_possible" invisible="1" />
                   <field name="scan_location_or_pack_first" />
                   <div

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -293,7 +293,20 @@ const Checkout = {
                         {path: "origin"},
                         {path: "carrier.name", label: "Carrier"},
                         {path: "move_line_count", label: "Lines"},
-                        {path: "priority", label: "Priority"},
+                        {
+                            path: "priority",
+                            render_component: "priority-widget",
+                            render_options: function (record) {
+                                const priority = parseInt(record.priority);
+                                // We need to pass the label to the component as an option instead of using "display_no_value"
+                                // because pickings with no priority will still have a string value of "0"
+                                // and the label would always be displayed.
+                                return {
+                                    priority,
+                                    label: priority ? "Priority: " : null,
+                                };
+                            },
+                        },
                     ],
                 },
             };

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -293,6 +293,7 @@ const Checkout = {
                         {path: "origin"},
                         {path: "carrier.name", label: "Carrier"},
                         {path: "move_line_count", label: "Lines"},
+                        {path: "priority", label: "Priority"},
                     ],
                 },
             };

--- a/shopfloor_mobile_base/static/wms/src/components/priority-widget.js
+++ b/shopfloor_mobile_base/static/wms/src/components/priority-widget.js
@@ -18,6 +18,7 @@ export var PriorityWidget = Vue.component("priority-widget", {
     },
     template: `
 <div :class="[$options._componentTag, opts.mode ? 'mode-' + opts.mode: '', 'd-inline']">
+    <span v-if="opts.label">{{ opts.label }}</span>
     <span v-for="n in _.range(1, opts.priority + 1)" v-if="opts.priority" :class="['priority-' + n]">
         <v-icon color="amber accent-2">mdi-star</v-icon>
     </span>


### PR DESCRIPTION
Replaces https://github.com/OCA/wms/pull/770

Change the order of the pickings in the checkout scenario so that they're displayed by priority.
Also, display the priority as star icons.

Ref: cos-4264.