### PR TITLE
[IMP] stock_available_to_promise_release: Improve migration script

### DIFF
--- a/stock_available_to_promise_release/migrations/16.0.3.1.0/post-migrate.py
+++ b/stock_available_to_promise_release/migrations/16.0.3.1.0/post-migrate.py
@@ -12,6 +12,7 @@ def migrate(cr, version):
         FROM
             procurement_group
         WHERE
-            stock_picking.group_id = procurement_group.id
+            stock_picking.state NOT IN ('done', 'cancel')
+        AND stock_picking.group_id = procurement_group.id
     """
     )

--- a/stock_available_to_promise_release/migrations/16.0.3.1.0/pre-migrate.py
+++ b/stock_available_to_promise_release/migrations/16.0.3.1.0/pre-migrate.py
@@ -1,0 +1,24 @@
+# Copyright 2024 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Initialize default value when adding field instead updating every record.
+    """
+
+    field_spec = [
+        (
+            "release_policy",
+            "stock.picking",
+            False,
+            "char",
+            "varchar",
+            "stock_available_to_promise_release",
+            "direct",
+        )
+    ]
+
+    openupgrade.add_fields(env, field_spec=field_spec)


### PR DESCRIPTION
In order to update all existing records with the default value, use field creation with default instead updating.

Update pickings with procurement group value for current ones.