### PR TITLE
[14.0[FIX] shopfloor, zone_picking: get right qty when pack/lot is changed

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -667,12 +667,15 @@ class ZonePicking(Component):
                 )
             else:
                 change_package_lot = self._actions_for("change.package.lot")
+                move_line = first(move_lines)
                 response = change_package_lot.change_package(
-                    first(move_lines),
+                    move_line,
                     package,
-                    # FIXME we may need to pass the quantity being done
-                    self._response_for_set_line_destination,
-                    self._response_for_change_pack_lot,
+                    response_ok_func=functools.partial(
+                        self._response_for_set_line_destination,
+                        qty_done=self._get_prefill_qty(move_line, qty=0),
+                    ),
+                    response_error_func=self._response_for_change_pack_lot,
                 )
         else:
             response = self._list_move_lines(sublocation or self.zone_location)
@@ -1434,7 +1437,10 @@ class ZonePicking(Component):
         # pre-configured callable used to generate the response as the
         # change.package.lot component is not aware of the needed response type
         # and related parameters for zone picking scenario
-        response_ok_func = functools.partial(self._response_for_set_line_destination)
+        response_ok_func = functools.partial(
+            self._response_for_set_line_destination,
+            qty_done=self._get_prefill_qty(move_line),
+        )
         response_error_func = functools.partial(self._response_for_change_pack_lot)
         response = None
         change_package_lot = self._actions_for("change.package.lot")

--- a/shopfloor/tests/test_zone_picking_change_pack_lot.py
+++ b/shopfloor/tests/test_zone_picking_change_pack_lot.py
@@ -87,6 +87,7 @@ class ZonePickingChangePackLotCase(ZonePickingCommonCase):
             message=self.service.msg_store.package_replaced_by_package(
                 previous_package, self.free_package
             ),
+            qty_done=self.service._get_prefill_qty(move_line),
         )
 
     def test_change_pack_lot_change_lot_ok(self):
@@ -137,4 +138,5 @@ class ZonePickingChangePackLotCase(ZonePickingCommonCase):
             message=self.service.msg_store.lot_replaced_by_lot(
                 previous_lot, self.free_lot
             ),
+            qty_done=self.service._get_prefill_qty(move_line),
         )

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -348,6 +348,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             message=self.service.msg_store.package_replaced_by_package(
                 package1, package1b
             ),
+            qty_done=self.service._get_prefill_qty(move_lines[0]),
         )
         # Check the package has been changed on the move line
         self.assertEqual(self.picking1.package_level_ids[0].package_id, package1b)


### PR DESCRIPTION
Get the right quantity when we change a pack/lot:
![image](https://github.com/OCA/wms/assets/5315285/e5a604ae-c3ab-4f31-92a0-6b5c4f73f60c)
