### PR TITLE
[14.0][IMP] shopfloor, stock_picking_partner_note: display picking info notes in cluster_picking and checkout scenarios

### DIFF
--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -98,7 +98,6 @@ class Checkout(Component):
         return {
             "selected_move_lines": self._data_for_move_lines(lines.sorted()),
             "picking": self.data.picking(picking),
-            "packing_info": self._data_for_packing_info(picking),
             "no_package_enabled": not self.options.get("checkout__disable_no_package"),
             # Used by inheriting module
             "package_allowed": True,
@@ -110,14 +109,6 @@ class Checkout(Component):
             data=self._data_response_for_select_package(picking, lines),
             message=message,
         )
-
-    def _data_for_packing_info(self, picking):
-        """Return the packing information
-
-        Intended to be extended.
-        """
-        # TODO: This could be avoided if included in the picking parser.
-        return ""
 
     def _response_for_select_dest_package(self, picking, move_lines, message=None):
         packages = picking.mapped("move_line_ids.result_package_id").filtered(

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -67,7 +67,6 @@ class CheckoutCommonCase(CommonCase):
                     self._move_line_data(ml) for ml in picking.move_line_ids.sorted()
                 ],
                 "picking": self._picking_summary_data(picking),
-                "packing_info": "",
                 "no_package_enabled": True,
                 "package_allowed": True,
             },

--- a/shopfloor/tests/test_checkout_list_delivery_packaging.py
+++ b/shopfloor/tests/test_checkout_list_delivery_packaging.py
@@ -111,7 +111,6 @@ class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackag
                 "selected_move_lines": [
                     self._move_line_data(ml) for ml in selected_lines.sorted()
                 ],
-                "packing_info": self.service._data_for_packing_info(self.picking),
                 "no_package_enabled": not self.service.options.get(
                     "checkout__disable_no_package"
                 ),

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -172,7 +172,6 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
             data={
                 "picking": self.data.picking(picking),
                 "selected_move_lines": self.data.move_lines(selected_lines),
-                "packing_info": self.service._data_for_packing_info(picking),
                 "no_package_enabled": not self.service.options.get(
                     "checkout__disable_no_package"
                 ),

--- a/shopfloor/tests/test_checkout_select_package_base.py
+++ b/shopfloor/tests/test_checkout_select_package_base.py
@@ -21,7 +21,6 @@ class CheckoutSelectPackageMixin:
                     self._move_line_data(ml) for ml in selected_lines.sorted()
                 ],
                 "picking": self._picking_summary_data(picking),
-                "packing_info": packing_info,
                 "no_package_enabled": no_package_enabled,
                 "package_allowed": package_allowed,
             },

--- a/shopfloor_mobile/static/wms/src/css/main.css
+++ b/shopfloor_mobile/static/wms/src/css/main.css
@@ -71,3 +71,10 @@ I tested only w/ checkout/select_package for now
     top: 5px;
     right: 5px;
 }
+
+/*
+Split the lines correctly if there are multiple lines separated by \n in a v-text.
+*/
+.split-text-lines {
+    white-space: pre-line;
+}

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -76,8 +76,8 @@ const Checkout = {
             </div>
 
             <div v-if="state_is('select_package')">
-                <v-alert type="info" tile v-if="state.data.packing_info" class="packing-info">
-                    <p v-text="state.data.packing_info" />
+                <v-alert type="info" tile v-if="state.data.picking.note" class="packing-info">
+                    <p v-text="state.data.picking.note" />
                 </v-alert>
                 <item-detail-card
                     v-if="state.data.picking.carrier"

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -77,7 +77,7 @@ const Checkout = {
 
             <div v-if="state_is('select_package')">
                 <v-alert type="info" tile v-if="state.data.picking.note" class="packing-info">
-                    <p v-text="state.data.picking.note" />
+                    <p class="split-text-lines" v-text="state.data.picking.note" />
                 </v-alert>
                 <item-detail-card
                     v-if="state.data.picking.carrier"

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -34,7 +34,7 @@ const ClusterPicking = {
                 v-on:cancel="state.on_cancel"
                 />
             <v-alert type="info" tile v-if="state_is('start_line') && state.data.picking.note" class="packing-info">
-                <p v-text="state.data.picking.note" />
+                <p class="split-text-lines" v-text="state.data.picking.note" />
             </v-alert>
             <batch-picking-line-detail
                 v-if="state_in(['start_line', 'scan_destination', 'change_pack_lot', 'stock_issue'])"

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -33,6 +33,9 @@ const ClusterPicking = {
                 v-on:confirm="state.on_confirm"
                 v-on:cancel="state.on_cancel"
                 />
+            <v-alert type="info" tile v-if="state_is('start_line') && state.data.picking.note" class="packing-info">
+                <p v-text="state.data.picking.note" />
+            </v-alert>
             <batch-picking-line-detail
                 v-if="state_in(['start_line', 'scan_destination', 'change_pack_lot', 'stock_issue'])"
                 :line="state.data"

--- a/shopfloor_packing_info/__manifest__.py
+++ b/shopfloor_packing_info/__manifest__.py
@@ -3,14 +3,14 @@
 {
     "name": "Shopfloor Packing Info",
     "summary": "Allows to predefine packing information messages per partner.",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.2.0",
     "development_status": "Alpha",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": False,
-    "depends": ["shopfloor", "sales_team"],
+    "depends": ["shopfloor", "sales_team", "stock_picking_partner_note"],
     "data": [
         "security/ir.model.access.csv",
         "views/res_partner_views.xml",

--- a/shopfloor_packing_info/migrations/14.0.1.2.0/post-migrate.py
+++ b/shopfloor_packing_info/migrations/14.0.1.2.0/post-migrate.py
@@ -41,11 +41,12 @@ def populate_stock_picking_note__packing(env):
                 "note_type_id": packing_note_type.id,
             }
         )
-        partner = env["res.partner"].search(
-            [("shopfloor_packing_info_id", "=", packing_info.id)], limit=1
+        partners = env["res.partner"].search(
+            [("shopfloor_packing_info_id", "=", packing_info.id)]
         )
-        if partner:
-            partner.stock_picking_note_ids |= note
+        if partners:
+            for partner in partners:
+                partner.stock_picking_note_ids |= note
 
 
 def migrate(cr, version):

--- a/shopfloor_packing_info/migrations/14.0.1.2.0/post-migrate.py
+++ b/shopfloor_packing_info/migrations/14.0.1.2.0/post-migrate.py
@@ -1,0 +1,56 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+# NOTE: This module is deprecated in favor of stock_picking_partner_note.
+# Here, we migrate the data from shopfloor.packing.info to stock.picking.note.
+
+
+def setup_stock_picking_note__packing(env):
+    """Create a new packing note type named 'packing'."""
+
+    _logger.info("Create a new picking note type named 'packing'")
+    packing_note_type = env["stock.picking.note.type"].search(
+        [("name", "=", "packing")], limit=1
+    )
+    if not packing_note_type:
+        packing_note_type = env["stock.picking.note.type"].create({"name": "packing"})
+    return packing_note_type
+
+
+def populate_stock_picking_note__packing(env):
+    """Migrate data from shopfloor.packing.info to stock.picking.note of type 'packing'.
+
+    We also update the stock_picking_note_ids of the partners
+    based on their existing shopfloor_packing_info_id values."""
+
+    _logger.info(
+        "Migrate data from shopfloor.packing.info to stock.picking.note of type 'packing'"
+    )
+    packing_note_type = setup_stock_picking_note__packing(env)
+    existing_packing_infos = env["shopfloor.packing.info"].search([])
+    for packing_info in existing_packing_infos:
+        note = env["stock.picking.note"].create(
+            {
+                "name": packing_info.text,
+                "note_type_id": packing_note_type.id,
+            }
+        )
+        partner = env["res.partner"].search(
+            [("shopfloor_packing_info_id", "=", packing_info.id)], limit=1
+        )
+        if partner:
+            partner.stock_picking_note_ids |= note
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    populate_stock_picking_note__packing(env)

--- a/shopfloor_packing_info/readme/DESCRIPTION.rst
+++ b/shopfloor_packing_info/readme/DESCRIPTION.rst
@@ -1,3 +1,7 @@
+DEPRECATED: This module is deprecated in favor of stock_picking_partner_note,
+which is now used in shopfloor to display notes in the app.
+
+
 Adds the option to choose predefined messages for the
 parameter "Checkout Packing Info", that is set on Customers
 and reused in other places, mainly pickings. These new messages


### PR DESCRIPTION
Depends on:
- https://github.com/OCA/stock-logistics-workflow/pull/1504

Stock picking partner notes are notes that are pre-defined for each customer
and can be displayed for each picking.
With this PR, we send them to the frontend for the cluster picking scenario and display them where needed.

This PR also deprecated `shopfloor_packing_info` in favor of `stock_picking_partner_note`, which is now used for both checkout and cluster picking.

![note_in_cluster_picking](https://github.com/OCA/wms/assets/77412816/068a9a5c-b76c-42c6-b8c4-f39e79ebcf72)



ref: cos-4214