### PR TITLE
[16.0] shopfloor cluster_picking: Custom sorting by device

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -339,8 +339,7 @@ class ClusterPicking(Component):
             return self.prepare_unload(batch.id)
         return self._response_for_start_line(next_line, message=message)
 
-    @staticmethod
-    def _sort_key_lines(line):
+    def _sort_key_lines(self, line):
         return (
             line.shopfloor_priority or 10,
             line.location_id.shopfloor_picking_sequence or "",

--- a/shopfloor_batch_automatic_creation/__manifest__.py
+++ b/shopfloor_batch_automatic_creation/__manifest__.py
@@ -14,6 +14,7 @@
     "depends": ["shopfloor", "stock_picking_batch_creation"],
     "data": [
         "views/shopfloor_menu_views.xml",
+        "views/stock_device_type.xml",
     ],
     "installable": True,
 }

--- a/shopfloor_batch_automatic_creation/models/__init__.py
+++ b/shopfloor_batch_automatic_creation/models/__init__.py
@@ -1,1 +1,2 @@
 from . import shopfloor_menu
+from . import stock_device_type

--- a/shopfloor_batch_automatic_creation/models/stock_device_type.py
+++ b/shopfloor_batch_automatic_creation/models/stock_device_type.py
@@ -1,0 +1,33 @@
+# Copyright 2021 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools.safe_eval import test_python_expr
+
+
+class StockDeviceType(models.Model):
+
+    _inherit = "stock.device.type"
+
+    line_sort_key_code = fields.Text(
+        groups="base.group_system",
+        string="Line sort key method",
+        help="""Python code to sort the lines in the batch.
+
+        The 'line' will be a recordset of stock.move.line.
+        and the method must assign a value to the variable 'key'
+        that will be used to sort the lines. You can also call
+        the super method to get the default behavior.
+        """,
+    )
+
+    @api.constrains("line_sort_key_code")
+    def _check_line_sort_key_code(self):
+        for record in self:
+            code = record.line_sort_key_code and record.line_sort_key_code.strip()
+            if not code:
+                continue
+            msg = test_python_expr(expr=code, mode="exec")
+            if msg:
+                raise ValidationError(msg)

--- a/shopfloor_batch_automatic_creation/views/stock_device_type.xml
+++ b/shopfloor_batch_automatic_creation/views/stock_device_type.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 ACSONE SA/NV
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record model="ir.ui.view" id="stock_device_type_form_view">
+        <field
+            name="inherit_id"
+            ref="stock_picking_batch_creation.stock_device_type_form_view"
+        />
+        <field name="model">stock.device.type</field>
+        <field name="arch" type="xml">
+            <xpath expr="//group/group[last()]" position="after">
+                <div style="margin-top: 4px;">
+                    <h3>Custom code to construct the key to sort move lines</h3>
+                    <p>Two variables are available:</p>
+                    <ul>
+                        <li><code
+                            >line</code>: The stock move line Record for with the key must be computed.</li>
+                        <li><code>super</code>: The initial method to compute the key.
+
+                        </li>
+                        <li>To assign the key value: <code
+                            >key = (line.product_id.weight, ) + super(line)</code></li>
+                    </ul>
+                    <p>Leave blank to use the default method.</p>
+                </div>
+                <field name="line_sort_key_code" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
With this change, in the cluster picking scenario,  you can now provide a custom code on a stock device that will be used to order the operation when this device is used