### PR TITLE
[14.0][FIX] shopfloor_base: Test without menu on actions

### DIFF
--- a/shopfloor_base/tests/common.py
+++ b/shopfloor_base/tests/common.py
@@ -70,9 +70,11 @@ class CommonCase(SavepointCase, RegistryMixin, ComponentMixin):
             **params
         )
 
-    def get_service(self, usage, collection=None, env=None, **kw):
+    def get_service(self, usage, collection=None, env=None, menu=None, **kw):
         with self.work_on_services(collection=collection, env=env, **kw) as work:
             service = work.component(usage=usage)
+            if menu:
+                service.work.menu = menu
             # Thanks to shopfloor.app we don't need controllers
             # but not having a controller means that non decorated methods
             # stay undecorated as they are not fixed at startup by base_rest.


### PR DESCRIPTION
The menu on a scenario is not set until i is used by dispatch
https://github.com/OCA/wms/blob/67963c9ef461d87c47d0dd9bf25a4e34e7485c2f/shopfloor_base/services/service.py#L35
It is set here
https://github.com/OCA/wms/blob/67963c9ef461d87c47d0dd9bf25a4e34e7485c2f/shopfloor_base/services/service.py#L202

When trying to get a action for
https://github.com/OCA/wms/blob/67963c9ef461d87c47d0dd9bf25a4e34e7485c2f/shopfloor_base/services/service.py#L39
The menu is not set on the returned component.
Because it is not as a component_instance.work._propagate_kwargs
https://github.com/OCA/wms/blob/67963c9ef461d87c47d0dd9bf25a4e34e7485c2f/shopfloor_base/actions/base_action.py#L23

Only kw args getting set as _propagate_kwargs 
https://github.com/OCA/connector/blob/30531a2131ee9cb9168216310f280fae0827771d/component/core.py#L242

Since there is now kwarg menu when initializing the service component
https://github.com/OCA/wms/blob/67963c9ef461d87c47d0dd9bf25a4e34e7485c2f/shopfloor_base/models/shopfloor_app.py#L300
https://github.com/OCA/rest-framework/blob/e8ce61565003639f31623354b952e5aee2df02f3/base_rest/models/rest_service_registration.py#L185

The menu is not propagated to actions_for


cc @i-vyshnevska @jbaudoux @TDu @simahawk 