### PR TITLE
[14.0][IMP] shopfloor_mobile: allow line breaks in picking note

### DIFF
--- a/shopfloor_mobile/static/wms/src/scenario/checkout.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.js
@@ -76,8 +76,10 @@ const Checkout = {
             </div>
 
             <div v-if="state_is('select_package')">
-                <v-alert type="info" tile v-if="state.data.packing_info" class="packing-info">
-                    <p v-text="state.data.packing_info" />
+                <v-alert type="info" tile v-if="state.data.picking.note" class="packing-info">
+                    <div v-for="note in utils.wms.split_picking_note(state)">
+                        <span v-text="note"/>
+                    </div>
                 </v-alert>
                 <item-detail-card
                     v-if="state.data.picking.carrier"

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.js
@@ -30,6 +30,11 @@ const ClusterPicking = {
                 v-on:confirm="state.on_confirm"
                 v-on:cancel="state.on_cancel"
                 />
+            <v-alert type="info" tile v-if="state_is('start_line') && state.data.picking.note" class="packing-info">
+                <div v-for="note in utils.wms.split_picking_note(state)">
+                    <span v-text="note"/>
+                </div>
+            </v-alert>
             <batch-picking-line-detail
                 v-if="state_in(['start_line', 'scan_destination', 'change_pack_lot', 'stock_issue'])"
                 :line="state.data"

--- a/shopfloor_mobile/static/wms/src/wms_utils.js
+++ b/shopfloor_mobile/static/wms/src/wms_utils.js
@@ -331,6 +331,10 @@ export class WMSUtils {
         };
         return _.extend(props, override || {});
     }
+    split_picking_note(state) {
+        // Allow to introduce line breaks in the note.
+        return state.data.picking.note.split("\n");
+    }
 }
 
 utils_registry.add("wms", new WMSUtils());


### PR DESCRIPTION
This PR allows to properly render picking notes with line breaks.

![cluster_picking_with_notes](https://github.com/OCA/wms/assets/77412816/fb226cba-6e9a-46ff-b398-b9df9e8df120)


Motivated by this PR: https://github.com/OCA/stock-logistics-workflow/pull/1543
(although the behavior is the same in shopfloor without it).

ref: cos-4507