### PR TITLE
[16.0][IMP] stock_release_channel_shipment_lead_time

### DIFF
--- a/stock_release_channel_process_end_time/models/stock_picking.py
+++ b/stock_release_channel_process_end_time/models/stock_picking.py
@@ -1,5 +1,6 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -8,28 +9,47 @@ class StockPicking(models.Model):
 
     _inherit = "stock.picking"
 
-    schedule_date_prior_to_channel_process_end_date_search = fields.Boolean(
+    # TODO: move this field to stock_release_channel so that we don't have to alter
+    # _field_picking_domains.
+    scheduled_date_prior_to_channel_end_date_search = fields.Boolean(
         store=False,
-        search="_search_schedule_date_prior_to_channel_process_end_date",
+        search="_search_scheduled_date_prior_to_channel_end_date",
         help="Technical field to search on not processed pickings where the scheduled "
-        "date is prior to the process end date of available channels.",
+        "date is prior to the end date of related channel.",
     )
 
     @api.model
     def fields_get(self, allfields=None, attributes=None):
-        """Hide schedule_date_prior_to_channel_process_end_date_search from
-        filterable/searchable fields"""
+        # Hide scheduled_date_prior_to_channel_end_date_search from
+        # filterable/searchable fields
         res = super().fields_get(allfields, attributes)
-        if res.get("schedule_date_prior_to_channel_process_end_date_search"):
-            res["schedule_date_prior_to_channel_process_end_date_search"][
-                "searchable"
-            ] = False
+        if res.get("scheduled_date_prior_to_channel_end_date_search"):
+            res["scheduled_date_prior_to_channel_end_date_search"]["searchable"] = False
         return res
 
     @api.model
-    def _search_schedule_date_prior_to_channel_process_end_date(self, operator, value):
+    def _search_scheduled_date_prior_to_channel_end_date_condition(self):
+        self.env["stock.release.channel"].flush_model(["process_end_date"])
+        self.env["stock.picking"].flush_model(["scheduled_date"])
+        end_date = (
+            "date(stock_release_channel.process_end_date "
+            "at time zone 'UTC' at time zone wh.tz) "
+        )
+        now = fields.Datetime.now()
+        cond = f"""
+            CASE WHEN stock_release_channel.process_end_date is not null
+            THEN date(stock_picking.scheduled_date at time zone 'UTC' at time zone wh.tz)
+            < {end_date} + interval '1 day'
+            ELSE date(stock_picking.scheduled_date at time zone 'UTC' at time zone wh.tz)
+            < date(TIMESTAMP %s at time zone wh.tz) + interval '1 day'
+            END
+        """
+        return cond, [now]
+
+    @api.model
+    def _search_scheduled_date_prior_to_channel_end_date(self, operator, value):
         """Search on not processed pickings where the scheduled date is prior to
-        the process end date of available channels.
+        the end date of related channel.
 
         As we compare dates, we convert datetimes in the timezone of the warehouse
         """
@@ -60,16 +80,37 @@ class StockPicking(models.Model):
         WHERE
             stock_picking.state NOT IN ('done', 'cancel')
             AND
-              CASE WHEN stock_release_channel.process_end_date is not null
-              THEN date(stock_picking.scheduled_date at time zone 'UTC' at time zone wh.tz)
-                < date(stock_release_channel.process_end_date
-                       at time zone 'UTC' at time zone wh.tz) + interval '1 day'
-              ELSE date(stock_picking.scheduled_date at time zone 'UTC' at time zone wh.tz)
-                < date(now() at time zone wh.tz) + interval '1 day'
-              END
         """
+        (
+            cond_q,
+            params,
+        ) = self._search_scheduled_date_prior_to_channel_end_date_condition()
+        query += cond_q
+
         if value:
             operator_inselect = "inselect" if operator == "=" else "not inselect"
         else:
             operator_inselect = "not inselect" if operator == "=" else "inselect"
-        return [("id", operator_inselect, (query, []))]
+        return [("id", operator_inselect, (query, params))]
+
+    def _after_release_set_expected_date(self):
+        enabled_update_scheduled_date = bool(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(
+                "stock_release_channel_process_end_time.stock_release_use_channel_end_date"
+            )
+        )
+        res = super()._after_release_set_expected_date()
+        for rec in self:
+            # Check if a channel has been assigned to the picking and write
+            # scheduled_date if different to avoid unnecessary write
+            if (
+                rec.state not in ("done", "cancel")
+                and rec.release_channel_id
+                and rec.release_channel_id.process_end_date
+                and rec.scheduled_date != rec.release_channel_id.process_end_date
+                and enabled_update_scheduled_date
+            ):
+                rec.scheduled_date = rec.release_channel_id.process_end_date
+        return res

--- a/stock_release_channel_process_end_time/models/stock_release_channel.py
+++ b/stock_release_channel_process_end_time/models/stock_release_channel.py
@@ -18,6 +18,7 @@ class StockReleaseChannel(models.Model):
         "be ended. This information will be used to compute the channel pickings "
         "scheduled date at channel awaking.",
     )
+    # TODO: move this field to stock_release_channel, make stored and rename to tz
     process_end_time_tz = fields.Selection(
         selection=_tz_get,
         compute="_compute_process_end_time_tz",
@@ -89,7 +90,7 @@ class StockReleaseChannel(models.Model):
             if criteria[0] == "scheduled_date":
                 new_domain.append(
                     (
-                        "schedule_date_prior_to_channel_process_end_date_search",
+                        "scheduled_date_prior_to_channel_end_date_search",
                         "=",
                         True,
                     )

--- a/stock_release_channel_shipment_lead_time/__manifest__.py
+++ b/stock_release_channel_shipment_lead_time/__manifest__.py
@@ -1,3 +1,4 @@
+# Copyright 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
@@ -11,7 +12,6 @@
     "maintainers": ["jbaudoux"],
     "website": "https://github.com/OCA/wms",
     "depends": [
-        "web",
         "stock_release_channel",  # OCA/wms
         "stock_release_channel_process_end_time",  # OCA/wms
         "stock_warehouse_calendar",  # OCA/stock-logistics-warehouse

--- a/stock_release_channel_shipment_lead_time/models/stock_picking.py
+++ b/stock_release_channel_shipment_lead_time/models/stock_picking.py
@@ -1,32 +1,55 @@
+# Copyright 2023 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Camptocamp
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
-
     _inherit = "stock.picking"
 
     def _get_release_channel_possible_candidate_domain(self):
-        """
-        override to exclude deliveries (OUT pickings) where
-        the date_deadline is after the shipment date.
-        """
-        self.ensure_one()
+        # Exclude deliveries (OUT pickings) when the date_deadline is after the shipment date
         domain = super()._get_release_channel_possible_candidate_domain()
 
-        # date_deadline is datetime UTC => convert to timezone user to compare
-        # with shipment_date is date
-        if self.date_deadline:
-            date_deadline = fields.Datetime.context_timestamp(
-                self, self.date_deadline
+        date = self.date_deadline
+        if date:
+            # date is datetime UTC => convert to local time to compare
+            # with shipment_date which is local date
+            tz = (
+                self.picking_type_id.warehouse_id.partner_id.tz
+                or self.company_id.partner_id.tz
+            )
+            date = fields.Datetime.context_timestamp(
+                self.with_context(tz=tz), date
             ).date()
 
             domain.extend(
                 [
                     "|",
                     ("shipment_date", "=", False),
-                    ("shipment_date", ">=", date_deadline),
+                    ("shipment_date", ">=", date),
                 ]
             )
         return domain
+
+    @api.model
+    def _search_scheduled_date_prior_to_channel_end_date_condition(self):
+        self.env["stock.release.channel"].flush_model(
+            ["process_end_date", "shipment_date", "shipment_lead_time"]
+        )
+        self.env["stock.picking"].flush_model(["scheduled_date"])
+        end_date = "stock_release_channel.shipment_date"
+        # We don't consider warehouse calendar when there is no process end date
+        lead_time = (
+            "interval '1 day' * coalesce(stock_release_channel.shipment_lead_time, 0)"
+        )
+        now = fields.Datetime.now()
+        cond = f"""
+            CASE WHEN stock_release_channel.process_end_date is not null
+            THEN date(stock_picking.scheduled_date at time zone 'UTC' at time zone wh.tz)
+            < {end_date} + interval '1 day'
+            ELSE date(stock_picking.scheduled_date at time zone 'UTC' at time zone wh.tz)
+            < date(TIMESTAMP %s at time zone wh.tz) + {lead_time} + interval '1 day'
+            END
+        """
+        return cond, [now]

--- a/stock_release_channel_shipment_lead_time/readme/CONTRIBUTORS.rst
+++ b/stock_release_channel_shipment_lead_time/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 * `Trobz <https://trobz.com>`_:
 
     * Hoang Diep <hoang@trobz.com>

--- a/stock_release_channel_shipment_lead_time/readme/DESCRIPTION.rst
+++ b/stock_release_channel_shipment_lead_time/readme/DESCRIPTION.rst
@@ -1,5 +1,14 @@
-This module allows to set delivery lead time for release channel.
-When setting on shipment lead time on release channel, the shipment date is computed automatically base on
-lead time days or warehouse calendar. There are 2 main enhanced features with this module:
-- Filter deliveries base on shipment date defined on a channel
-- Set delivery date for shipment advice if picking is linked to a channel
+Manage shipment date and delivery lead time on release channel.
+The shipment date is computed automatically base on process end date + shipment
+lead time days and warehouse calendar.
+
+Exclude deliveries promised after shipment date. A delivery with a deadline
+won't be assigned to a channel with a shipment date prior to the deadline. This
+allows to prevent to deliver a sales order with a commitment date in the
+future.
+
+Adapt computation of release ready to take into account the shipment lead time.
+A delivery part of a release channel won't be counted as release ready if the
+scheduled date is after the shipment date.
+
+Add the delivery date on the shipment advice.

--- a/stock_release_channel_shipment_lead_time/tests/__init__.py
+++ b/stock_release_channel_shipment_lead_time/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_assign_channel_shipment_date
 from . import test_release_shipment_date
+from . import test_release_end_date

--- a/stock_release_channel_shipment_lead_time/tests/test_release_end_date.py
+++ b/stock_release_channel_shipment_lead_time/tests/test_release_end_date.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from freezegun import freeze_time
+
+from odoo import fields
+
+from odoo.addons.stock_release_channel.tests.common import ChannelReleaseCase
+
+
+class ReleaseChannelEndDateCase(ChannelReleaseCase):
+    @freeze_time("2023-01-27 10:00:00")
+    def test_channel_counter_release_ready(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "stock_release_channel_process_end_time.stock_release_use_channel_end_date",
+            True,
+        )
+        # Remove existing jobs as some already exists to assign pickings to channel
+        jobs_before = self.env["queue.job"].search([])
+        jobs_before.unlink()
+        # Set the end time
+        self.channel.process_end_time = 23.0
+        # Set picking scheduled date
+        pickings = self.picking | self.picking2 | self.picking3
+        pickings.write({"scheduled_date": fields.Datetime.now()})
+
+        # Asleep the release channel to void the process end date
+        self.channel.action_sleep()
+        self.channel.invalidate_recordset()
+        # Execute the picking channel assignations
+        self.channel.with_context(test_queue_job_no_delay=True).action_wake_up()
+
+        self.assertEqual(pickings, self.channel.picking_ids)
+        # at this stage, the pickings are not ready to be released as the
+        # qty available is not enough
+        self.assertFalse(self.channel._get_pickings_to_release())
+
+        self._update_qty_in_location(self.loc_bin1, self.product1, 100.0)
+        self._update_qty_in_location(self.loc_bin1, self.product2, 100.0)
+
+        self.assertEqual(pickings, self.channel._get_pickings_to_release())
+        # if the scheduled date of one picking is changed to be on a time after the
+        # process end date but on the same day, it should still be releasable
+        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-27 23:30:00")
+        self.assertEqual(pickings, self.channel._get_pickings_to_release())
+        # if the scheduled date of one picking is changed to be on a date after the
+        # process end date, it should not be releasable anymore
+        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-28 00:00:00")
+        self.assertEqual(pickings[1:], self.channel._get_pickings_to_release())
+
+        # Now set channel lead time. It back releasable
+        self.channel.shipment_lead_time = 1
+        self.assertEqual(pickings, self.channel._get_pickings_to_release())
+        # Set date after lead time, it is excluded
+        pickings[0].scheduled_date = fields.Datetime.from_string("2023-01-29 00:00:00")
+        self.assertEqual(pickings[1:], self.channel._get_pickings_to_release())


### PR DESCRIPTION
* Improve computation of release ready when there is a process end date
* Exclude deliveries promised after shipment date. A delivery with a deadline won't be assigned to a channel with a shipment date prior to the deadline.

@sebalix @sbejaoui @lmignon @rousseldenis 