### PR TITLE
[14.0]  shopfloor: improve qty picker

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -49,10 +49,11 @@
     "data": [
         "data/shopfloor_scenario_data.xml",
         "security/groups.xml",
+        "views/product_packaging_type.xml",
         "views/shopfloor_menu.xml",
-        "views/stock_picking_type.xml",
         "views/stock_location.xml",
         "views/stock_move_line.xml",
+        "views/stock_picking_type.xml",
     ],
     "demo": [
         "demo/stock_picking_type_demo.xml",

--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -153,6 +153,7 @@ class DataAction(Component):
             "id",
             ("packaging_type_id:name", lambda rec, fname: rec.packaging_type_id.name),
             ("packaging_type_id:code", lambda rec, fname: rec.packaging_type_id.code),
+            ("packaging_type_id:shopfloor_icon", self._packaging_icon_data),
             "qty",
         ]
 
@@ -315,6 +316,17 @@ class DataAction(Component):
             self._packaging_parser,
             multi=True,
         )
+
+    def _packaging_icon_data(self, rec, field):
+        icon_data = {"alt_text": rec.packaging_type_id.name}
+        if not rec.packaging_type_id.shopfloor_icon:
+            return icon_data
+        icon_data[
+            "url"
+        ] = "/web/image/product.packaging.type/{}/shopfloor_icon/30x30".format(
+            rec.packaging_type_id.id
+        )
+        return icon_data
 
     def _product_supplier_code(self, rec, field):
         supplier_info = fields.first(

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -135,6 +135,14 @@ class ShopfloorSchemaAction(Component):
             "name": {"type": "string", "nullable": False, "required": True},
             "code": {"type": "string", "nullable": True, "required": True},
             "qty": {"type": "float", "required": True},
+            "shopfloor_icon": {
+                "type": "dict",
+                "required": False,
+                "schema": {
+                    "url": {"type": "string", "required": False},
+                    "alt_text": {"type": "string", "required": False},
+                },
+            },
         }
 
     def delivery_packaging(self):

--- a/shopfloor/models/__init__.py
+++ b/shopfloor/models/__init__.py
@@ -1,4 +1,5 @@
 from . import priority_postpone_mixin
+from . import product_packaging_type
 from . import shopfloor_menu
 from . import shopfloor_app
 from . import stock_picking_type

--- a/shopfloor/models/product_packaging_type.py
+++ b/shopfloor/models/product_packaging_type.py
@@ -1,4 +1,5 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
+# Copyright 2023 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
 
@@ -6,4 +7,8 @@ from odoo import fields, models
 class ProductPackagingType(models.Model):
     _inherit = "product.packaging.type"
 
-    icon = fields.Image()
+    shopfloor_icon = fields.Binary(
+        help="Icon to be displayed in the frontend qty picker. "
+        "Its final size will be a 30x30 image, "
+        "which means that square-shaped icons will work best."
+    )

--- a/shopfloor/models/product_packaging_type.py
+++ b/shopfloor/models/product_packaging_type.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ProductPackagingType(models.Model):
+    _inherit = "product.packaging.type"
+
+    icon = fields.Image()

--- a/shopfloor/tests/test_actions_data_base.py
+++ b/shopfloor/tests/test_actions_data_base.py
@@ -148,8 +148,16 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
             "code": record.packaging_type_id.code,
             "qty": record.qty,
         }
+        data["shopfloor_icon"] = self._expected_packaging_shopfloor_icon(record)
         data.update(kw)
         return data
+
+    def _expected_packaging_shopfloor_icon(self, record):
+        shopfloor_icon_data = {"alt_text": record.packaging_type_id.name}
+        shopfloor_icon = record.packaging_type_id.shopfloor_icon
+        if shopfloor_icon:
+            shopfloor_icon_data["url"] = shopfloor_icon
+        return shopfloor_icon_data
 
     def _expected_delivery_packaging(self, record, **kw):
         data = {

--- a/shopfloor/views/product_packaging_type.xml
+++ b/shopfloor/views/product_packaging_type.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_product_packaging_type_form" model="ir.ui.view">
+        <field name="name">shopfloor.product.packaging.type.form</field>
+        <field name="model">product.packaging.type</field>
+        <field
+            name="inherit_id"
+            ref="product_packaging_type.view_product_packaging_type_form"
+        />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <div>
+                    <field name="icon" widget="image" width="90" />
+                </div>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/shopfloor/views/product_packaging_type.xml
+++ b/shopfloor/views/product_packaging_type.xml
@@ -10,7 +10,7 @@
         <field name="arch" type="xml">
             <field name="name" position="after">
                 <div>
-                    <field name="icon" widget="image" width="90" />
+                    <field name="shopfloor_icon" widget="image" width="90" />
                 </div>
             </field>
         </field>

--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -280,9 +280,16 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
                     <v-col cols="2" md="2" v-if="!readonly">
                         <span class="qty-todo">/ {{ qty_todo_by_pkg[pkg.id] }}</span>
                     </v-col>
-                    <v-col>
+                    <v-col cols="4">
                         <div :class="qty_by_pkg[pkg.id] > 0 ? 'pkg-name font-weight-bold' : 'pkg-name'"> {{ pkg[pkgNameKey] }}</div>
                         <div v-if="contained_packaging[pkg.id]" :class="qty_by_pkg[pkg.id] > 0 ? 'pkg-qty font-weight-bold' : 'pkg-qty'">(x{{ contained_packaging[pkg.id].qty }} {{ contained_packaging[pkg.id].pkg.name }})</div>
+                    </v-col>
+                    <v-col cols="2" v-if="_.result(contained_packaging[pkg.id], 'pkg.shopfloor_icon.url', '')">
+                        <img
+                            class="qty-picker-packaging-icon"
+                            :src="_.result(contained_packaging[pkg.id], 'pkg.shopfloor_icon.url', '')"
+                            :alt="_.result(contained_packaging[pkg.id], 'pkg.shopfloor_icon.alt_text', '')"
+                        />
                     </v-col>
                 </v-row>
             </v-expansion-panel-content>

--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -214,15 +214,15 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
         this.$root.trigger("qty_edit", this.qty);
     },
     computed: {
-        qty_color: function () {
+        qty_color_class: function () {
             if (this.qty == this.qtyTodo) {
                 if (this.readonly) return "";
-                return "background-color: rgb(143, 191, 68)";
+                return "qty-color-green";
             }
             if (this.qty > this.qtyTodo) {
-                return "background-color: orangered";
+                return "qty-color-orangered";
             }
-            return "background-color: pink";
+            return "qty-color-pink";
         },
         qty_todo_by_pkg: function () {
             // Used to calculate the qty needed of each package type
@@ -247,7 +247,7 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
             <v-expansion-panel-header expand-icon="mdi-menu-down">
                 <v-row dense align="center">
                     <v-col cols="5" md="3">
-                        <input type="number" v-model="qty" class="qty-done" :style="qty_color"
+                        <input type="number" v-model="qty" class="qty-done"
                             v-on:click.stop
                             :readonly="readonly"
                         />
@@ -268,7 +268,7 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
                     :class="(readonly && !qty_by_pkg[pkg.id]) ? 'd-none' : ''"
                 >
                     <v-col cols="4" md="2">
-                        <input type="text" inputmode="decimal" class="qty-done"
+                        <input type="text" inputmode="decimal" :class="['qty-done', qty_by_pkg[pkg.id] > 0 ? qty_color_class : '']"
                             v-model.lazy="qty_by_pkg[pkg.id]"
                             :data-origvalue="qty_by_pkg[pkg.id]"
                             :data-pkg="JSON.stringify(pkg)"

--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -281,8 +281,8 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
                         <span class="qty-todo">/ {{ qty_todo_by_pkg[pkg.id] }}</span>
                     </v-col>
                     <v-col>
-                        <div class="pkg-name"> {{ pkg[pkgNameKey] }}</div>
-                        <div v-if="contained_packaging[pkg.id]" class="pkg-qty">(x{{ contained_packaging[pkg.id].qty }} {{ contained_packaging[pkg.id].pkg.name }})</div>
+                        <div :class="qty_by_pkg[pkg.id] > 0 ? 'pkg-name font-weight-bold' : 'pkg-name'"> {{ pkg[pkgNameKey] }}</div>
+                        <div v-if="contained_packaging[pkg.id]" :class="qty_by_pkg[pkg.id] > 0 ? 'pkg-qty font-weight-bold' : 'pkg-qty'">(x{{ contained_packaging[pkg.id].qty }} {{ contained_packaging[pkg.id].pkg.name }})</div>
                     </v-col>
                 </v-row>
             </v-expansion-panel-content>

--- a/shopfloor_mobile/static/wms/src/css/main.css
+++ b/shopfloor_mobile/static/wms/src/css/main.css
@@ -50,6 +50,15 @@ ul.packaging span:first-child {
 .packaging-qty-picker .qty-todo {
     text-align: center;
 }
+.packaging-qty-picker .qty-color-green {
+    background-color: rgb(143, 191, 68, 0.5);
+}
+.packaging-qty-picker .qty-color-orangered {
+    background-color: orangered;
+}
+.packaging-qty-picker .qty-color-pink {
+    background-color: pink;
+}
 .packaging-qty-picker .pkg-name {
     line-height: 1;
     padding-top: 2px;

--- a/shopfloor_mobile/static/wms/src/css/main.css
+++ b/shopfloor_mobile/static/wms/src/css/main.css
@@ -80,3 +80,8 @@ I tested only w/ checkout/select_package for now
     top: 5px;
     right: 5px;
 }
+
+.qty-picker-packaging-icon {
+    width: 30px;
+    height: 30px;
+}


### PR DESCRIPTION
- Write the qty and Package type text in bold for the type to pick
- Instead of color-coding the boxes (since this is usually used to indicate what type of information it is), introduce a small icon next to the package type to show what it is.

![image](https://github.com/OCA/wms/assets/77412816/b68aad27-bba1-4c4c-bddc-0316dbc8b5a9)


ref: cos-4220