### PR TITLE
[16.0][IMP] stock_available_to_promise_release reset last_release_date on backorder

### DIFF
--- a/stock_available_to_promise_release/models/stock_picking.py
+++ b/stock_available_to_promise_release/models/stock_picking.py
@@ -27,7 +27,7 @@ class StockPicking(models.Model):
         help="Date/time used to sort moves to deliver first. "
         "Used to calculate the ordered available to promise.",
     )
-    last_release_date = fields.Datetime()
+    last_release_date = fields.Datetime(copy=False)
     release_policy = fields.Selection(
         [("direct", "As soon as possible"), ("one", "When all products are ready")],
         default="direct",


### PR DESCRIPTION
When creating a backorder `last_release_date` should reset.