### PR TITLE
[IMP] stock_release_channel: add a field to define the channel state at wakeup

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -184,6 +184,12 @@ class StockReleaseChannel(models.Model):
         "channel.\n",
         default="asleep",
     )
+    state_at_wakeup = fields.Selection(
+        selection=[("open", "Open"), ("locked", "Locked")],
+        default="open",
+        required=True,
+        help="The state of the channel upon waking it up",
+    )
     is_action_lock_allowed = fields.Boolean(
         compute="_compute_is_action_lock_allowed",
         help="Technical field to check if the " "action 'Lock' is allowed.",
@@ -849,7 +855,8 @@ class StockReleaseChannel(models.Model):
 
     def action_wake_up(self):
         self._check_is_action_wake_up_allowed()
-        self.write({"state": "open"})
+        for rec in self:
+            rec.state = rec.state_at_wakeup
         self.assign_pickings()
 
     @api.model

--- a/stock_release_channel/tests/test_release_channel_lifecycle.py
+++ b/stock_release_channel/tests/test_release_channel_lifecycle.py
@@ -60,7 +60,20 @@ class TestReleaseChannelLifeCycle(ReleaseChannelCase):
                 ),
             )
             trap.enqueued_jobs[0].perform()
+        self.assertEqual(self.default_channel.state, "open")
         self.assertEqual(move.picking_id.release_channel_id, self.default_channel)
+
+    def test_release_channel_wake_up_at_open_state(self):
+        self.assertEqual(self.default_channel.state_at_wakeup, "open")
+        self.default_channel.action_sleep()
+        self.default_channel.action_wake_up()
+        self.assertEqual(self.default_channel.state, "open")
+
+    def test_release_channel_wake_up_at_locked_state(self):
+        self.default_channel.state_at_wakeup = "locked"
+        self.default_channel.action_sleep()
+        self.default_channel.action_wake_up()
+        self.assertEqual(self.default_channel.state, "locked")
 
     def test_release_channel_sleep_unassign(self):
         self.move = self._create_single_move(self.product1, 10)

--- a/stock_release_channel/views/stock_release_channel_views.xml
+++ b/stock_release_channel/views/stock_release_channel_views.xml
@@ -72,6 +72,7 @@
                             groups="stock.group_stock_manager"
                         >
                             <group name="options">
+                        <field name="state_at_wakeup" />
                         <field name="release_forbidden" />
                         <field
                                     name="release_mode"

--- a/stock_release_channel_plan/tests/test_stock_release_channel_plan.py
+++ b/stock_release_channel_plan/tests/test_stock_release_channel_plan.py
@@ -22,3 +22,21 @@ class TestStockReleaseChannelPlan(ReleaseChannelPlanCase):
         self.assertEqual(self.plan2_channel2.state, "asleep")
         self.assertEqual(self.plan3_channel1.state, "open")
         self.assertEqual(self.plan3_channel2.state, "open")
+
+    def test_launch_plan_at_locked_state(self):
+        """Test launching plan1"""
+        self.plan1_channel1.write({"state": "locked", "state_at_wakeup": "locked"})
+        self.plan1_channel2.write({"state": "asleep", "state_at_wakeup": "locked"})
+        self.plan2_channel1.write({"state": "locked", "state_at_wakeup": "locked"})
+        self.plan2_channel2.write({"state": "asleep", "state_at_wakeup": "locked"})
+        self.plan3_channel1.write({"state": "open", "state_at_wakeup": "locked"})
+        self.plan3_channel2.write({"state": "open", "state_at_wakeup": "locked"})
+
+        self._launch_channel(self.plan1)
+
+        self.assertEqual(self.plan1_channel1.state, "locked")
+        self.assertEqual(self.plan1_channel2.state, "locked")
+        self.assertEqual(self.plan2_channel1.state, "locked")
+        self.assertEqual(self.plan2_channel2.state, "asleep")
+        self.assertEqual(self.plan3_channel1.state, "open")
+        self.assertEqual(self.plan3_channel2.state, "open")

--- a/stock_release_channel_plan/wizards/launch_plan.py
+++ b/stock_release_channel_plan/wizards/launch_plan.py
@@ -24,7 +24,9 @@ class StockReleaseChannelPlanWizardLaunch(models.TransientModel):
 
     @api.model
     def _action_launch(self, channels):
-        channels.filtered("is_action_unlock_allowed").action_unlock()
+        channels.filtered(
+            lambda c: c.is_action_unlock_allowed and c.state_at_wakeup == "open"
+        ).action_unlock()
 
         channels_to_wakeup = channels.filtered("is_action_wake_up_allowed")
         channels_to_wakeup.action_wake_up()


### PR DESCRIPTION
When activating a channel, it assigns pickings matching its selection criteria. If the channel is in automatic release mode, the release is made right away.

This PR adds a field to allow waking up the channel in a locked state if needed.

@jbaudoux , @lmignon , @rousseldenis 