### PR TITLE
[FIX] stock_release_channel: Fix enqueued jobs tests / stock_release_channel_process_end_time: Freeze

### DIFF
--- a/stock_release_channel/tests/test_assign_job.py
+++ b/stock_release_channel/tests/test_assign_job.py
@@ -18,8 +18,9 @@ class TestReleaseChannel(ReleaseChannelCase):
             (picking1 + picking2)._delay_assign_release_channel()
             trap.assert_jobs_count(1, only=picking1.assign_release_channel)
             trap.assert_jobs_count(1, only=picking2.assign_release_channel)
+            enqueued_job = trap.enqueued_jobs[0]
             trap.perform_enqueued_jobs()
-            self.assertEqual(f"{message}", trap.enqueued_jobs[0].result)
+            self.assertEqual(f"{message}", enqueued_job.result)
         self.assertEqual(move.picking_id.release_channel_id, expected)
         self.assertEqual(move2.picking_id.release_channel_id, self.default_channel)
 
@@ -48,8 +49,9 @@ class TestReleaseChannel(ReleaseChannelCase):
             )
             picking._delay_assign_release_channel()
             trap.assert_jobs_count(1, only=picking.assign_release_channel)
+            enqueued_job = trap.enqueued_jobs[0]
             trap.perform_enqueued_jobs()
-            self.assertEqual(message, trap.enqueued_jobs[0].result)
+            self.assertEqual(message, enqueued_job.result)
         move = self._create_single_move(self.product2, 10)
         with trap_jobs() as trap:
             picking = move.picking_id
@@ -59,5 +61,6 @@ class TestReleaseChannel(ReleaseChannelCase):
             )
             picking._delay_assign_release_channel()
             trap.assert_jobs_count(1, only=picking.assign_release_channel)
+            enqueued_job = trap.enqueued_jobs[0]
             trap.perform_enqueued_jobs()
-            self.assertEqual(message, trap.enqueued_jobs[0].result)
+            self.assertEqual(message, enqueued_job.result)

--- a/stock_release_channel_partner_delivery_window/tests/test_release_window.py
+++ b/stock_release_channel_partner_delivery_window/tests/test_release_window.py
@@ -87,6 +87,7 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         # Window
         today = fields.Date.today()
         self.picking.partner_id = self.customer_time_window
+        self.channel.process_end_date = today  # Friday
         self._assign_picking(self.picking)
         self.assertNotEqual(self.channel, self.picking.release_channel_id)
         self.channel.process_end_date = today + timedelta(


### PR DESCRIPTION
- [x] As queue_job has changed enqueued_jobs property behavior (void the property after performing jobs), we need to adapt tests.

See https://github.com/OCA/queue/commit/832dd9b96bdc0bc7ddd064e1e86f9d400d99a97d

- [x] In stock_release_channel_process_end_time: Freeze the channel process end time too