### PR TITLE
[FIX] stock_release_channel: Don't assign first a release channel if it will be filtered

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -486,8 +486,6 @@ class StockReleaseChannel(models.Model):
             current = picking
             domain = channel._prepare_domain()
             code = channel.sudo().code
-            if not domain and not code:
-                current.release_channel_id = channel
             if domain:
                 current = picking.filtered_domain(domain)
             if not current:


### PR DESCRIPTION

The release channel should be assigned at the end of all evaluation rules including the last filtering function.