### PR TITLE
[16.0][IMP] Release : set expected date

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -143,26 +143,9 @@ class StockPicking(models.Model):
         to the released one.
         """
         self._after_release_set_last_release_date()
-        self._after_release_set_expected_date()
 
     def _after_release_set_last_release_date(self):
         self.last_release_date = fields.Datetime.now()
-
-    def _after_release_set_expected_date(self):
-        prep_time = self.env.company.stock_release_max_prep_time
-        new_expected_date = fields.Datetime.add(
-            fields.Datetime.now(), minutes=prep_time
-        )
-        move_to_update = self.move_ids.filtered(
-            lambda m: m.state in ["assigned", "confirmed", "partially_available"]
-        )
-        move_to_update_ids = move_to_update.ids
-        for origin_moves in move_to_update._get_chained_moves_iterator("move_dest_ids"):
-            move_to_update_ids += origin_moves.ids
-
-        self.env["stock.move"].browse(move_to_update_ids).write(
-            {"date": new_expected_date}
-        )
 
     def action_open_move_need_release(self):
         self.ensure_one()

--- a/stock_release_channel/models/stock_move.py
+++ b/stock_release_channel/models/stock_move.py
@@ -25,3 +25,11 @@ class StockMove(models.Model):
         if pickings:
             pickings._delay_assign_release_channel()
         return moves
+
+    def _release_get_expected_date(self):
+        """Return the new scheduled date of a single delivery move"""
+        channel = self.picking_id.release_channel_id
+        expected_date = channel and channel._get_expected_date()
+        if not expected_date:
+            return super()._release_get_expected_date()
+        return expected_date

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -499,7 +499,8 @@ class StockReleaseChannel(models.Model):
             current = channel._assign_release_channel_additional_filter(current)
             if not current:
                 continue
-            current.release_channel_id = channel
+            if current.release_channel_id != channel:
+                current.release_channel_id = channel
             break
 
         if not picking.release_channel_id:

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -798,3 +798,8 @@ class StockReleaseChannel(models.Model):
         )
         for pick in pickings:
             pick._delay_assign_release_channel()
+
+    def _get_expected_date(self):
+        """Return the new date to set on move chain"""
+        self.ensure_one()
+        return False

--- a/stock_release_channel_process_end_time/models/stock_picking.py
+++ b/stock_release_channel_process_end_time/models/stock_picking.py
@@ -73,25 +73,3 @@ class StockPicking(models.Model):
         else:
             operator_inselect = "not inselect" if operator == "=" else "inselect"
         return [("id", operator_inselect, (query, []))]
-
-    def _after_release_set_expected_date(self):
-        enabled_update_scheduled_date = bool(
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param(
-                "stock_release_channel_process_end_time.stock_release_use_channel_end_date"
-            )
-        )
-        res = super()._after_release_set_expected_date()
-        for rec in self:
-            # Check if a channel has been assigned to the picking and write
-            # scheduled_date if different to avoid unnecessary write
-            if (
-                rec.state not in ("done", "cancel")
-                and rec.release_channel_id
-                and rec.release_channel_id.process_end_date
-                and rec.scheduled_date != rec.release_channel_id.process_end_date
-                and enabled_update_scheduled_date
-            ):
-                rec.scheduled_date = rec.release_channel_id.process_end_date
-        return res


### PR DESCRIPTION
* stock_available_to_promise_release
    * Set date before release, so much easier, no need to extract chain of moves and go back and forth the chain
    * Don't modify other moves of the picking. If picking contains moves from other SO, all the other pickings in the chain of moves where also updated, not only the one just released (cc @mt-software-de) 
    * Add hook to get the date
    * Allow to receive a predefined date to set on the pickings
* stock_release_channel
   * Add hook to get date from channel
   * Add support to channel change. Propagate new date
* stock_release_channel_process_end_time
    * Use new provided hooks which fixes date propagation; No need to travel the chain of moves
    * Now works properly when the module that propagates the channel on all pickings of the chain is not installed
    * Channel change and update date is now already managed by stock_release_channel module. Just use the provided hook

cc @sebalix @lmignon @sbejaoui @mt-software-de 