### PR TITLE
[IMP] stock_available_to_promise_release: set move to need release after pick cancel

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -576,7 +576,7 @@ class StockMove(models.Model):
             procurement_requests.append(
                 self.env["procurement.group"].Procurement(
                     move.product_id,
-                    move.product_uom_qty,
+                    move.product_uom_qty - move.reserved_availability,
                     move.product_uom,
                     move.location_id,
                     move.rule_id and move.rule_id.name or "/",

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -113,3 +113,12 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.picking1.printed = True
         with self.assertRaisesRegex(UserError, "You are not allowed to unrelease"):
             self.shipping1.move_ids._action_cancel()
+
+    def test_cancel_pick(self):
+        """
+        if we manually cancel one of picking chain we set the dest moves
+        to need_release so they can be released again
+        """
+        self.assertFalse(self.shipping1.need_release)
+        self.picking1.action_cancel()
+        self.assertTrue(self.shipping1.need_release)

--- a/stock_available_to_promise_release/tests/test_unrelease_2steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_2steps.py
@@ -122,3 +122,41 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         self.assertFalse(self.shipping1.need_release)
         self.picking1.action_cancel()
         self.assertTrue(self.shipping1.need_release)
+
+    def test_cancel_partial_pick(self):
+        # In this tests we partially process a picking then confirm it.
+        # We cancel the backorder and check that the shippings is set to need_release
+        # We then release the shippings again and check that the backorder is created
+        # for the remaining qty only
+        self.assertFalse(self.shipping1.need_release)
+        self.assertFalse(self.shipping2.need_release)
+        original_qty = self.picking1.move_ids.product_uom_qty
+        self.assertGreater(original_qty, 1)
+        self.picking1.move_line_ids[0].qty_done = 1
+        self.picking1._action_done()
+        self.assertEqual(self.shipping1.move_ids.state, "partially_available")
+        # get the backorder
+        backorder_pick = self._prev_picking(self.shipping1).filtered(
+            lambda p: p.state == "assigned"
+        )
+        self.assertTrue(backorder_pick)
+        backorder_pick.action_assign()
+        self.assertEqual(backorder_pick.move_ids.state, "assigned")
+        # the backorder should have only one move for the remaining qty
+        self.assertEqual(backorder_pick.move_ids.product_uom_qty, original_qty - 1)
+        # we cancel the backorder
+        backorder_pick.action_cancel()
+        # the shipping should be set to need_release
+        self.assertTrue(self.shipping1.need_release)
+        self.assertTrue(self.shipping2.need_release)
+        # the shipping move should still be partially available
+        self.assertEqual(self.shipping1.move_ids.state, "partially_available")
+        self.assertEqual(self.shipping2.move_ids.state, "waiting")
+        # and if we release it again, the backorder should be created
+        # for the remaining qty
+        self.deliveries.release_available_to_promise()
+        backorder_pick = self._prev_picking(self.shipping1).filtered(
+            lambda p: p.state == "assigned"
+        )
+        self.assertTrue(backorder_pick)
+        self.assertEqual(backorder_pick.move_ids.product_uom_qty, original_qty - 1)

--- a/stock_available_to_promise_release/tests/test_unrelease_3steps.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_3steps.py
@@ -68,3 +68,22 @@ class TestAvailableToPromiseRelease3steps(PromiseReleaseCommonCase):
         # self.assertFalse(move_cancel.move_dest_ids)
         self.assertFalse(move_cancel.move_orig_ids)
         self.assertEqual(self.ship2.move_ids.move_orig_ids, self.pack2.move_ids)
+
+    def test_cancel_pick(self):
+        """
+        if we manually cancel one of picking chain we set the dest moves
+        to need_release so they can be released again
+        """
+        self.assertFalse(self.ship1.move_ids.need_release)
+        self.pick1.action_cancel()
+        self.assertTrue(self.pack1.move_ids.need_release)
+        self.assertTrue(self.ship1.move_ids.need_release)
+
+    def test_cancel_pack(self):
+        """
+        if we manually cancel one of picking chain we set the dest moves
+        to need_release so they can be released again
+        """
+        self.assertFalse(self.ship1.move_ids.need_release)
+        self.pack1.action_cancel()
+        self.assertTrue(self.ship1.move_ids.need_release)


### PR DESCRIPTION
if we manually cancel one of picking chain we set the dest moves to need_release so they can be released again