### PR TITLE
[16.0][FIX] stock_available_to_promise_release: fix cache and failing tests

### DIFF
--- a/stock_release_channel_auto_release/tests/test_channel_release_auto.py
+++ b/stock_release_channel_auto_release/tests/test_channel_release_auto.py
@@ -17,9 +17,6 @@ class TestChannelReleaseAuto(ChannelReleaseCase):
         cls._update_qty_in_location(cls.loc_bin1, cls.product1, 1000.0)
         cls._update_qty_in_location(cls.loc_bin1, cls.product2, 1000.0)
 
-        # invalidate cache for computed fields bases on qty in stock
-        cls.env.invalidate_all()
-
     @contextmanager
     def assert_release_job_enqueued(self, channel):
         pickings_to_release = channel._get_pickings_to_release()


### PR DESCRIPTION
_compute_ordered_available_to_promise has no depends set. Any field depending on computed values must invalidate cache before reading.

cc @sebalix @mt-software-de @rousseldenis 