### PR TITLE
[14.0][FIX] stock_dynamic_routing: routing moves has to be MTO

### DIFF
--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -532,4 +532,6 @@ class StockMove(models.Model):
             # https://github.com/odoo/odoo/commit/ecf726ae
             # to be on the safe side, force it to False
             "package_level_id": False,
+            # A routing move is always in MTO
+            "procure_method": "make_to_order",
         }


### PR DESCRIPTION
This is causing trouble by merging back moves in the `stock_available_to_promise_release_dynamic_routing` glue module which were split on purpose by the dynamic routing rules.