### PR TITLE
[16.0][FIX] stock_storage_type: v16 migration - fix quants for product put-away

### DIFF
--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -9,6 +9,7 @@
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/wms",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
+    "maintainers": ["jbaudoux", "rousseldenis"],
     "license": "AGPL-3",
     "application": False,
     "installable": True,

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -369,13 +369,14 @@ class StockLocation(models.Model):
         package_type = self._get_package_type(package, product)
         # exclude_sml_ids are passed into the context during the get_putaway_strategy
         # call.
-        stock_move_line_ids = self.env.context.get("exclude_sml_ids", [])
-        stock_move_lines = self.env["stock.move.line"].browse(stock_move_line_ids)
-        quants = (
-            package.quant_ids
-            if package
-            else stock_move_lines.mapped("reserved_quant_id")
-        )
+        if package:
+            quants = package.quant_ids
+        else:
+            stock_move_line_ids = self.env.context.get("exclude_sml_ids", [])
+            stock_move_lines = self.env["stock.move.line"].browse(stock_move_line_ids)
+            quants = stock_move_lines.mapped("reserved_quant_id").filtered(
+                lambda q: q.product_id == product
+            )
         if not package_type:
             # Fallback on standard one
             return putaway_location


### PR DESCRIPTION
In case of product put-away computation, the quants extracted from the moves in the context are for all the moves of the transfer. So we need to filter on the product for which we compute the put-away.

cc @rousseldenis @sebalix 