### PR TITLE
stock_available_to_promise_release_block: fix action_block_release

### DIFF
--- a/stock_available_to_promise_release_block/models/stock_move.py
+++ b/stock_available_to_promise_release_block/models/stock_move.py
@@ -36,8 +36,7 @@ class StockMove(models.Model):
 
     def action_block_release(self):
         """Block the release."""
-        if self.need_release:
-            self.release_blocked = True
+        self.filtered("need_release").release_blocked = True
 
     def action_unblock_release(self):
         """Unblock the release."""


### PR DESCRIPTION
When calling action_block_release on multiple moves, avoid having a singleton error.