### PR TITLE
[IMP] improve logging

### DIFF
--- a/delivery_carrier_warehouse/tests/test_delivery_carrier_warehouse.py
+++ b/delivery_carrier_warehouse/tests/test_delivery_carrier_warehouse.py
@@ -1,9 +1,9 @@
 # Copyright 2020 Camptocamp SA
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
-from odoo.tests.common import Form, SavepointCase
+from odoo.tests.common import Form, TransactionCase
 
 
-class TestSaleDeliveryCarrierPreference(SavepointCase):
+class TestSaleDeliveryCarrierPreference(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -502,12 +502,13 @@ class StockReleaseChannel(models.Model):
             break
 
         if not picking.release_channel_id:
-            message = (
-                f"Transfer {picking.name} could not be assigned to a "
+            # by this point, the picking should have been assigned
+            message_template = (
+                "Transfer %(picking_name)s could not be assigned to a "
                 "channel, you should add a final catch-all rule"
             )
-            # by this point, the picking should have been assigned
-            _logger.warning(message)
+            _logger.warning(message_template, {"picking_name": picking.name})
+            message = _(message_template, picking_name=picking.name)
         return message
 
     def _assign_release_channel_additional_filter(self, pickings):

--- a/stock_release_channel_process_end_time/tests/test_release_end_date.py
+++ b/stock_release_channel_process_end_time/tests/test_release_end_date.py
@@ -91,7 +91,7 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.assertFalse(self.channel._get_pickings_to_release())
         self._update_qty_in_location(self.loc_bin1, self.product1, 100.0)
         self._update_qty_in_location(self.loc_bin1, self.product2, 100.0)
-        pickings.refresh()
+        pickings.env.invalidate_all()
         # the pickings are now ready to be released
         self.assertEqual(pickings, self.channel._get_pickings_to_release())
         # if the scheduled date of one picking is changed to be after the


### PR DESCRIPTION
- Better use of logger.warn, so tools like sentry recognize these messages as the same one.
- Translate message.
- Also, resolve a couple of deprecations.