### PR TITLE
[16.0] stock_warehouse_flow: enable auto-created locations

### DIFF
--- a/stock_warehouse_flow/models/stock_warehouse_flow.py
+++ b/stock_warehouse_flow/models/stock_warehouse_flow.py
@@ -294,6 +294,7 @@ class StockWarehouseFlow(models.Model):
                         {
                             "name": self.sequence_prefix,
                             "location_id": self.warehouse_id.wh_output_stock_loc_id.id,
+                            "active": True,
                         }
                     )
                 )
@@ -319,6 +320,7 @@ class StockWarehouseFlow(models.Model):
                         {
                             "name": self.sequence_prefix,
                             "location_id": self.warehouse_id.wh_pack_stock_loc_id.id,
+                            "active": True,
                         }
                     )
                 self.pick_type_id.default_location_dest_id = self.pack_stock_loc_id


### PR DESCRIPTION
When generating automatically the new delivery route, created locations should be enabled by default.

Tests on CI were failing since this commit in `odoo/odoo`:
- https://github.com/odoo/odoo/commit/91cb87f50ce46e1c9196e4c3ff6c0300ee27581e

Details: quants are now cached, and the cache is built by using `child_of` operator which was ignoring archived locations. When no cache was used, `=` operator was used which is working as expected, e.g:
```python
(Pdb++) self.env['stock.quant'].search([("product_id", "in", [20]), ("location_id", "=", 211)])
stock.quant(153,)
(Pdb++) self.env['stock.quant'].search([("product_id", "in", [20]), ("location_id", "child_of", 211)])
stock.quant()
```
This cache should probably make use of `active_test=False`, but `stock_warehouse_flow` must enabled the locations it creates anyway.