### PR TITLE
[IMP] shopfloor, zone picking: Allow partial transfer when scanning a location

### DIFF
--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1169,43 +1169,40 @@ class ZonePicking(Component):
             )
 
         extra_message = ""
-        if moving_full_quantity:
-            # When the barcode is a location,
-            # only allow it if moving the full qty.
-            location = search.location_from_scan(barcode)
-            if location:
-                package = None
-                if handle_complete_mix_pack:
-                    package = move_line.package_id
-                if self._pick_pack_same_time():
-                    (
-                        good_for_packing,
-                        message,
-                    ) = self._handle_pick_pack_same_time_for_location(move_line)
-                    # TODO: we should append the msg instead.
-                    # To achieve this, we should refactor `response.message` to a list
-                    # or, to no break backward compat, we could add `extra_messages`
-                    # to allow backend to send a main message and N additional messages.
-                    extra_message = message
-                    if not good_for_packing:
-                        return self._response_for_set_line_destination(
-                            move_line, message=message, qty_done=quantity
-                        )
-                pkg_moved, response = self._set_destination_location(
-                    move_line,
-                    package,
-                    quantity,
-                    confirmation,
-                    location,
-                    barcode,
-                )
-                if response:
-                    if extra_message:
-                        if response.get("message"):
-                            response["message"]["body"] += "\n" + extra_message["body"]
-                        else:
-                            response["message"] = extra_message
-                    return response
+        location = search.location_from_scan(barcode)
+        if location:
+            package = None
+            if handle_complete_mix_pack:
+                package = move_line.package_id
+            if self._pick_pack_same_time():
+                (
+                    good_for_packing,
+                    message,
+                ) = self._handle_pick_pack_same_time_for_location(move_line)
+                # TODO: we should append the msg instead.
+                # To achieve this, we should refactor `response.message` to a list
+                # or, to no break backward compat, we could add `extra_messages`
+                # to allow backend to send a main message and N additional messages.
+                extra_message = message
+                if not good_for_packing:
+                    return self._response_for_set_line_destination(
+                        move_line, message=message, qty_done=quantity
+                    )
+            pkg_moved, response = self._set_destination_location(
+                move_line,
+                package,
+                quantity,
+                confirmation,
+                location,
+                barcode,
+            )
+            if response:
+                if extra_message:
+                    if response.get("message"):
+                        response["message"]["body"] += "\n" + extra_message["body"]
+                    else:
+                        response["message"] = extra_message
+                return response
 
         # When the barcode is a package
         package = search.package_from_scan(barcode)


### PR DESCRIPTION
In the zone picking scenario, operators can choose to pick less than the reserved quantity. Previously, the system required them, in this case, to place the goods in a package first.

This restriction was unnecessary, as it forced operators to perform an extra step that they do not actually do in real life. We trust them to know what they're doing, so let's keep it simple.

With this fix, if a user scans a location, they can move the products directly to the scanned location.