### PR TITLE
[14.0][FIX] stock_available_to_promise_release: release_ready for stock.picking

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -85,10 +85,11 @@ class StockPicking(models.Model):
             release_ready_count = sum(
                 1 for move in move_lines if move._is_release_ready()
             )
-            if picking._get_shipping_policy() == "one":
-                release_ready = release_ready_count == len(move_lines)
-            else:
-                release_ready = bool(release_ready_count)
+            if move_lines:
+                if picking._get_shipping_policy() == "one":
+                    release_ready = release_ready_count == len(move_lines)
+                else:
+                    release_ready = bool(release_ready_count)
             picking.release_ready_count = release_ready_count
             picking.release_ready = release_ready
 

--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -1206,3 +1206,13 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         new_move = move.copy()
         new_move._assign_picking()
         self.assertNotEqual(picking, new_move.picking_id)
+
+    def test_cancel_release_ready(self):
+        self.wh.delivery_route_id.write({"available_to_promise_defer_pull": True})
+        self._update_qty_in_location(self.loc_bin1, self.product1, 20.0)
+        picking = self._create_picking_chain(
+            self.wh, [(self.product1, 5)], move_type="one"
+        )
+        self.assertTrue(picking.release_ready)
+        picking.action_cancel()
+        self.assertFalse(picking.release_ready)


### PR DESCRIPTION
If there is not any move which needs a release
the picking shouldn't release_ready either