### PR TITLE
[14.0][IMP] shopfloor: apply zero_check only if product is not a consumable

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -776,8 +776,11 @@ class ClusterPicking(Component):
                 qty_done=quantity,
             )
         move_line.write({"qty_done": quantity, "result_package_id": bin_package.id})
-
-        zero_check = move_line.picking_id.picking_type_id.shopfloor_zero_check
+        # Only apply zero check if the product is of type "product".
+        zero_check = (
+            move_line.product_id.type == "product"
+            and move_line.picking_id.picking_type_id.shopfloor_zero_check
+        )
         if zero_check and move_line.location_id.planned_qty_in_location_is_empty():
             return self._response_for_zero_check(batch, move_line)
 

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -959,7 +959,11 @@ class ZonePicking(Component):
 
         location_changed = True
         # Zero check
-        zero_check = self.picking_type.shopfloor_zero_check
+        # Only apply zero check if the product is of type "product".
+        zero_check = (
+            move_line.product_id.type == "product"
+            and self.picking_type.shopfloor_zero_check
+        )
         if zero_check and move_line.location_id.planned_qty_in_location_is_empty():
             response = self._response_for_zero_check(move_line)
         return (location_changed, response)
@@ -1042,7 +1046,11 @@ class ZonePicking(Component):
             return (package_changed, response)
         package_changed = True
         # Zero check
-        zero_check = self.picking_type.shopfloor_zero_check
+        # Only apply zero check if the product is of type "product".
+        zero_check = (
+            move_line.product_id.type == "product"
+            and self.picking_type.shopfloor_zero_check
+        )
         if zero_check and move_line.location_id.planned_qty_in_location_is_empty():
             response = self._response_for_zero_check(move_line)
         return (package_changed, response)


### PR DESCRIPTION
Consumables don't need to be taken into account when applying the zero_check.

ref: cos-4403