### PR TITLE
[14.0][IMP] shopfloor: add option to exclude package types in product info

### DIFF
--- a/setup/shopfloor_reception_vendor_packaging/odoo/addons/shopfloor_reception_vendor_packaging
+++ b/setup/shopfloor_reception_vendor_packaging/odoo/addons/shopfloor_reception_vendor_packaging
@@ -1,0 +1,1 @@
+../../../../shopfloor_reception_vendor_packaging

--- a/setup/shopfloor_reception_vendor_packaging/setup.py
+++ b/setup/shopfloor_reception_vendor_packaging/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/setup/shopfloor_vendor_packaging/odoo/addons/shopfloor_vendor_packaging
+++ b/setup/shopfloor_vendor_packaging/odoo/addons/shopfloor_vendor_packaging
@@ -1,0 +1,1 @@
+../../../../shopfloor_vendor_packaging

--- a/setup/shopfloor_vendor_packaging/setup.py
+++ b/setup/shopfloor_vendor_packaging/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/shopfloor_reception_vendor_packaging/README.rst
+++ b/shopfloor_reception_vendor_packaging/README.rst
@@ -1,0 +1,1 @@
+wait for the bot

--- a/shopfloor_reception_vendor_packaging/__init__.py
+++ b/shopfloor_reception_vendor_packaging/__init__.py
@@ -1,0 +1,2 @@
+from . import services
+from .post_init_hook import post_init_hook

--- a/shopfloor_reception_vendor_packaging/__manifest__.py
+++ b/shopfloor_reception_vendor_packaging/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Shopfloor Reception Vendor Packaging",
+    "summary": "Manage shopfloor reception behavior for vendor packaging",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "depends": ["shopfloor_reception", "shopfloor_vendor_packaging"],
+    "auto_install": True,
+    "post_init_hook": "post_init_hook",
+}

--- a/shopfloor_reception_vendor_packaging/post_init_hook.py
+++ b/shopfloor_reception_vendor_packaging/post_init_hook.py
@@ -1,0 +1,32 @@
+# Copyright 2024 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import json
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    reception_scenario = env["shopfloor.scenario"].search([("key", "=", "reception")])
+    _update_scenario_options(reception_scenario)
+    reception_menus = env["shopfloor.menu"].search(
+        [("scenario_id", "=", reception_scenario.id)]
+    )
+    _enable_option_in_menus(reception_menus)
+
+
+def _update_scenario_options(scenario):
+    options = scenario.options
+    options["display_vendor_packaging"] = True
+    options_edit = json.dumps(options or {}, indent=4, sort_keys=True)
+    scenario.write({"options_edit": options_edit})
+    _logger.info("Option display_vendor_packaging added to scenario Reception")
+
+
+def _enable_option_in_menus(menus):
+    menus.display_vendor_packaging = True
+    _logger.info("Option display_vendor_packaging enabled for reception menus")

--- a/shopfloor_reception_vendor_packaging/readme/CONTRIBUTORS.rst
+++ b/shopfloor_reception_vendor_packaging/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>

--- a/shopfloor_reception_vendor_packaging/readme/DESCRIPTION.rst
+++ b/shopfloor_reception_vendor_packaging/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Add reception-specific logic and data after the implementation of shopfloor_vendor_packaging.

--- a/shopfloor_reception_vendor_packaging/services/__init__.py
+++ b/shopfloor_reception_vendor_packaging/services/__init__.py
@@ -1,0 +1,1 @@
+from . import reception

--- a/shopfloor_reception_vendor_packaging/services/reception.py
+++ b/shopfloor_reception_vendor_packaging/services/reception.py
@@ -1,0 +1,17 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+from odoo.addons.component.core import Component
+
+
+class Reception(Component):
+    _inherit = "shopfloor.reception"
+
+    def _data_for_move_lines(self, lines, **kw):
+        kw["display_vendor_packaging"] = self.work.menu.display_vendor_packaging
+        return super()._data_for_move_lines(lines, **kw)
+
+    def _data_for_moves(self, moves, **kw):
+        kw["display_vendor_packaging"] = self.work.menu.display_vendor_packaging
+        return super()._data_for_moves(moves, **kw)

--- a/shopfloor_vendor_packaging/README.rst
+++ b/shopfloor_vendor_packaging/README.rst
@@ -1,0 +1,1 @@
+wait for the bot

--- a/shopfloor_vendor_packaging/__init__.py
+++ b/shopfloor_vendor_packaging/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import actions

--- a/shopfloor_vendor_packaging/__manifest__.py
+++ b/shopfloor_vendor_packaging/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Shopfloor Vendor Packaging",
+    "summary": "Manage shopfloor behavior for vendor packaging",
+    "version": "14.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/wms",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "application": False,
+    "data": [
+        "views/shopfloor_menu.xml",
+    ],
+    "depends": ["shopfloor", "product_packaging_type_vendor"],
+    "auto-install": True,
+}

--- a/shopfloor_vendor_packaging/actions/__init__.py
+++ b/shopfloor_vendor_packaging/actions/__init__.py
@@ -1,0 +1,1 @@
+from . import data

--- a/shopfloor_vendor_packaging/actions/data.py
+++ b/shopfloor_vendor_packaging/actions/data.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.component.core import Component
+from odoo.addons.shopfloor_base.utils import ensure_model
+
+
+class DataAction(Component):
+    _inherit = "shopfloor.data.action"
+
+    @ensure_model("stock.move.line")
+    def move_line(self, record, with_picking=False, **kw):
+        display_vendor_packaging = kw.get("display_vendor_packaging")
+        record = record.with_context(
+            display_vendor_packaging=display_vendor_packaging,
+        )
+        return super().move_line(record, with_picking, **kw)
+
+    @ensure_model("stock.move")
+    def move(self, record, **kw):
+        display_vendor_packaging = kw.get("display_vendor_packaging")
+        record = record.with_context(
+            display_vendor_packaging=display_vendor_packaging,
+        )
+        return super().move(record, **kw)
+
+    @ensure_model("stock.package_level")
+    def package_level(self, record, **kw):
+        display_vendor_packaging = kw.get("display_vendor_packaging")
+        record = record.with_context(display_vendor_packaging=display_vendor_packaging)
+        return super().package_level(record, **kw)
+
+    @ensure_model("product.product")
+    def product(self, record, **kw):
+        display_vendor_packaging = kw.get("display_vendor_packaging")
+        record = record.with_context(display_vendor_packaging=display_vendor_packaging)
+        return super().product(record, **kw)
+
+    def _product_packaging(self, rec, field):
+        display_vendor_packaging = rec.env.context.get("display_vendor_packaging")
+        packagings = rec.packaging_ids
+        if display_vendor_packaging:
+            packagings = packagings.filtered(lambda x: x.qty)
+        else:
+            packagings = packagings.filtered(
+                lambda x: x.qty and not x.packaging_type_id.is_vendor_packaging
+            )
+        return self._jsonify(
+            packagings,
+            self._packaging_parser,
+            multi=True,
+        )

--- a/shopfloor_vendor_packaging/models/__init__.py
+++ b/shopfloor_vendor_packaging/models/__init__.py
@@ -1,0 +1,1 @@
+from . import shopfloor_menu

--- a/shopfloor_vendor_packaging/models/shopfloor_menu.py
+++ b/shopfloor_vendor_packaging/models/shopfloor_menu.py
@@ -1,0 +1,29 @@
+# Copyright 2024 Camptocamp SA (http://www.camptocamp.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+DISPLAY_VENDOR_PACKAGING_HELP = """
+    When enabled, the user will be able to see the vendor packagings
+    in the frontend, e.g. in the qty picker.
+"""
+
+
+class ShopfloorMenu(models.Model):
+    _inherit = "shopfloor.menu"
+
+    display_vendor_packaging = fields.Boolean(
+        string="Display vendor packagings",
+        default=False,
+        help=DISPLAY_VENDOR_PACKAGING_HELP,
+    )
+    display_vendor_packaging_is_possible = fields.Boolean(
+        compute="_compute_display_vendor_packaging_is_possible",
+    )
+
+    @api.depends("scenario_id")
+    def _compute_display_vendor_packaging_is_possible(self):
+        for menu in self:
+            menu.display_vendor_packaging_is_possible = menu.scenario_id.has_option(
+                "display_vendor_packaging"
+            )

--- a/shopfloor_vendor_packaging/readme/CONTRIBUTORS.rst
+++ b/shopfloor_vendor_packaging/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Juan Miguel Sánchez Arce <juan.sanchez@camptocamp.com>

--- a/shopfloor_vendor_packaging/readme/DESCRIPTION.rst
+++ b/shopfloor_vendor_packaging/readme/DESCRIPTION.rst
@@ -1,0 +1,2 @@
+When installed, this module adds a new option in shopfloor
+to prevent vendor packagings from being displayed in the frontend.

--- a/shopfloor_vendor_packaging/tests/__init__.py
+++ b/shopfloor_vendor_packaging/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_shopfloor_vendor_packaging

--- a/shopfloor_vendor_packaging/tests/test_shopfloor_vendor_packaging.py
+++ b/shopfloor_vendor_packaging/tests/test_shopfloor_vendor_packaging.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.shopfloor.tests.test_actions_data_base import ActionsDataCaseBase
+
+
+class TestShopfloorVendorPackaging(ActionsDataCaseBase):
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super().setUpClass(*args, **kwargs)
+        cls.product = cls.move_a.move_line_ids.product_id
+        vendor_packaging_type = (
+            cls.env["product.packaging.type"]
+            .sudo()
+            .create(
+                {
+                    "name": "Test Vendor Packaging Type",
+                    "code": "VP",
+                    "sequence": 99,
+                    "is_vendor_packaging": True,
+                }
+            )
+        )
+        vendor_packaging = (
+            cls.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "Test Vendor Packaging",
+                    "qty": 15,
+                    "packaging_type_id": vendor_packaging_type.id,
+                }
+            )
+        )
+        cls.product.sudo().update(
+            {"packaging_ids": cls.product.packaging_ids | vendor_packaging}
+        )
+
+    def test_data_product(self):
+        data = self.data.product(self.product, display_vendor_packaging=False)
+        self.assert_schema(self.schema.product(), data)
+        expected_packaging_codes = ["DEFAULT"]
+        self.assertEqual(
+            [packaging["code"] for packaging in data["packaging"]],
+            expected_packaging_codes,
+        )
+
+    def test_data_product_with_vendor_packaging(self):
+        data = self.data.product(self.product, display_vendor_packaging=True)
+        self.assert_schema(self.schema.product(), data)
+        expected_packaging_codes = ["DEFAULT", "VP"]
+        self.assertEqual(
+            [packaging["code"] for packaging in data["packaging"]],
+            expected_packaging_codes,
+        )

--- a/shopfloor_vendor_packaging/views/shopfloor_menu.xml
+++ b/shopfloor_vendor_packaging/views/shopfloor_menu.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="shopfloor_menu_form_view" model="ir.ui.view">
+        <field name="model">shopfloor.menu</field>
+        <field name="inherit_id" ref="shopfloor.shopfloor_menu_form_view" />
+        <field name="arch" type="xml">
+            <group name="options" position="inside">
+                <group
+                    name="display_vendor_packaging"
+                    attrs="{'invisible': [('display_vendor_packaging_is_possible', '=', False)]}"
+                >
+                    <field name="display_vendor_packaging_is_possible" invisible="1" />
+                    <field name="display_vendor_packaging" />
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Depends on:
- https://github.com/OCA/product-attribute/pull/1523

Qty picker:
<img src="https://github.com/OCA/wms/assets/77412816/1eff781f-05cb-4df5-acdb-28d87fc61430" width="600" height="400">

Settings:
<img src="https://github.com/OCA/wms/assets/77412816/957c2cac-7ed5-4c23-a278-ed9213615e21" width="400" height="450">



ref: cos-4389