### PR TITLE
[14.0][FIX] stock_available_to_promise_release: Imp on chained moves cancel

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -190,3 +190,7 @@ class StockPicking(models.Model):
         processing has already started will be ignored
         """
         self.mapped("move_lines").unrelease(safe_unrelease=safe_unrelease)
+
+    def action_cancel(self):
+        self.filtered(lambda p: p.state not in ("done", "cancel")).unrelease()
+        return super().action_cancel()


### PR DESCRIPTION
On move lines cancelation, the unrelease of the related transfers is being done. And it works well.

But when the module `stock_picking_restrict_cancel_with_orig_move` from stock-logistics-workflow is installed, they can conflict on the `_action_cancel` function from stock.move.line.

If the implementation of that function is first being called on this other module, an error will be raised before the unrelease of the moves can be done.

Both modules only depend on `stock`. This typically happens with chained moves.

The solution to also call the release of operation on the `action_cancel` of the stock picking, fixes the problem. Altough it is a litlle redundant with the implementation on stock move.