### PR TITLE
[14.0] stock_available_to_promise_release: backport some commits from 16.0

### DIFF
--- a/stock_available_to_promise_release/models/__init__.py
+++ b/stock_available_to_promise_release/models/__init__.py
@@ -6,3 +6,4 @@ from . import stock_picking_type
 from . import stock_rule
 from . import res_company
 from . import res_config_settings
+from . import stock_location

--- a/stock_available_to_promise_release/models/stock_location.py
+++ b/stock_available_to_promise_release/models/stock_location.py
@@ -1,0 +1,19 @@
+# Copyright 2023 ACSONE SA/NV
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo import models
+from odoo.osv import expression
+
+
+class StockLocation(models.Model):
+    _inherit = "stock.location"
+
+    def _get_available_to_promise_domain(self):
+        location_domain = []
+        for location in self:
+            location_domain = expression.OR(
+                [
+                    location_domain,
+                    [("location_id.parent_path", "=like", location.parent_path + "%")],
+                ]
+            )
+        return location_domain

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -116,12 +116,23 @@ class StockMove(models.Model):
     def _check_unrelease_allowed(self):
         for move in self:
             if not move.unrelease_allowed:
-                raise UserError(
-                    _(
-                        "You are not allowed to unrelease this move %(move_name)s.",
-                        move_name=move.display_name,
-                    )
+                message = _(
+                    "You are not allowed to unrelease this move %(move_name)s.",
+                    move_name=move.display_name,
                 )
+                if move.picking_id:
+                    message += _(
+                        "\n- Picking: %(picking_name)s.",
+                        picking_name=move.picking_id.name,
+                    )
+                if move.move_orig_ids and move.move_orig_ids.picking_id:
+                    message += _(
+                        "\n- Origin picking(s):\n\t -%(picking_names)s.",
+                        picking_names="\n\t- ".join(
+                            move.move_orig_ids.picking_id.mapped("name")
+                        ),
+                    )
+                raise UserError(message)
 
     def _previous_promised_qty_sql_main_query(self):
         return """

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -332,13 +332,7 @@ class StockMove(models.Model):
                 }
             return res
 
-        location_domain = [
-            (
-                "location_id.parent_path",
-                "=like",
-                warehouse.view_location_id.parent_path + "%",
-            )
-        ]
+        location_domain = warehouse.view_location_id._get_available_to_promise_domain()
         domain_quant = expression.AND(
             [[("product_id", "in", self.product_id.ids)], location_domain]
         )

--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -188,7 +188,7 @@ class StockPicking(models.Model):
     def unrelease(self, safe_unrelease=False):
         """Unrelease the moves of the picking.
 
-        If safe_unrelease is True, the unreleasaable moves for which the
+        If safe_unrelease is True, the unreleasable moves for which the
         processing has already started will be ignored
         """
         self.mapped("move_lines").unrelease(safe_unrelease=safe_unrelease)

--- a/stock_available_to_promise_release/models/stock_picking_type.py
+++ b/stock_available_to_promise_release/models/stock_picking_type.py
@@ -10,14 +10,17 @@ class StockPickingType(models.Model):
     count_picking_need_release = fields.Integer(compute="_compute_picking_count")
     unrelease_on_backorder = fields.Boolean(
         string="Unrelease on backorder",
-        help="If checked, when a backorder is created the moves into the "
-        "backorder are unreleased if they come from a route configured "
-        "to manually release moves",
+        help="If checked, when a backorder is created (i.e. at the validation of "
+        "the delivery), the moves into the backorder are unreleased as long as "
+        "they came from a route configured to manually release moves. This means "
+        "that the moves that were not delivered are put back in need for release "
+        "and the unprocessed internal pulled moves are canceled.",
     )
     prevent_new_move_after_release = fields.Boolean(
         string="Prevent new move after release",
-        help="If checked, when a picking is released it's no more possible to "
-        "assign new moves to it.",
+        help="If checked, once a delivery picking has been released, no more "
+        "moves will be added to it. For example, if you add lines in the origin "
+        "sales order, the new moves will be added to a new delivery.",
     )
 
     def _compute_picking_count_need_release_domains(self):

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -2,9 +2,10 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import fields
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
+@tagged("post_install", "-at_install")
 class PromiseReleaseCommonCase(common.SavepointCase):
     @classmethod
     def setUpClass(cls):

--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -27,7 +27,7 @@
     </record>
 
     <record id="stock_picking_type_form" model="ir.ui.view">
-        <field name="name">stock.picking.type.kanban</field>
+        <field name="name">stock.picking.type.form</field>
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form" />
         <field name="arch" type="xml">


### PR DESCRIPTION
An attempt to reduce the diff between 14.0 and 16.0 but it's quite difficult as the commit history between 14.0 and 16.0 starts to be really different.