### PR TITLE
[IMP] stock_available_to_promise_release: Improve migration/init script to initialize 'release_policy' field with default values

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+openupgradelib

--- a/stock_available_to_promise_release/__init__.py
+++ b/stock_available_to_promise_release/__init__.py
@@ -1,3 +1,2 @@
-from . import models
-from . import wizards
-from .hooks import pre_init_hook
+from . import models, wizards
+from .hooks import init_release_policy, pre_init_hook

--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -25,4 +25,5 @@
     "application": False,
     "development_status": "Beta",
     "pre_init_hook": "pre_init_hook",
+    "external_dependencies": {"python": ["openupgradelib"]},
 }

--- a/stock_available_to_promise_release/hooks.py
+++ b/stock_available_to_promise_release/hooks.py
@@ -1,11 +1,33 @@
 # Copyright 2023 ACSONE SA/NV
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-
 import logging
 
+from openupgradelib import openupgrade
+
+from odoo import SUPERUSER_ID, api
 from odoo.tools import sql
 
 _logger = logging.getLogger(__name__)
+
+
+def init_release_policy(cr):
+    if not sql.column_exists(cr, "stock_picking", "release_policy"):
+        # Use the default sql query instead relying on ORM as all records will
+        # be updated.
+        _logger.info("Creating 'release_policy' field on stock.picking")
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        field_spec = [
+            (
+                "release_policy",
+                "stock.picking",
+                False,
+                "selection",
+                False,
+                "stock_available_to_promise_release",
+                "direct",
+            )
+        ]
+        openupgrade.add_fields(env, field_spec=field_spec)
 
 
 def pre_init_hook(cr):
@@ -27,3 +49,4 @@ def pre_init_hook(cr):
         """
         )
         _logger.info(f"{cr.rowcount} rows updated")
+    init_release_policy(cr)

--- a/stock_available_to_promise_release/migrations/16.0.3.1.0/post-migrate.py
+++ b/stock_available_to_promise_release/migrations/16.0.3.1.0/post-migrate.py
@@ -13,5 +13,6 @@ def migrate(cr, version):
             procurement_group
         WHERE
             stock_picking.group_id = procurement_group.id
+        AND stock_picking.state NOT IN ('done', 'cancel')
     """
     )

--- a/stock_available_to_promise_release/migrations/16.0.3.1.0/pre-migrate.py
+++ b/stock_available_to_promise_release/migrations/16.0.3.1.0/pre-migrate.py
@@ -1,0 +1,15 @@
+# Copyright 2024 ACSONE SA/NV (https://acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+# pylint: disable=odoo-addons-relative-import
+from odoo.addons.stock_available_to_promise_release.hooks import init_release_policy
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Use the default sql query instead relying on ORM as all records will
+    be updated.
+    """
+    init_release_policy(env.cr)

--- a/stock_available_to_promise_release/static/description/index.html
+++ b/stock_available_to_promise_release/static/description/index.html
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION


The upgrade script should initialize the value with the sql default instead updating every existing record (maybe billions).