### PR TITLE
[16.0][FIX] stock_available_to_promise_release: unrelease

### DIFF
--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -67,6 +67,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         new_picking = self._prev_picking(self.shipping) - self.picking
         self.assertTrue(new_picking)
         self.assertEqual(new_picking.state, "assigned")
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.shipping.move_ids)
+        )
 
     def test_unrelease_partially_processed_move(self):
         """Check it's not possible to unrelease a move that has been partially
@@ -119,6 +122,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
                 lambda m: m.state not in ("cancel", "done")
             )
         )
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in backorder_ship.move_ids)
+        )
 
     def test_auto_unrelease_on_backorder(self):
         """Check that moves into a backorder are unreleased if specified on
@@ -152,4 +158,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             backorder_ship.move_ids.move_orig_ids.filtered(
                 lambda m: m.state not in ("cancel", "done")
             )
+        )
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in backorder_ship.move_ids)
         )

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -48,6 +48,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         move_cancel = self.picking1.move_ids.filtered(lambda m: m.state == "cancel")
         self.assertEqual(move_cancel.product_uom_qty, 2)
         self.assertTrue(self.shipping1.need_release)
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.shipping1.move_ids)
+        )
 
     # def test_unrelease_picking_is_done(self):
     #     # the pick moves for delivery 1 and 2 are merged
@@ -71,3 +74,6 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertEqual(move_active.product_uom_qty, 3.0)
         self.assertEqual(move_cancel.product_uom_qty, 2.0)
         self.assertEqual(move_active.move_dest_ids, self.shipping2.move_ids)
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.shipping2.move_ids)
+        )

--- a/stock_available_to_promise_release/tests/test_unrelease_3steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_3steps.py
@@ -53,6 +53,9 @@ class TestAvailableToPromiseRelease3steps(PromiseReleaseCommonCase):
         self.assertEqual(self.pack1.state, "cancel")
         self.assertTrue(self.ship1.need_release)
         self.assertFalse(self.ship2.need_release)
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.ship1.move_ids)
+        )
         # Check pick has one move cancel and one still assign
         move_active = self.pick1.move_ids.filtered(lambda l: l.state == "assigned")
         move_cancel = self.pick1.move_ids.filtered(lambda l: l.state == "cancel")


### PR DESCRIPTION
Recover initial procure_method.

Before this change, once you have unreleased a move, you can steal whatever is available on output :/

cc @sbejaoui @lmignon @mt-software-de @TDu @sebalix