### PR TITLE
[14.0][IMP] shopfloor: mark lines as sf_checkout_done when handled in backend

### DIFF
--- a/shopfloor/models/stock_picking.py
+++ b/shopfloor/models/stock_picking.py
@@ -116,3 +116,14 @@ class StockPicking(models.Model):
         )
         assigned_moves._action_assign()
         return new_picking.id
+
+    def _put_in_pack(self, move_line_ids, create_package_level=True):
+        """
+        Marks the corresponding move lines as 'shopfloor_checkout_done'
+        when the package is created in the backend.
+
+        """
+        new_package = super()._put_in_pack(move_line_ids, create_package_level)
+        lines = move_line_ids.filtered(lambda p: p.result_package_id == new_package)
+        lines.write({"shopfloor_checkout_done": True})
+        return new_package

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -455,3 +455,28 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
             selected_line,
             message={"message_type": "error", "body": "Barcode not found"},
         )
+
+    def test_put_in_pack(self):
+        picking = self._create_picking(
+            lines=[(self.product_a, 10), (self.product_b, 20)]
+        )
+        self._fill_stock_for_moves(picking.move_lines)
+        picking.action_assign()
+
+        # Test that the move lines are marked as 'shopfloor_checkout_done'
+        # when putting them in a pack in the backend.
+        picking._put_in_pack(picking.move_line_ids)
+        self.assertTrue(
+            all(line.shopfloor_checkout_done for line in picking.move_line_ids)
+        )
+
+        # Check that we return those lines to the frontend.
+        res = self.service.dispatch(
+            "summary",
+            params={
+                "picking_id": picking.id,
+            },
+        )
+        returned_lines = res["data"]["summary"]["picking"]["move_lines"]
+        expected_line_ids = [line["id"] for line in returned_lines]
+        self.assertEqual(expected_line_ids, picking.move_line_ids.ids)


### PR DESCRIPTION
This PR overrides the put_in_pack method from stock.picking
so that it marks lines as shopfloor_checkout_done
when putting them in a pack in the backend.

This is done to make sure that these lines are displayed
in the shopfloor frontend even if they're handled in the backend.

ref: cos-4343