### PR TITLE
[16.0][FIX] stock_release_channel_process_end_time: releasable picking computation

### DIFF
--- a/stock_release_channel_process_end_time/__manifest__.py
+++ b/stock_release_channel_process_end_time/__manifest__.py
@@ -8,8 +8,8 @@
         propagate it to the concerned pickings""",
     "version": "16.0.1.1.0",
     "license": "AGPL-3",
-    "maintainers": ["rousseldenis"],
-    "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
+    "maintainers": ["rousseldenis", "jbaudoux"],
+    "author": "ACSONE SA/NV,BCIM,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",
     "depends": [
         "partner_tz",

--- a/stock_release_channel_process_end_time/models/stock_release_channel.py
+++ b/stock_release_channel_process_end_time/models/stock_release_channel.py
@@ -1,4 +1,5 @@
 # Copyright 2023 ACSONE SA/NV
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import api, fields, models
 

--- a/stock_release_channel_process_end_time/readme/CONTRIBUTORS.rst
+++ b/stock_release_channel_process_end_time/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * Denis Roussel <denis.roussel@acsone.eu>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/stock_release_channel_process_end_time/tests/test_release_end_date.py
+++ b/stock_release_channel_process_end_time/tests/test_release_end_date.py
@@ -1,4 +1,5 @@
 # Copyright 2023 ACSONE SA/NV
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from freezegun import freeze_time
 
@@ -59,6 +60,49 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
             "2023-01-27 23:30:00",
             fields.Datetime.to_string(self.channel.process_end_date),
         )
+
+    @freeze_time("2023-01-27 10:00:00")
+    def test_channel_counter_release_ready(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "stock_release_channel_process_end_time.stock_release_use_channel_end_date",
+            True,
+        )
+        # Remove existing jobs as some already exists to assign pickings to channel
+        jobs_before = self.env["queue.job"].search([])
+        jobs_before.unlink()
+        # Set the end time
+        self.channel.process_end_time = 23.0
+        # Set picking scheduled date
+        pickings = self.picking | self.picking2 | self.picking3
+        pickings.write({"scheduled_date": fields.Datetime.now()})
+
+        # Asleep the release channel to void the process end date
+        self.channel.action_sleep()
+        self.channel.invalidate_recordset()
+        self.channel.action_wake_up()
+        # Execute the picking channel assignations
+        jobs_after = self.env["queue.job"].search([])
+        for job in jobs_after:
+            job = Job.load(job.env, job.uuid)
+            job.perform()
+
+        self.assertEqual(pickings, self.channel.picking_ids)
+        # at this stage, the pickings are not ready to be released as the
+        # qty available is not enough
+        self.assertFalse(self.channel._get_pickings_to_release())
+
+        self._update_qty_in_location(self.loc_bin1, self.product1, 100.0)
+        self._update_qty_in_location(self.loc_bin1, self.product2, 100.0)
+
+        self.assertEqual(pickings, self.channel._get_pickings_to_release())
+        # if the scheduled date of one picking is changed to be on a time after the
+        # process end date but on the same day, it should still be releasable
+        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-27 23:30:00")
+        self.assertEqual(pickings, self.channel._get_pickings_to_release())
+        # if the scheduled date of one picking is changed to be on a date after the
+        # process end date, it should not be releasable anymore
+        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-28 00:00:00")
+        self.assertEqual(pickings[1:], self.channel._get_pickings_to_release())
 
     @freeze_time("2023-01-27 10:00:00")
     def test_picking_scheduled_date(self):


### PR DESCRIPTION
Fix failing test on `stock_release_channel` when this module is installed

Ensure computation is bound to related channel.
Fix timezone conversion and compare dates.
Don't break base behavior when no process_end_date is set.

cc @lmignon @rousseldenis @sbejaoui @sebalix 