### PR TITLE
[16.0][IMP] stock_available_to_promise_release: Improves perfs

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -82,6 +82,7 @@ class StockPicking(models.Model):
     # invalidate cache before accessing this release_ready computed value
     @api.depends(lambda self: self._get_release_ready_depends())
     def _compute_release_ready(self):
+        self.move_ids.invalidate_recordset(["ordered_available_to_promise_qty"])
         for picking in self:
             moves = picking.move_ids.filtered(lambda move: move._is_release_needed())
             release_ready = False


### PR DESCRIPTION
The field 'ordered_available_to_promise_qty' is a computed field without depends. In the implementation of the `_is_release_ready` we expect that this field is up to date. Prior to this change, the 'ordered_available_to_promise_qty' was invalidated into the '_is_release_ready' method to ensure consistency. Unfortunately, since the '_is_release_ready' method is designed to work a a single record, when it was called from `_compute_release_ready` methods on a large recordset, this way of doing has as side effect to break the batch computation of the 'ordered_available_to_promise_qty' since the value was invalidated one at a time for each record. To restore the batch computation of the 'ordered_available_to_promise_qty', the cache invalidation is now done into the caller methods for the whole recordset