### PR TITLE
[16.0][IMP] sale_stock_available_to_promise_release_block block multiple order lines

### DIFF
--- a/sale_stock_available_to_promise_release_block/views/sale_order_line.xml
+++ b/sale_stock_available_to_promise_release_block/views/sale_order_line.xml
@@ -42,7 +42,8 @@
     <field name="state">code</field>
     <field name="code">
     if records:
-        records.move_ids.action_unblock_release()
+      for move in records.move_ids:
+        move.action_unblock_release()
     </field>
   </record>
 
@@ -54,7 +55,8 @@
     <field name="state">code</field>
     <field name="code">
     if records:
-        records.move_ids.action_block_release()
+      for move in records.move_ids:
+        move.action_block_release()
     </field>
   </record>
 


### PR DESCRIPTION
When we block multiple order lines we get the following traceback:

```
ValueError: <class 'ValueError'>: "Expected singleton: stock.move(53171, 53172)" while evaluating
'if records:\n        records.move_ids.action_block_release()'
```

