### PR TITLE
[16.0][FIX] stock_release_channel_process_end_time: time zone datetime computation

### DIFF
--- a/stock_release_channel_cutoff/tests/test_compute_cutoff_time.py
+++ b/stock_release_channel_cutoff/tests/test_compute_cutoff_time.py
@@ -1,4 +1,5 @@
 # Copyright 2023 Camptocamp
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from datetime import datetime
@@ -8,85 +9,60 @@ from freezegun import freeze_time
 from odoo.tests.common import TransactionCase
 
 
-class TestStockReleaseChannel(TransactionCase):
+class TestStockReleaseChannelCutoff(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.stock_release_channel_default = cls.env.ref(
-            "stock_release_channel.stock_release_channel_default"
-        )
-        cls.env.user.tz = "UTC"  # Timezone UTC
-
-    @freeze_time("2023-02-01 9:00:00")
-    def test_compute_cutoff_warning(self):
-        self.stock_release_channel_default.write(
+        cls.channel = cls.env.ref("stock_release_channel.stock_release_channel_default")
+        cls.channel.write(
             {
-                "cutoff_time": 8.0,
                 "process_end_date": datetime.strptime(
                     "2023-02-01 9:00:00", "%Y-%m-%d %H:%M:%S"
                 ),
             }
         )
-        # Ensure the cutoff_warning is correctly computed in the user's timezone
-        self.assertTrue(self.stock_release_channel_default.cutoff_warning)
-
-        # Write record with a cutoff time in UTC+1
-        self.env.user.tz = "Europe/Brussels"
-        self.stock_release_channel_default.write(
-            {
-                "cutoff_time": 9.5,
-            }
-        )
-        # Ensure the cutoff_warning is correctly computed in the user's timezone
-        # 9:30 - 1:00 (UTC+1) = 8:30
-        self.assertTrue(self.stock_release_channel_default.cutoff_warning)
-
-        # Test the case when cutoff_time is empty
-        self.stock_release_channel_default.write(
-            {
-                "cutoff_time": False,
-            }
-        )
-
-        self.assertFalse(self.stock_release_channel_default.cutoff_warning)
 
     @freeze_time("2023-02-01 9:00:00")
-    def test_cutoff_warning_with_process_end_date(self):
-        # Test the case when the process end date is greater than now
-        self.stock_release_channel_default.write(
-            {
-                "cutoff_time": 12.0,
-                "process_end_date": datetime.strptime(
-                    "2023-02-02 10:00:00", "%Y-%m-%d %H:%M:%S"
-                ),
-            }
-        )
-        self.assertFalse(self.stock_release_channel_default.cutoff_warning)
+    def test_compute_cutoff_no_warning(self):
+        # No cutoff
+        self.assertFalse(self.channel.cutoff_warning)
+        # Cutoff after now
+        self.channel.cutoff_time = 10.0
+        self.assertFalse(self.channel.cutoff_warning)
 
-        self.stock_release_channel_default.write(
-            {
-                "cutoff_time": 8.0,
-            }
-        )
-        self.assertFalse(self.stock_release_channel_default.cutoff_warning)
+    @freeze_time("2023-02-01 9:00:00")
+    def test_compute_cutoff_warning(self):
+        self.channel.cutoff_time = 8.0
+        self.assertTrue(self.channel.cutoff_warning)
 
-        # Test the case when the process end date is less than now
-        self.stock_release_channel_default.write(
-            {
-                "cutoff_time": 12.0,
-                "process_end_date": datetime.strptime(
-                    "2023-1-31 10:00:00", "%Y-%m-%d %H:%M:%S"
-                ),
-            }
-        )
-        self.assertTrue(self.stock_release_channel_default.cutoff_warning)
+    @freeze_time("2023-02-01 9:00:00")
+    def test_compute_cutoff_no_warning_tz(self):
+        self.env.company.partner_id.tz = "Europe/Brussels"
+        # It is now in local time 2023-02-01 10:00:00
+        self.channel.cutoff_time = 10.5
+        self.assertFalse(self.channel.cutoff_warning)
 
-        self.stock_release_channel_default.write(
-            {
-                "cutoff_time": 8.0,
-                "process_end_date": datetime.strptime(
-                    "2023-1-31 10:00:00", "%Y-%m-%d %H:%M:%S"
-                ),
-            }
-        )
-        self.assertTrue(self.stock_release_channel_default.cutoff_warning)
+    @freeze_time("2023-02-01 9:00:00")
+    def test_compute_cutoff_warning_tz(self):
+        self.env.company.partner_id.tz = "Europe/Brussels"
+        # It is now in local time 2023-02-01 10:00:00
+        self.channel.cutoff_time = 9.5
+        self.assertTrue(self.channel.cutoff_warning)
+
+    @freeze_time("2023-01-31 9:00:00")
+    def test_cutoff_warning_with_process_end_date_tomorrow(self):
+        # Test the case when the process end date is tomorrow
+        self.channel.cutoff_time = 10.0
+        self.assertFalse(self.channel.cutoff_warning)
+
+        self.channel.cutoff_time = 8.0
+        self.assertFalse(self.channel.cutoff_warning)
+
+    @freeze_time("2023-02-02 9:00:00")
+    def test_cutoff_warning_with_process_end_date_yesterday(self):
+        # Test the case when the process end date is yesterday
+        self.channel.cutoff_time = 10.0
+        self.assertTrue(self.channel.cutoff_warning)
+
+        self.channel.cutoff_time = 8.0
+        self.assertTrue(self.channel.cutoff_warning)

--- a/stock_release_channel_process_end_time/tests/test_release_end_date.py
+++ b/stock_release_channel_process_end_time/tests/test_release_end_date.py
@@ -153,19 +153,81 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.assertTrue(self.channel.with_user(user).process_end_time_can_edit)
 
     @freeze_time("2023-01-27")
-    def test_channel_end_date_warehouse_timezone(self):
+    def test_channel_end_date_warehouse_timezone_asia(self):
+        # Today is 2023-01-27 06:00 in Asia
+        # Set a warehouse with an adress and a timezone on channel
+        self.channel.warehouse_id = self.env.ref("stock.warehouse0")
+        self.channel.warehouse_id.partner_id.tz = "Etc/GMT-6"
+        # Set the end time - In UTC == 15:00
+        self.channel.process_end_time = 21.0
+        # Asleep the release channel to void the process end date
+        self.channel.action_sleep()
+        self.channel.invalidate_recordset()
+        # Wake up the channel to set the process end date
+        self.channel.action_wake_up()
+        # Local time is 2023-01-27 21:00
+        self.assertEqual(
+            "2023-01-27 15:00:00",
+            fields.Datetime.to_string(self.channel.process_end_date),
+        )
+        # Set the end time - In UTC == 21:00
+        self.channel.process_end_time = 3.0
+        # Asleep the release channel to void the process end date
+        self.channel.action_sleep()
+        self.channel.invalidate_recordset()
+        # Wake up the channel to set the process end date
+        self.channel.action_wake_up()
+        # Local time is 2023-01-28 03:00
+        self.assertEqual(
+            "2023-01-27 21:00:00",
+            fields.Datetime.to_string(self.channel.process_end_date),
+        )
+
+    @freeze_time("2023-01-27")
+    def test_channel_end_date_warehouse_timezone_america(self):
+        # Now is 2023-01-26 18:00 in America
+        # Set a warehouse with an adress and a timezone on channel
+        self.channel.warehouse_id = self.env.ref("stock.warehouse0")
+        self.channel.warehouse_id.partner_id.tz = "Etc/GMT+6"
+        # Set the end time - In UTC == 3:00 +1d
+        self.channel.process_end_time = 21.0
+        # Asleep the release channel to void the process end date
+        self.channel.action_sleep()
+        self.channel.invalidate_recordset()
+        # Wake up the channel to set the process end date
+        self.channel.action_wake_up()
+        # Local time is 2023-01-26 21:00
+        self.assertEqual(
+            "2023-01-27 03:00:00",
+            fields.Datetime.to_string(self.channel.process_end_date),
+        )
+        # Set the end time - In UTC == 9:00
+        self.channel.process_end_time = 3.0
+        # Asleep the release channel to void the process end date
+        self.channel.action_sleep()
+        self.channel.invalidate_recordset()
+        # Wake up the channel to set the process end date
+        self.channel.action_wake_up()
+        # Local time is 2023-01-27 03:00
+        self.assertEqual(
+            "2023-01-27 09:00:00",
+            fields.Datetime.to_string(self.channel.process_end_date),
+        )
+
+    @freeze_time("2023-01-27 11:00:00")
+    def test_channel_end_date_warehouse_timezone_tomorrow(self):
         # Set a warehouse with an adress and a timezone on channel
         self.channel.warehouse_id = self.env.ref("stock.warehouse0")
         self.channel.warehouse_id.partner_id.tz = "Europe/Brussels"
         # Set the end time - In UTC == 22:00
-        self.channel.process_end_time = 23.0
+        self.channel.process_end_time = 10.0
         # Asleep the release channel to void the process end date
         self.channel.action_sleep()
         self.channel.invalidate_recordset()
         # Wake up the channel to set the process end date
         self.channel.action_wake_up()
         self.assertEqual(
-            "2023-01-27 22:00:00",
+            "2023-01-28 09:00:00",
             fields.Datetime.to_string(self.channel.process_end_date),
         )
 

--- a/stock_release_channel_process_end_time/utils.py
+++ b/stock_release_channel_process_end_time/utils.py
@@ -1,35 +1,42 @@
 # Copyright 2023 ACSONE SA/NV
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import math
-from datetime import datetime, time, timedelta
+from datetime import datetime, time
 
 import pytz
 
+from odoo import fields
 from odoo.tools import float_round
 
-from odoo.addons.partner_tz.tools.tz_utils import tz_to_utc_time
+from odoo.addons.partner_tz.tools.tz_utils import (
+    tz_to_utc_naive_datetime,
+    utc_to_tz_naive_datetime,
+)
 
 
-def float_to_time(hours, tz=False) -> time:
+def float_to_time(hours) -> time:
     """This returns a tuple (hours, minutes) from a float representation of time"""
-    if not tz:
-        tz = pytz.utc
     if hours == 24.0:
         return time.max
     fractional, integral = math.modf(hours)
     time_result = time(
         int(integral), int(float_round(60 * fractional, precision_digits=0)), 0
     )
-    time_result = tz_to_utc_time(tz, time_result)
     return time_result
 
 
-def next_datetime(current: datetime, hours: time, **kwargs) -> datetime:
-    repl = current.replace(
-        hour=hours.hour, minute=hours.minute, second=0, microsecond=0, **kwargs
+def time_to_datetime(hours: time, now=False, tz=False) -> datetime:
+    """Returns UTC datetime with given hours in local time"""
+    if not tz:
+        tz = pytz.utc
+    now = now or fields.Datetime.now()
+    now_tz = utc_to_tz_naive_datetime(tz, now)
+    dt_tz = now_tz.replace(
+        hour=hours.hour,
+        minute=hours.minute,
+        second=0,
+        microsecond=0,
     )
-    if hours.tzinfo:
-        repl += hours.utcoffset()
-    while repl <= current:
-        repl = repl + timedelta(days=1)
-    return repl
+    dt = tz_to_utc_naive_datetime(tz, dt_tz)
+    return dt


### PR DESCRIPTION
* stock_release_channel_process_end_time: Fix end date computation according to time zone
* stock_release_channel_cutoff: Fix cutoff warning according to time zone, make one unittest per test

cc @sbejaoui @sebalix