### PR TITLE
[14.0][FIX] shopfloor_manual_product_transfer_mobile: fix wrong qty_done

### DIFF
--- a/shopfloor_manual_product_transfer_mobile/static/wms/src/scenario/manual_product_transfer.js
+++ b/shopfloor_manual_product_transfer_mobile/static/wms/src/scenario/manual_product_transfer.js
@@ -163,6 +163,9 @@ const ManualProductTransfer = {
             }
             if ("qty_done" in data) return data.qty_done;
             if ("quantity" in data) return data.quantity;
+            if ("move_lines" in data) {
+                return data.move_lines.reduce((total, val) => total + val.qty_done, 0);
+            }
             return 0;
         },
         lot: function () {


### PR DESCRIPTION
In scenario `shopfloor_manual_product_transfer_mobile`, state `scan_destination_location`, the `qty_done` was not correctly calculated.

Note: the new code follows the logic implemented to calculate `quantity` in this same file, which did take into account this possibility (line 154).

ref: cos-4440