### PR TITLE
[16.0][FIX] stock_available_to_promise_release : cancellation must unrelease

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -112,25 +112,38 @@ class StockMove(models.Model):
         )
 
     def _check_unrelease_allowed(self):
-        for move in self:
-            if not move.unrelease_allowed:
-                message = _(
-                    "You are not allowed to unrelease this move %(move_name)s.",
-                    move_name=move.display_name,
+        forbidden_moves = self.filtered(lambda m: not m.unrelease_allowed)
+        if not forbidden_moves:
+            return
+        message = _("You are not allowed to unrelease those deliveries:\n")
+
+        for picking, forbidden_moves_by_picking in groupby(
+            forbidden_moves, lambda m: m.picking_id
+        ):
+            forbidden_moves_by_picking = self.browse().concat(
+                *forbidden_moves_by_picking
+            )
+            message += "\n\t- %s" % picking.name
+            forbidden_origin_pickings = self.picking_id.browse()
+            for move in forbidden_moves_by_picking:
+                iterator = move._get_chained_moves_iterator("move_orig_ids")
+                next(iterator)  # skip the current move
+                for origin_moves in iterator:
+                    for origin_picking, moves_by_picking in groupby(
+                        origin_moves, lambda m: m.picking_id
+                    ):
+                        moves_by_picking = self.browse().concat(*moves_by_picking)
+                        if not move._is_unrelease_allowed_on_origin_moves(
+                            moves_by_picking
+                        ):
+                            forbidden_origin_pickings |= origin_picking
+            if forbidden_origin_pickings:
+                message += " "
+                message += _(
+                    "- blocking transfer(s): %(picking_names)s",
+                    picking_names=" ".join(forbidden_origin_pickings.mapped("name")),
                 )
-                if move.picking_id:
-                    message += _(
-                        "\n- Picking: %(picking_name)s.",
-                        picking_name=move.picking_id.name,
-                    )
-                if move.move_orig_ids and move.move_orig_ids.picking_id:
-                    message += _(
-                        "\n- Origin picking(s):\n\t -%(picking_names)s.",
-                        picking_names="\n\t- ".join(
-                            move.move_orig_ids.picking_id.mapped("name")
-                        ),
-                    )
-                raise UserError(message)
+        raise UserError(message)
 
     def _previous_promised_qty_sql_main_query(self):
         return """

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -428,9 +428,8 @@ class StockMove(models.Model):
         )
 
     def _action_cancel(self):
-        # Unrelease moves that can be, before canceling them.
-        moves_to_unrelease = self.filtered(lambda m: m.unrelease_allowed)
-        moves_to_unrelease.unrelease()
+        # Unrelease moves that must be, before canceling them.
+        self.unrelease()
         super()._action_cancel()
         self.write({"need_release": False})
         return True

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -81,9 +81,7 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         ).button_validate()
         self.assertEqual(self.picking.state, "done")
         self.assertFalse(self.shipping.move_ids.unrelease_allowed)
-        with self.assertRaisesRegex(
-            UserError, "You are not allowed to unrelease this move"
-        ):
+        with self.assertRaisesRegex(UserError, "You are not allowed to unrelease"):
             self.shipping.move_ids.unrelease()
 
     def test_unrelease_backorder(self):


### PR DESCRIPTION
Before the change, when you cancel a delivery move, if it cannot be unreleased, it was skipping the unrelease but still canceling the move. You then end-up with a canceled OUT but with a PICK still in to do.

I also improved the error message to show all forbidden deliveries and their list of related blocking pickings (no matter the amount of steps) 

cc @TDu @sebalix @rousseldenis @lmignon 