### PR TITLE
[16.0][FIX] stock_dynamic_routing : avoid set state cancel to original picking with canceled_by_routing

### DIFF
--- a/stock_dynamic_routing/models/stock_move.py
+++ b/stock_dynamic_routing/models/stock_move.py
@@ -58,6 +58,13 @@ class StockMove(models.Model):
         self._apply_routing_rule_pull(moves_with_routing_details)
         self._apply_routing_rule_push(moves_with_routing_details)
 
+    def _action_cancel(self):
+        origin_moves = self.mapped("move_dest_ids")
+        res = super()._action_cancel()
+        for move in origin_moves:
+            move.picking_id.state = "confirmed"
+        return res
+
     def _action_assign(self, force_qty=False):
         if self.env.context.get("exclude_apply_dynamic_routing"):
             return super()._action_assign(force_qty=force_qty)

--- a/stock_dynamic_routing/models/stock_picking.py
+++ b/stock_dynamic_routing/models/stock_picking.py
@@ -17,7 +17,11 @@ class StockPicking(models.Model):
         res = super()._compute_state()
         for picking in self:
             if picking.canceled_by_routing:
-                picking.state = "cancel"
+                if not picking.move_ids:
+                    picking.state = "cancel"
+                else:
+                    # call to dynamic_routing_handle_empty to check/reset the flag
+                    self._dynamic_routing_handle_empty()
         return res
 
     def _dynamic_routing_handle_empty(self):
@@ -29,3 +33,6 @@ class StockPicking(models.Model):
                 # We could drop it but it can make code crash later in the
                 # transaction. This flag will set the picking as cancel.
                 picking.canceled_by_routing = True
+            else:
+                # If picking is not empty, update value.
+                picking.canceled_by_routing = False


### PR DESCRIPTION
When new picking is cancelled, original picking with canceled_by_routing = True stay all time to cancel, we add new check to see if have movements to mark that flag to false