### PR TITLE
[16.0][IMP] stock_release_channel: Set default state to asleep and add new criteria to disable pickings from being automatically assigned

### DIFF
--- a/stock_release_channel/demo/stock_release_channel.xml
+++ b/stock_release_channel/demo/stock_release_channel.xml
@@ -5,6 +5,7 @@
         <field name="name">Default</field>
         <field name="sequence">999</field>
         <field name="rule_domain">[]</field>
+        <field name="state">open</field>
     </record>
 
 </odoo>

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -109,6 +109,7 @@ class StockPicking(models.Model):
     def _get_release_channel_possible_candidate_domain(self):
         self.ensure_one()
         return [
+            ("is_manual_assignment", "=", False),
             ("state", "!=", "asleep"),
             "|",
             ("picking_type_ids", "=", False),

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -182,7 +182,7 @@ class StockReleaseChannel(models.Model):
         "still working)\n"
         "* Asleep: Assigned pickings not processed are unassigned from the release "
         "channel.\n",
-        default="open",
+        default="asleep",
     )
     is_action_lock_allowed = fields.Boolean(
         compute="_compute_is_action_lock_allowed",

--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -217,6 +217,7 @@ class StockReleaseChannel(models.Model):
     show_last_picking_done = fields.Boolean(
         compute="_compute_show_last_picking_done",
     )
+    is_manual_assignment = fields.Boolean("Manual assignment")
 
     @api.depends("state")
     def _compute_is_action_lock_allowed(self):

--- a/stock_release_channel/tests/common.py
+++ b/stock_release_channel/tests/common.py
@@ -100,6 +100,8 @@ class ReleaseChannelCase(common.TransactionCase):
 
     @classmethod
     def _create_channel(cls, **vals):
+        # Forced update state of channel to "open"
+        vals.update({"state": "open"})
         return cls.env["stock.release.channel"].create(vals)
 
     def _run_customer_procurement(self, date=None):

--- a/stock_release_channel/tests/test_release_channel.py
+++ b/stock_release_channel/tests/test_release_channel.py
@@ -56,3 +56,15 @@ class TestReleaseChannel(ReleaseChannelCase):
         self.assertEqual(channel2.sequence, 10)
         channel3 = self._create_channel(name="Test3")
         self.assertEqual(channel3.sequence, 20)
+
+    def test_is_manual_assignment(self):
+        # Manual Assignment
+        self.default_channel.is_manual_assignment = True
+        move = self._create_single_move(self.product1, 10)
+        move.picking_id.assign_release_channel()
+        self.assertEqual(move.picking_id.release_channel_id.id, False)
+        # Automatic Assignment
+        self.default_channel.is_manual_assignment = False
+        move = self._create_single_move(self.product1, 10)
+        move.picking_id.assign_release_channel()
+        self.assertEqual(move.picking_id.release_channel_id.id, self.default_channel.id)

--- a/stock_release_channel/views/stock_release_channel_views.xml
+++ b/stock_release_channel/views/stock_release_channel_views.xml
@@ -100,6 +100,7 @@
                                         <field name="code" />
                                     </tree>
                                 </field>
+                                <field name="is_manual_assignment" />
                                 <field
                                     name="rule_domain"
                                     widget="domain"

--- a/stock_release_channel_process_end_time/tests/test_release_end_date.py
+++ b/stock_release_channel_process_end_time/tests/test_release_end_date.py
@@ -153,6 +153,7 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
             {
                 "name": "Test Date",
                 "process_end_time": 15,
+                "state": "open",
             }
         )
         channel.action_sleep()

--- a/stock_release_channel_propagate_channel_picking/tests/test_procurement.py
+++ b/stock_release_channel_propagate_channel_picking/tests/test_procurement.py
@@ -27,6 +27,7 @@ class TestReleaseChannelProcurement(ReleaseChannelCase):
                 "name": "Propagate Channel",
                 "sequence": 200,
                 "rule_domain": [],
+                "state": "open",
             }
         )
 


### PR DESCRIPTION
On creation of a new channel, it was by default `open` and without selection criteria meaning that it was collecting all possible deliveries.
Now by default, the channel is created in state `asleep`.
A new feature has been added to prevent any auto assignment of any delivery in a channel