### PR TITLE
[14.0] shopfloor_mobile_base: add actions registry

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/screen.js
+++ b/shopfloor_mobile_base/static/wms/src/components/screen.js
@@ -5,6 +5,7 @@
  */
 
 import event_hub from "../services/event_hub.js";
+import {actions_registry} from "../services/actions_registry.js";
 
 /* eslint-disable strict */
 Vue.component("Screen", {
@@ -333,11 +334,34 @@ Vue.component("nav-items-extra", {
 Vue.component("app-bar-actions", {
     template: `
     <div :class="$options._componentTag">
+        <component
+            v-for="action in actions()"
+            :is="action.render_component"
+            :options="action.render_options ? action.render_options() : {}"
+            :key="make_component_key([action.render_component])"
+            />
+    </div>
+    `,
+    methods: {
+        actions: function () {
+            return actions_registry.by_tag("app-bar-actions");
+        },
+    },
+});
+
+// Scan anything action component
+Vue.component("app-bar-action-scan-anything", {
+    template: `
         <v-btn icon @click="$router.push({'name': 'scan_anything'})" :disabled="this.$route.name=='scan_anything'">
             <v-icon >mdi-magnify</v-icon>
         </v-btn>
-    </div>
     `,
+});
+// Scan anything action registry add
+actions_registry.add("app-bar-action-scan-anything", {
+    render_component: "app-bar-action-scan-anything",
+    tag: "app-bar-actions",
+    sequence: 100,
 });
 
 Vue.component("app-version-footer", {

--- a/shopfloor_mobile_base/static/wms/src/services/actions_registry.js
+++ b/shopfloor_mobile_base/static/wms/src/services/actions_registry.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Camptocamp SA
+ * @author Simone Orsi <simahawk@gmail.com>
+ * License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+ */
+
+/**
+ * Global actions registry.
+ *
+ * Register action components to be used by specific UI components.
+ *
+ * For an example, check `app-bar-action-scan-anything`.
+ *
+ */
+export class ActionsRegistry {
+    constructor() {
+        this._data = {};
+    }
+    get(key) {
+        return this._data[key];
+    }
+    add(key, value) {
+        _.set(this._data, key, value);
+    }
+    /**
+     * Retrieve all actions matching given tag sorted by sequence.
+     *
+     * @param {String} tag: tag to filter with
+     */
+    by_tag(tag) {
+        return _.filter(this._data, function (x) {
+            return x.tag == tag;
+        }).sort((current, next) => current.sequence - next.sequence);
+    }
+}
+
+export var actions_registry = new ActionsRegistry();


### PR DESCRIPTION
Makes easier to plug in actions from external modules w/o having to override the top bar component.