### PR TITLE
[16.0][IMP] sale_stock_available_to_promise_release: show/hide availability on SO reports

### DIFF
--- a/sale_stock_available_to_promise_release/__manifest__.py
+++ b/sale_stock_available_to_promise_release/__manifest__.py
@@ -15,6 +15,7 @@
         "views/stock_picking_views.xml",
         "views/product_product_views.xml",
         "views/sale_order_views.xml",
+        "views/res_config_settings.xml",
     ],
     "installable": True,
     "license": "LGPL-3",

--- a/sale_stock_available_to_promise_release/models/__init__.py
+++ b/sale_stock_available_to_promise_release/models/__init__.py
@@ -4,3 +4,5 @@ from . import stock_move
 from . import stock_picking
 from . import procurement_group
 from . import product_product
+from . import res_config_settings
+from . import res_company

--- a/sale_stock_available_to_promise_release/models/res_company.py
+++ b/sale_stock_available_to_promise_release/models/res_company.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+
+    _inherit = "res.company"
+
+    stock_sale_report_display_is_available = fields.Boolean(
+        help="Show Available column in SO and quotation reports",
+        default=True,
+    )

--- a/sale_stock_available_to_promise_release/models/res_config_settings.py
+++ b/sale_stock_available_to_promise_release/models/res_config_settings.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Trobz
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    stock_sale_report_display_is_available = fields.Boolean(
+        related="company_id.stock_sale_report_display_is_available",
+        readonly=False,
+    )

--- a/sale_stock_available_to_promise_release/reports/sale_order.xml
+++ b/sale_stock_available_to_promise_release/reports/sale_order.xml
@@ -9,7 +9,7 @@
     >
       <xpath expr="//th[@name='th_description']" position="after">
         <th
-                t-if="doc.state != 'draft'"
+                t-if="doc.state != 'draft' and doc.company_id.stock_sale_report_display_is_available"
                 name="th_is_available"
                 class="text-right nowrap"
             >Available</th>
@@ -17,7 +17,7 @@
 
       <xpath expr="//td[@name='td_name']" position="after">
           <td
-                t-if="doc.state != 'draft'"
+                t-if="doc.state != 'draft' and doc.company_id.stock_sale_report_display_is_available"
                 name="td_is_available"
                 class="nowrap text-right"
             >

--- a/sale_stock_available_to_promise_release/views/res_config_settings.xml
+++ b/sale_stock_available_to_promise_release/views/res_config_settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='stock_reservation']" position="inside">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="stock_sale_report_display_is_available" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="stock_sale_report_display_is_available" />
+                        <div class="text-muted">
+                            Show Available column in SO and quotation reports
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add parameter to make the column Available on SO reports invisible

Results
- Setting enabled
![OCAAB](https://github.com/OCA/wms/assets/48206917/bd39066a-3042-4e5d-8185-74cf7803f3f2)
- With setting activated
![OCAAB1](https://github.com/OCA/wms/assets/48206917/dbd07294-b0e5-43eb-9b34-38d3344e8023)
- Setting disabled
![OCAAB2](https://github.com/OCA/wms/assets/48206917/90440e0b-d0bf-4bc0-930c-5db3d42cdf72)
