### PR TITLE
[FIX] shopfloor_single_product_transfer: Set package before posting

### DIFF
--- a/shopfloor_single_product_transfer/services/single_product_transfer.py
+++ b/shopfloor_single_product_transfer/services/single_product_transfer.py
@@ -746,11 +746,10 @@ class ShopfloorSingleProductTransfer(Component):
             )
             if response:
                 return response
-            response = self._set_quantity__post_move(
+            move_line.result_package_id = package
+            return self._set_quantity__post_move(
                 move_line, location, confirmation=confirmation
             )
-            move_line.result_package_id = package
-            return response
         # Else, go to `set_location` screen
         move_line.result_package_id = package
         return self._response_for_set_location(move_line, package)


### PR DESCRIPTION
If a package is scanned which is not empty
then it needs to be ensured that the package
is set before the move is posted

cc @jbaudoux @TDu @mmequignon 

With the PR https://github.com/OCA/wms/pull/744 we fixed the addressed issue
but with the later merged PR https://github.com/OCA/wms/pull/710 we reverted kinda the FIX. 