### PR TITLE
[16.0][IMP] stock_release_channel: assign picking after channel sleep if possible

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -848,7 +848,7 @@ class StockReleaseChannel(models.Model):
         pickings_to_unassign.write({"release_channel_id": False})
         pickings_to_unassign.unrelease()
         self.write({"state": "asleep"})
-        pickings_to_unassign.assign_release_channel()
+        pickings_to_unassign._delay_assign_release_channel()
 
     def action_wake_up(self):
         self._check_is_action_wake_up_allowed()

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -848,6 +848,7 @@ class StockReleaseChannel(models.Model):
         pickings_to_unassign.write({"release_channel_id": False})
         pickings_to_unassign.unrelease()
         self.write({"state": "asleep"})
+        pickings_to_unassign.assign_release_channel()
 
     def action_wake_up(self):
         self._check_is_action_wake_up_allowed()

--- a/stock_release_channel/tests/test_release_channel_lifecycle.py
+++ b/stock_release_channel/tests/test_release_channel_lifecycle.py
@@ -42,6 +42,14 @@ class TestReleaseChannelLifeCycle(ReleaseChannelCase):
         move.picking_id.assign_release_channel()
         self.assertFalse(move.picking_id.release_channel_id)
 
+    def test_release_channel_asleep_assignable_if_suitable_candidate(self):
+        move = self._create_single_move(self.product1, 10)
+        move.picking_id.assign_release_channel()
+        self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
+        copy_channel = self.default_channel.copy({"name": "channel copy"})
+        self.default_channel.action_sleep()
+        self.assertEqual(move.picking_id.release_channel_id, copy_channel)
+
     def test_release_channel_wake_up_assign(self):
         self.default_channel.action_sleep()
         move = self._create_single_move(self.product1, 10)

--- a/stock_release_channel/tests/test_release_channel_lifecycle.py
+++ b/stock_release_channel/tests/test_release_channel_lifecycle.py
@@ -47,7 +47,9 @@ class TestReleaseChannelLifeCycle(ReleaseChannelCase):
         move.picking_id.assign_release_channel()
         self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
         copy_channel = self.default_channel.copy({"name": "channel copy"})
-        self.default_channel.action_sleep()
+        with trap_jobs() as trap:
+            self.default_channel.action_sleep()
+            trap.perform_enqueued_jobs()
         self.assertEqual(move.picking_id.release_channel_id, copy_channel)
 
     def test_release_channel_wake_up_assign(self):

--- a/stock_release_channel/tests/test_release_channel_lifecycle.py
+++ b/stock_release_channel/tests/test_release_channel_lifecycle.py
@@ -46,7 +46,9 @@ class TestReleaseChannelLifeCycle(ReleaseChannelCase):
         move = self._create_single_move(self.product1, 10)
         move.picking_id.assign_release_channel()
         self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
-        copy_channel = self.default_channel.copy({"name": "channel copy"})
+        copy_channel = self.default_channel.copy(
+            {"name": "channel copy", "state": "open"}
+        )
         with trap_jobs() as trap:
             self.default_channel.action_sleep()
             trap.perform_enqueued_jobs()


### PR DESCRIPTION
After the sleep action, attempt to assign undone pickings to another channel if possible