### PR TITLE
[14.0][FIX] stock_available_to_promise_release: unrelease

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -380,11 +380,15 @@ class StockMove(models.Model):
 
     def _prepare_move_split_vals(self, qty):
         vals = super()._prepare_move_split_vals(qty)
+
         # The method set procure_method as 'make_to_stock' by default on split,
-        # but we want to keep 'make_to_order' for chained moves when we split
-        # a partially available move in _run_stock_rule().
+        # but we want to keep 'make_to_order' for chained moves.
+        # Note this has been fixed in v15.0
+        # https://github.com/odoo/odoo/commit/4180afb95112dbb1119fd68b7bd3f2f5e1160422
+        vals.update({"procure_method": self.procure_method})
+
         if self.env.context.get("release_available_to_promise"):
-            vals.update({"procure_method": self.procure_method, "need_release": True})
+            vals.update({"need_release": True})
         return vals
 
     def _get_release_decimal_precision(self):

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -556,6 +556,9 @@ class StockMove(models.Model):
         for move in moves_to_unrelease:
             iterator = move._get_chained_moves_iterator("move_orig_ids")
             moves_to_cancel = self.env["stock.move"]
+            # backup procure_method as when you don't propagate cancel, the
+            # destination move is forced to make_to_stock
+            procure_method = move.procure_method
             next(iterator)  # skip the current move
             for origin_moves in iterator:
                 origin_moves = origin_moves.filtered(
@@ -569,6 +572,8 @@ class StockMove(models.Model):
                     # origin_moves._action_cancel()
                     moves_to_cancel |= origin_moves
             moves_to_cancel._action_cancel()
+            # restore the procure_method overwritten by _action_cancel()
+            move.procure_method = procure_method
         moves_to_unrelease.write({"need_release": True})
         for picking, moves in itertools.groupby(
             moves_to_unrelease, lambda m: m.picking_id

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -67,7 +67,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertTrue(new_picking)
         self.assertEqual(new_picking.state, "assigned")
         self.assertTrue(
-            all(m.procure_method == "make_to_order" for m in self.shipping.move_ids)
+            all(m.procure_method == "make_to_order" for m in self.shipping.move_lines)
         )
 
     def test_unrelease_partially_processed_move(self):
@@ -132,7 +132,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             )
         )
         self.assertTrue(
-            all(m.procure_method == "make_to_order" for m in backorder_ship.move_ids)
+            all(m.procure_method == "make_to_order" for m in backorder_ship.move_lines)
         )
 
     def test_unrelease_picking_wizard(self):

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -66,6 +66,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         new_picking = self._prev_picking(self.shipping) - self.picking
         self.assertTrue(new_picking)
         self.assertEqual(new_picking.state, "assigned")
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.shipping.move_ids)
+        )
 
     def test_unrelease_partially_processed_move(self):
         """Check it's not possible to unrelease a move that has been partially
@@ -127,6 +130,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
             backorder_ship.move_lines.move_orig_ids.filtered(
                 lambda m: m.state not in ("cancel", "done")
             )
+        )
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in backorder_ship.move_ids)
         )
 
     def test_unrelease_picking_wizard(self):

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -51,7 +51,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertEqual(move_cancel.product_uom_qty, 2)
         self.assertTrue(self.shipping1.need_release)
         self.assertTrue(
-            all(m.procure_method == "make_to_order" for m in self.shipping1.move_ids)
+            all(m.procure_method == "make_to_order" for m in self.shipping1.move_lines)
         )
 
     # def test_unrelease_picking_is_done(self):
@@ -77,5 +77,5 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertEqual(move_cancel.product_uom_qty, 2.0)
         self.assertEqual(move_active.move_dest_ids, self.shipping2.move_lines)
         self.assertTrue(
-            all(m.procure_method == "make_to_order" for m in self.shipping2.move_ids)
+            all(m.procure_method == "make_to_order" for m in self.shipping2.move_lines)
         )

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -50,6 +50,9 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         move_cancel = self.picking1.move_lines.filtered(lambda m: m.state == "cancel")
         self.assertEqual(move_cancel.product_uom_qty, 2)
         self.assertTrue(self.shipping1.need_release)
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.shipping1.move_ids)
+        )
 
     # def test_unrelease_picking_is_done(self):
     #     # the pick moves for delivery 1 and 2 are merged
@@ -73,3 +76,6 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertEqual(move_active.product_uom_qty, 3.0)
         self.assertEqual(move_cancel.product_uom_qty, 2.0)
         self.assertEqual(move_active.move_dest_ids, self.shipping2.move_lines)
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.shipping2.move_ids)
+        )

--- a/stock_available_to_promise_release/tests/test_unrelease_3steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_3steps.py
@@ -53,6 +53,9 @@ class TestAvailableToPromiseRelease3steps(PromiseReleaseCommonCase):
         self.assertEqual(self.pack1.state, "cancel")
         self.assertTrue(self.ship1.need_release)
         self.assertFalse(self.ship2.need_release)
+        self.assertTrue(
+            all(m.procure_method == "make_to_order" for m in self.ship1.move_ids)
+        )
         # Check pick has one move cancel and one still assign
         move_active = self.pick1.move_lines.filtered(lambda l: l.state == "assigned")
         move_cancel = self.pick1.move_lines.filtered(lambda l: l.state == "cancel")

--- a/stock_available_to_promise_release/tests/test_unrelease_3steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_3steps.py
@@ -54,7 +54,7 @@ class TestAvailableToPromiseRelease3steps(PromiseReleaseCommonCase):
         self.assertTrue(self.ship1.need_release)
         self.assertFalse(self.ship2.need_release)
         self.assertTrue(
-            all(m.procure_method == "make_to_order" for m in self.ship1.move_ids)
+            all(m.procure_method == "make_to_order" for m in self.ship1.move_lines)
         )
         # Check pick has one move cancel and one still assign
         move_active = self.pick1.move_lines.filtered(lambda l: l.state == "assigned")


### PR DESCRIPTION
Backport of https://github.com/OCA/wms/pull/807
* Recover initial procure_method
* Before this change, once you have unreleased a move, you can steal whatever is available on output :/

Also ensures that split does never changes the procure_method to 'make to stock'. This was fixed in v15 by odoo.
* This backports https://github.com/odoo/odoo/commit/4180afb95112dbb1119fd68b7bd3f2f5e1160422#diff-55c6314416a6a400da6acd5018d161a55eeeb0e3008fec8828121e3dd12be0ebR1744

cc @TDu @mt-software-de @sebalix 