### PR TITLE
[FIX] stock_available_to_promise_release: Fix priority

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -605,6 +605,10 @@ class StockMove(models.Model):
             picking_ids.update(moves.picking_id.ids)
             moves = moves.move_orig_ids
         pickings = self.env["stock.picking"].browse(picking_ids)
+        # Don't take into account pickings that are already done or canceled
+        # This can happen if a move is a reliquat of a picking that has been
+        # already been processed.
+        pickings = pickings.filtered(lambda p: p.state not in ("done", "cancel"))
         pickings._after_release_update_chain()
         # Set the highest priority on all pickings in the chain
         priorities = pickings.mapped("priority")


### PR DESCRIPTION
When we compute the priority to apply at release time to the released picking, we must ignore priorities from already processed pickings. This is required to avoid corner cases where you explicitely set a new lower priority on a picking to release and this priority is changed since some of your moves are linked to backoder pickings already processed with an higher priority

cc @jbaudoux @rousseldenis @sbejaoui 