### PR TITLE
[14.0][FIX] s_a_promise_release: Reset last_release_date on unrelease

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -635,6 +635,7 @@ class StockMove(models.Model):
                 move_names=move_names,
             )
             picking.message_post(body=body)
+            picking.last_release_date = False
 
     def _split_origins(self, origins):
         """Split the origins of the move according to the quantity into the

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -54,13 +54,14 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         )
         self.assertEqual(self.picking.move_lines.state, "cancel")
         self.assertEqual(self.picking.state, "cancel")
+        self.assertFalse(self.picking.last_release_date)
 
     def test_unrelease_full(self):
         """Unrelease all moves of a released ship. The pick should be deleted and
         the moves should be mark as to release"""
         with self._assert_full_unreleased():
             self.shipping.move_lines.unrelease()
-
+        self.assertFalse(self.shipping.last_release_date)
         # I can release again the move and a new pick is created
         self.shipping.release_available_to_promise()
         new_picking = self._prev_picking(self.shipping) - self.picking


### PR DESCRIPTION
When a transfer has been unreleased the `last_release_date` is not reset.
This breaks the counters and the list of records (To Release, To Do) on the related channel.

Now with this change the field name/label is incoherent...