### PR TITLE
[16.0][FIX] stock_release_channel_process_end_time: end date compute

### DIFF
--- a/stock_release_channel_process_end_time/models/stock_release_channel.py
+++ b/stock_release_channel_process_end_time/models/stock_release_channel.py
@@ -45,8 +45,12 @@ class StockReleaseChannel(models.Model):
     def _compute_process_end_date(self):
         now = fields.Datetime.now()
         for channel in self:
-            # We check if a date is not already set (manually)
-            if channel.state != "asleep" and not channel.process_end_date:
+            if channel.state == "asleep":
+                channel.process_end_date = False
+            # otherwise we check if a date is not already set (manually)
+            elif channel.process_end_date:
+                continue
+            elif channel.process_end_time:
                 end = next_datetime(
                     now,
                     float_to_time(
@@ -55,7 +59,7 @@ class StockReleaseChannel(models.Model):
                     ),
                 )
                 channel.process_end_date = end
-            elif channel.state == "asleep":
+            else:
                 channel.process_end_date = False
 
     @api.depends("warehouse_id.partner_id.tz")


### PR DESCRIPTION
Process end date computation: an end time must be set to compute

cc @sebalix @sbejaoui @rousseldenis 