### PR TITLE
[16.0] Fix build regarding `stock_available_to_promise_release` and `stock_release_channel_batch_mode_commercial_partner`

### DIFF
--- a/stock_available_to_promise_release/tests/test_reservation.py
+++ b/stock_available_to_promise_release/tests/test_reservation.py
@@ -459,6 +459,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertFalse(out_picking)
 
         self._update_qty_in_location(self.loc_bin1, self.product1, 10.0)
+        cust_picking.invalidate_model(["release_ready"])
         self.env["stock.move"].invalidate_model(
             fnames=[
                 "previous_promised_qty",

--- a/stock_release_channel_batch_mode_commercial_partner/tests/test_channel_release_batch.py
+++ b/stock_release_channel_batch_mode_commercial_partner/tests/test_channel_release_batch.py
@@ -31,6 +31,7 @@ class TestChannelReleaseBatch(ChannelReleaseCase):
 
     def test_release_auto_group_commercial_partner_no_next_batch(self):
         self.channel.batch_mode = "group_commercial_partner"
-        self.pickings.need_release = False  # cheat for getting the right condition
+        # cheat for getting the right condition
+        self.pickings.move_ids.need_release = False
         action = self.channel.release_next_batch()
         self._assert_action_nothing_in_the_queue(action)


### PR DESCRIPTION
- Invalidate the cache of `stock.picking.release_ready` field when we put some qty in stock to recompute it.
- Fix test of `stock_release_channel_batch_mode_commercial_partner`