### PR TITLE
[14.0][FIX] shopfloor_reception: Ensure state assign of remaining move

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1305,7 +1305,6 @@ class Reception(Component):
         new_move = move.create(split_move_vals)
         new_move.move_line_ids = selected_line
         new_move._action_confirm(merge=False)
-        new_move._recompute_state()
         new_move._action_assign()
         # Set back the quantity to do on one of the lines
         line = fields.first(
@@ -1318,7 +1317,8 @@ class Reception(Component):
                 move.product_uom_qty, line[0].product_uom_id
             )
             line.product_uom_qty = move_quantity
-        move._recompute_state()
+        else:
+            move._action_assign()
         new_move.extract_and_action_done()
 
     def set_destination(


### PR DESCRIPTION
If there is not all processed for one move, we have to ensure that the state of the remaining move is still `assigned`.
Otherwise the last remaining qty of this move will be not split into a own transfer.

https://github.com/OCA/wms/blob/c9cf770e08eae63574f7dd7c5dcbc238e6e00fe0/shopfloor_reception/services/reception.py#L1297
https://github.com/OCA/wms/blob/c9cf770e08eae63574f7dd7c5dcbc238e6e00fe0/shopfloor/models/stock_move.py#L100

cc @jbaudoux @TDu @mmequignon 