### PR TITLE
[14.0] shopfloor_mobile_base: force nav item counter update

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -77,7 +77,6 @@ new Vue({
             global_state_key: "",
             loading: false,
             loading_msg_custom: "",
-            loadingMenu: false,
             appconfig: null,
         };
         _.merge(data, config_registry.generare_data_keys());
@@ -121,10 +120,10 @@ new Vue({
             self.profile = profile;
             self.loadMenu(true);
         });
+        event_hub.$on("menu_drawer:update", function () {
+            self.loadMenu(true);
+        });
         event_hub.$emit("app:mounted", self, false);
-    },
-    beforeUpdate: function () {
-        this.loadMenu(true);
     },
     computed: {
         ...config_registry.generate_computed_properties(),
@@ -235,20 +234,9 @@ new Vue({
                     "SERVICE-CTX-PROFILE-ID": this.profile.id,
                 },
             });
-            if (!this.loadingMenu) {
-                // TODO: this is added to make sure to always have
-                // up-to-date counter in the navigation drawer items.
-                // It is not an ideal solution though, as it will be called
-                // whenever the component is updated (there's no easy way
-                // to refresh the counters only when needed,
-                // as each scenario has a different implementation).
-                // That being said, this call is very small so it's not that costly.
-                this.loadingMenu = true;
-                return odoo.call("menu").then((result) => {
-                    self.appmenu = result.data;
-                    this.loadingMenu = false;
-                });
-            }
+            return odoo.call("menu").then(function (result) {
+                self.appmenu = result.data;
+            });
         },
         login: function (evt, data) {
             evt.preventDefault();

--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -77,6 +77,7 @@ new Vue({
             global_state_key: "",
             loading: false,
             loading_msg_custom: "",
+            loadingMenu: false,
             appconfig: null,
         };
         _.merge(data, config_registry.generare_data_keys());
@@ -121,6 +122,9 @@ new Vue({
             self.loadMenu(true);
         });
         event_hub.$emit("app:mounted", self, false);
+    },
+    beforeUpdate: function () {
+        this.loadMenu(true);
     },
     computed: {
         ...config_registry.generate_computed_properties(),
@@ -231,9 +235,20 @@ new Vue({
                     "SERVICE-CTX-PROFILE-ID": this.profile.id,
                 },
             });
-            return odoo.call("menu").then(function (result) {
-                self.appmenu = result.data;
-            });
+            if (!this.loadingMenu) {
+                // TODO: this is added to make sure to always have
+                // up-to-date counter in the navigation drawer items.
+                // It is not an ideal solution though, as it will be called
+                // whenever the component is updated (there's no easy way
+                // to refresh the counters only when needed,
+                // as each scenario has a different implementation).
+                // That being said, this call is very small so it's not that costly.
+                this.loadingMenu = true;
+                return odoo.call("menu").then((result) => {
+                    self.appmenu = result.data;
+                    this.loadingMenu = false;
+                });
+            }
         },
         login: function (evt, data) {
             evt.preventDefault();

--- a/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
+++ b/shopfloor_mobile_base/static/wms/src/scenario/mixins.js
@@ -357,6 +357,9 @@ export var ScenarioBaseMixin = {
                 // Move to new state, data will be refreshed right after.
                 this.state_to(state_key);
             }
+            // Make sure the counters and all the data from the navigation drawer menu
+            // is up to date after new data from the backend is received.
+            event_hub.$emit("menu_drawer:update");
         },
         on_call_error: function (result) {
             alert(result.status + " " + result.error);


### PR DESCRIPTION
The navigation drawer counters were not being updated properly when going through the full workflow: they were only updated on opening / closing the drawer, when loading a new scenario or when refreshing the page.

With this change, we make sure to reach out to the backend with every operation to ensure we have up-to-date figures.

ref: cos-4245 & cos-4328