### PR TITLE
stock_release_channel: Add missing Copyright MT Software

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp
+# Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 import logging


### PR DESCRIPTION
I forgot to add my copyright on stock_release_channel.py
@jbaudoux @sebalix 