### PR TITLE
[16.0] shopfloor: location_content_transfer: get_work additional domain and sort key.

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Shopfloor",
     "summary": "manage warehouse operations with barcode scanners",
-    "version": "16.0.2.2.0",
+    "version": "16.0.2.2.1",
     "development_status": "Beta",
     "category": "Inventory",
     "website": "https://github.com/OCA/wms",

--- a/shopfloor/actions/move_line_search.py
+++ b/shopfloor/actions/move_line_search.py
@@ -110,10 +110,16 @@ class MoveLineSearch(Component):
 
     def counters_for_lines(self, lines):
         # Not using mapped/filtered to support simple lists and generators
-        priority_lines = [x for x in lines if int(x.picking_id.priority or "0") > 0]
+        priority_lines = set()
+        priority_pickings = set()
+        for line in lines:
+            if int(line.move_id.priority or "0") > 0:
+                priority_lines.add(line)
+            if int(line.picking_id.priority or "0") > 0:
+                priority_pickings.add(line.picking_id)
         return {
             "lines_count": len(lines),
             "picking_count": len({x.picking_id.id for x in lines}),
             "priority_lines_count": len(priority_lines),
-            "priority_picking_count": len({x.picking_id.id for x in priority_lines}),
+            "priority_picking_count": len(priority_pickings),
         }

--- a/shopfloor/actions/move_line_search.py
+++ b/shopfloor/actions/move_line_search.py
@@ -49,10 +49,10 @@ class MoveLineSearch(Component):
         if lot:
             domain += [("lot_id", "=", lot.id)]
         if match_user:
+            # we only want to see the lines assigned to the current user
             domain += [
-                "|",
-                ("shopfloor_user_id", "=", False),
-                ("shopfloor_user_id", "=", self.env.uid),
+                ("shopfloor_user_id", "in", (False, self.env.uid)),
+                ("picking_id.user_id", "in", (False, self.env.uid)),
             ]
         if picking_ready:
             domain += [("picking_id.state", "=", "assigned")]

--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -21,7 +21,9 @@
     "multiple_move_single_pack": true,
     "no_prefill_qty": true,
     "scan_location_or_pack_first": true,
-    "allow_alternative_destination_package": true
+    "allow_alternative_destination_package": true,
+    "allow_move_line_search_sort_order": false,
+    "allow_move_line_search_additional_domain": true
 }
         </field>
     </record>
@@ -68,7 +70,10 @@
     "allow_unreserve_other_moves": true,
     "allow_ignore_no_putaway_available": true,
     "allow_get_work": true,
-    "no_prefill_qty": true
+    "no_prefill_qty": true,
+    "allow_move_line_search_sort_order": true,
+    "allow_move_line_search_additional_domain": true
+
 }
         </field>
     </record>

--- a/shopfloor/migrations/16.0.2.2.1/post-init_search_move_line_options.py
+++ b/shopfloor/migrations/16.0.2.2.1/post-init_search_move_line_options.py
@@ -1,0 +1,33 @@
+# Copyright 2024 ACSONE SA/NV (http://acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import json
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    zone_picking = env.ref("shopfloor.scenario_zone_picking")
+    _update_scenario_options(zone_picking, sort_order=False, additional_domain=True)
+    location_content_transfer = env.ref("shopfloor.scenario_location_content_transfer")
+    _update_scenario_options(
+        location_content_transfer, sort_order=True, additional_domain=True
+    )
+
+
+def _update_scenario_options(scenario, sort_order=True, additional_domain=True):
+    options = scenario.options
+    options["allow_move_line_search_sort_order"] = sort_order
+    options["allow_move_line_search_additional_domain"] = additional_domain
+    options_edit = json.dumps(options or {}, indent=4, sort_keys=True)
+    scenario.write({"options_edit": options_edit})
+    _logger.info(
+        "Option allow_alternative_destination_package added to scenario %s",
+        scenario.name,
+    )

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -329,7 +329,11 @@ class LocationContentTransfer(Component):
             )
 
         move_lines = self.search_move_line.search_move_lines(
-            locations=location, match_user=True, enforce_picking_types=False
+            locations=location,
+            match_user=True,
+            picking_type=self.env[
+                "stock.picking.type"
+            ],  # disable filtering on picking types
         )
         move_lines = self._select_move_lines_first_location(move_lines)
 

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -233,12 +233,8 @@ class LocationContentTransfer(Component):
         return self.env["stock.move"].create(move_vals_list)
 
     def _find_location_to_work_from(self):
-        location = self.env["stock.location"]
         move_lines = self.search_move_line.search_move_lines(match_user=True)
-        for move_line in move_lines:
-            if move_line.location_id:
-                return move_line.location_id
-        return location
+        return first(move_lines).location_id
 
     def _select_move_lines_first_location(self, move_lines):
         location = move_lines[0].location_id

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -3,6 +3,7 @@
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _
+from odoo.fields import first
 
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
@@ -237,7 +238,7 @@ class LocationContentTransfer(Component):
         return first(move_lines).location_id
 
     def _select_move_lines_first_location(self, move_lines):
-        location = move_lines[0].location_id
+        location = first(move_lines).location_id
         return move_lines.filtered(lambda line: line.location_id == location)
 
     def find_work(self):
@@ -330,6 +331,7 @@ class LocationContentTransfer(Component):
         move_lines = self.search_move_line.search_move_lines(
             locations=location, match_user=True, enforce_picking_types=False
         )
+        move_lines = self._select_move_lines_first_location(move_lines)
 
         savepoint = self._actions_for("savepoint").new()
         unreserve = self._actions_for("stock.unreserve")

--- a/shopfloor/services/menu.py
+++ b/shopfloor/services/menu.py
@@ -21,8 +21,7 @@ class ShopfloorMenu(Component):
         move_line_search = self._actions_for(
             "search_move_line", picking_types=record.picking_type_ids
         )
-        locations = record.picking_type_ids.mapped("default_location_src_id")
-        lines_per_menu = move_line_search.search_move_lines_by_location(locations)
+        lines_per_menu = move_line_search.search_move_lines()
         return move_line_search.counters_for_lines(lines_per_menu)
 
     def _one_record_parser(self, record):

--- a/shopfloor/services/menu.py
+++ b/shopfloor/services/menu.py
@@ -19,7 +19,11 @@ class ShopfloorMenu(Component):
         # TODO: maybe to be improved w/ raw SQL as this run for each menu item
         # and it's called every time the menu is opened/gets refreshed
         move_line_search = self._actions_for(
-            "search_move_line", picking_types=record.picking_type_ids
+            "search_move_line",
+            picking_types=record.picking_type_ids,
+            additional_domain=record.move_line_search_additional_domain,
+            sort_order=record.move_line_search_sort_order,
+            sort_order_custom_code=record.move_line_search_sort_order_custom_code,
         )
         lines_per_menu = move_line_search.search_move_lines()
         return move_line_search.counters_for_lines(lines_per_menu)

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -15,7 +15,15 @@ class BaseShopfloorService(AbstractComponent):
     @property
     def search_move_line(self):
         # TODO: propagating `picking_types` should probably be default
-        return self._actions_for("search_move_line", propagate_kwargs=["picking_types"])
+        return self._actions_for(
+            "search_move_line",
+            propagate_kwargs=[
+                "picking_types",
+                "additional_domain",
+                "sort_order",
+                "sort_order_custom_code",
+            ],
+        )
 
 
 class BaseShopfloorProcess(AbstractComponent):
@@ -39,12 +47,30 @@ class BaseShopfloorProcess(AbstractComponent):
         return self.work.picking_types
 
     @property
+    def additional_domain(self):
+        return self.work.menu.move_line_search_additional_domain
+
+    @property
+    def sort_order(self):
+        return self.work.menu.move_line_search_sort_order
+
+    @property
+    def sort_order_custom_code(self):
+        return self.work.menu.move_line_search_sort_order_custom_code
+
+    @property
     def search_move_line(self):
         # TODO: picking types should be set somehow straight in the work context
         # by `_validate_headers_update_work_context` in this way
         # we can remove this override and the need to call `_get_process_picking_types`
         # every time.
-        return self._actions_for("search_move_line", picking_types=self.picking_types)
+        return self._actions_for(
+            "search_move_line",
+            picking_types=self.picking_types,
+            additional_domain=self.additional_domain,
+            sort_order=self.sort_order,
+            sort_order_custom_code=self.sort_order_custom_code,
+        )
 
     def _check_picking_status(self, pickings, states=("assigned",)):
         """Check if given pickings can be processed.

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -315,7 +315,7 @@ class ZonePicking(Component):
         return self.search_move_line.counters_for_lines(zone_lines)
 
     def _picking_type_zone_lines(self, zone_location, picking_type):
-        return self.search_move_line.search_move_lines_by_location(
+        return self.search_move_line.search_move_lines(
             zone_location, picking_type=picking_type
         )
 
@@ -429,7 +429,7 @@ class ZonePicking(Component):
         enforce_empty_package=False,
     ):
         """Find lines that potentially need work in given locations."""
-        return self.search_move_line.search_move_lines_by_location(
+        return self.search_move_line.search_move_lines(
             locations or self.zone_location,
             picking_type=picking_type or self.picking_type,
             order=self.lines_order,

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -3,6 +3,7 @@ from . import test_openapi
 from . import test_actions_change_package_lot
 from . import test_actions_data
 from . import test_actions_data_detail
+from . import test_actions_search_move_line
 from . import test_actions_search
 from . import test_actions_stock
 from . import test_single_pack_transfer

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_menu_counters
+from . import test_menu_contrains
 from . import test_openapi
 from . import test_actions_change_package_lot
 from . import test_actions_data

--- a/shopfloor/tests/test_actions_search_move_line.py
+++ b/shopfloor/tests/test_actions_search_move_line.py
@@ -95,7 +95,7 @@ class TestActionsSearchMoveLine(CommonCase):
 
     def test_search_move_line_match_user(self):
         with self.search_move_line() as move_line_search:
-            move_lines = move_line_search.search_move_lines_by_location(
+            move_lines = move_line_search.search_move_lines(
                 locations=self.picking_type.default_location_src_id,
                 match_user=True,
             )
@@ -104,7 +104,7 @@ class TestActionsSearchMoveLine(CommonCase):
         self.assertFalse(move_lines.shopfloor_user_id)
 
         with self.search_move_line(user=self.user1) as move_line_search:
-            move_lines = move_line_search.search_move_lines_by_location(
+            move_lines = move_line_search.search_move_lines(
                 locations=self.picking_type.default_location_src_id,
                 match_user=True,
             )
@@ -113,7 +113,7 @@ class TestActionsSearchMoveLine(CommonCase):
         self.assertFalse(move_lines.shopfloor_user_id)
 
         with self.search_move_line(user=self.user2) as move_line_search:
-            move_lines = move_line_search.search_move_lines_by_location(
+            move_lines = move_line_search.search_move_lines(
                 locations=self.picking_type.default_location_src_id,
                 match_user=True,
             )

--- a/shopfloor/tests/test_actions_search_move_line.py
+++ b/shopfloor/tests/test_actions_search_move_line.py
@@ -1,0 +1,94 @@
+# Copyright 2024 ACSONE SA/NV (http://www.acsone.eu)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# pylint: disable=missing-return
+from contextlib import contextmanager
+
+from odoo.addons.base_rest.controllers.main import _PseudoCollection
+from odoo.addons.component.core import WorkContext
+
+from .common import CommonCase
+
+
+class TestActionsSearchMoveLine(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.picking_user1 = cls._create_picking(
+            lines=[(cls.product_a, 10)], confirm=True
+        )
+        cls.picking_user2 = cls._create_picking(
+            lines=[(cls.product_a, 10)], confirm=True
+        )
+        cls.picking_no_user = cls._create_picking(
+            lines=[(cls.product_a, 10)], confirm=True
+        )
+
+        cls.pickings = cls.picking_no_user | cls.picking_user1 | cls.picking_user2
+        cls._fill_stock_for_moves(cls.pickings.move_ids)
+        cls.pickings.action_assign()
+        cls.move_lines = cls.pickings.move_line_ids
+        cls.user1 = cls.env.user.copy({"name": "User 1", "login": "user1"})
+        cls.user2 = cls.env.user.copy({"name": "User 2", "login": "user2"})
+        cls.picking_no_user.user_id = False
+        cls.picking_user1.user_id = cls.user1.id
+        cls.picking_user2.move_line_ids.write({"shopfloor_user_id": cls.user2.id})
+        cls.picking_user2.user_id = False
+
+    @contextmanager
+    def work_on_actions(self, user=None, **params):
+        params = params or {}
+        env = self.env(user=user) if user else self.env
+        collection = _PseudoCollection("shopfloor.action", env)
+        yield WorkContext(
+            model_name="rest.service.registration", collection=collection, **params
+        )
+
+    @contextmanager
+    def search_move_line(self, user=None):
+        with self.work_on_actions(user) as work:
+            move_line_search = work.component(usage="search_move_line")
+            yield move_line_search
+
+    @classmethod
+    def setUpClassVars(cls):
+        super().setUpClassVars()
+        cls.wh = cls.env.ref("stock.warehouse0")
+        cls.picking_type = cls.wh.out_type_id
+
+    def test_search_move_line_sorter(self):
+        with self.search_move_line() as move_line_search:
+            move_lines = self.move_lines.sorted(move_line_search._sort_key_move_lines())
+        # we must get operations in the following order:
+        #  * no shopfloor user and not user assigned to picking
+        #  * no shopfloor user and user assigned to picking
+        #  * shopfloor user or user assigned to picking
+
+        self.assertFalse(move_lines[0].shopfloor_user_id)
+        self.assertFalse(move_lines[0].picking_id.user_id)
+        self.assertFalse(move_lines[1].shopfloor_user_id)
+        self.assertTrue(move_lines[1].picking_id.user_id)
+        self.assertTrue(move_lines[2].shopfloor_user_id)
+
+        with self.search_move_line(user=self.user1) as move_line_search:
+            move_lines = self.move_lines.sorted(move_line_search._sort_key_move_lines())
+        # user1 is only assigned at picking level
+        # we must get operations in the following order:
+        # * no shopfloor user but user assigned to picking
+        # * no shopfloor user and not user assigned to picking
+        # * shopfloor user or user assigned to picking
+        self.assertFalse(move_lines[0].shopfloor_user_id)
+        self.assertEqual(move_lines[0].picking_id.user_id, self.user1)
+        self.assertFalse(move_lines[1].shopfloor_user_id)
+        self.assertTrue(move_lines[2].shopfloor_user_id)
+
+        with self.search_move_line(user=self.user2) as move_line_search:
+            move_lines = self.move_lines.sorted(move_line_search._sort_key_move_lines())
+        # user2 is only assigned at move level
+        # we must get operations in the following order:
+        # * shopfloor user or user assigned to picking
+        # * no shopfloor user and no user assigned to picking
+        # * no shopfloor user and user assigned to picking
+        self.assertEqual(move_lines[0].shopfloor_user_id, self.user2)
+        self.assertFalse(move_lines[1].shopfloor_user_id)
+        self.assertFalse(move_lines[1].picking_id.user_id)
+        self.assertTrue(move_lines[2].picking_id.user_id)

--- a/shopfloor/tests/test_actions_search_move_line.py
+++ b/shopfloor/tests/test_actions_search_move_line.py
@@ -57,7 +57,9 @@ class TestActionsSearchMoveLine(CommonCase):
 
     def test_search_move_line_sorter(self):
         with self.search_move_line() as move_line_search:
-            move_lines = self.move_lines.sorted(move_line_search._sort_key_move_lines())
+            move_lines = self.move_lines.sorted(
+                move_line_search._sort_key_move_lines(order="assigned_to_current_user")
+            )
         # we must get operations in the following order:
         #  * no shopfloor user and not user assigned to picking
         #  * no shopfloor user and user assigned to picking
@@ -70,7 +72,9 @@ class TestActionsSearchMoveLine(CommonCase):
         self.assertTrue(move_lines[2].shopfloor_user_id)
 
         with self.search_move_line(user=self.user1) as move_line_search:
-            move_lines = self.move_lines.sorted(move_line_search._sort_key_move_lines())
+            move_lines = self.move_lines.sorted(
+                move_line_search._sort_key_move_lines(order="assigned_to_current_user")
+            )
         # user1 is only assigned at picking level
         # we must get operations in the following order:
         # * no shopfloor user but user assigned to picking
@@ -82,7 +86,9 @@ class TestActionsSearchMoveLine(CommonCase):
         self.assertTrue(move_lines[2].shopfloor_user_id)
 
         with self.search_move_line(user=self.user2) as move_line_search:
-            move_lines = self.move_lines.sorted(move_line_search._sort_key_move_lines())
+            move_lines = self.move_lines.sorted(
+                move_line_search._sort_key_move_lines(order="assigned_to_current_user")
+            )
         # user2 is only assigned at move level
         # we must get operations in the following order:
         # * shopfloor user or user assigned to picking

--- a/shopfloor/tests/test_location_content_transfer_mix.py
+++ b/shopfloor/tests/test_location_content_transfer_mix.py
@@ -370,8 +370,8 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
             lambda l: not l.shopfloor_user_id and l.location_id == dest_location2
         )
         picking_before = pack_second_pallet.picking_id
-        move_lines = self.service._find_location_move_lines(
-            pack_second_pallet.location_id
+        move_lines = self.service.search_move_line.search_move_lines(
+            locations=pack_second_pallet.location_id
         )
         response = self._location_content_transfer_process_line(pack_second_pallet)
         response_packages = response["data"]["scan_destination_all"]["package_levels"]

--- a/shopfloor/tests/test_menu_contrains.py
+++ b/shopfloor/tests/test_menu_contrains.py
@@ -1,0 +1,40 @@
+# Copyright 2024 ACSONE SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import exceptions
+
+from .test_menu_base import MenuCountersCommonCase
+
+
+class TestMenuContrains(MenuCountersCommonCase):
+    def test_move_line_search_sort_order_custom_code_invalid(self):
+
+        with self.assertRaises(exceptions.ValidationError):
+            # wrong indentation in python code
+            self.menu1.sudo().write(
+                {
+                    "move_line_search_sort_order_custom_code": """
+  key = 1
+  toto(1)
+""",
+                    "move_line_search_sort_order": "custom_code",
+                }
+            )
+
+        self.menu1.sudo().write(
+            {
+                "move_line_search_sort_order_custom_code": "key = 1",
+                "move_line_search_sort_order": "custom_code",
+            }
+        )
+
+    def test_move_line_search_sort_order_mismatch(self):
+        with self.assertRaises(exceptions.ValidationError):
+            self.menu1.sudo().move_line_search_sort_order = "custom_code"
+
+        self.menu1.sudo().write(
+            {
+                "move_line_search_sort_order_custom_code": "key = 1",
+                "move_line_search_sort_order": "priority",
+            }
+        )
+        self.assertFalse(self.menu1.move_line_search_sort_order_custom_code)

--- a/shopfloor/tests/test_menu_counters.py
+++ b/shopfloor/tests/test_menu_counters.py
@@ -24,6 +24,9 @@ class TestMenuCountersCommonCase(MenuCountersCommonCase):
             .sudo()
             .search([("profile_id", "=", self.wms_profile.id)])
         )
+        # ensures expected counters are in the expected menu items
+        self.assertIn(self.menu1, expected_menu_items)
+        self.assertIn(self.menu2, expected_menu_items)
         service = self.get_service("menu", profile=self.wms_profile)
         response = service.dispatch("search")
         self._assert_menu_response(
@@ -33,6 +36,51 @@ class TestMenuCountersCommonCase(MenuCountersCommonCase):
         )
 
     def test_menu_search_profile2(self):
+        expected_menu_items = (
+            self.env["shopfloor.menu"]
+            .sudo()
+            .search([("profile_id", "=", self.wms_profile2.id)])
+        )
+        expected_counters = {
+            expected_menu_item[0].id: {
+                "lines_count": 0,
+                "picking_count": 0,
+                "priority_lines_count": 0,
+                "priority_picking_count": 0,
+            }
+            for expected_menu_item in expected_menu_items
+        }
+        service = self.get_service("menu", profile=self.wms_profile2)
+        response = service.dispatch("search")
+        self._assert_menu_response(
+            response,
+            expected_menu_items.sorted("sequence"),
+            expected_counters=expected_counters,
+        )
+
+    def test_menu_counter_priority(self):
+        """Test that priority counters are correctly computed.
+
+        Priority on lines must be based on the move priority.
+        Priority on pickings must be based on the picking priority.
+        """
+        self.pickings.write({"priority": "0"})
+        self.pickings.move_ids.write({"priority": "0"})
+        pickings_menu_2 = self.pickings.filtered(
+            lambda p: p.picking_type_id == self.menu2_picking_type
+        )
+        # Set priority on pickings only for first picking of menu 2
+        pickings_menu_2[0].write({"priority": "1"})
+        pickings_menu_2[0].move_ids.write({"priority": "0"})
+
+        # set priority on move lines only for second picking of menu 2
+        pickings_menu_2[1].write({"priority": "0"})
+        pickings_menu_2[1].move_ids[0].write({"priority": "1"})
+
+        # set priority on both move lines and pickings for third picking of menu 2
+        pickings_menu_2[2].write({"priority": "1"})
+        pickings_menu_2[2].move_ids.write({"priority": "1"})
+
         expected_counters = {
             self.menu1.id: {
                 "lines_count": 2,
@@ -43,16 +91,19 @@ class TestMenuCountersCommonCase(MenuCountersCommonCase):
             self.menu2.id: {
                 "lines_count": 6,
                 "picking_count": 3,
-                "priority_lines_count": 0,
-                "priority_picking_count": 0,
+                "priority_lines_count": 1 + len(pickings_menu_2[2].move_ids),
+                "priority_picking_count": 2,
             },
         }
         expected_menu_items = (
             self.env["shopfloor.menu"]
             .sudo()
-            .search([("profile_id", "=", self.wms_profile2.id)])
+            .search([("profile_id", "=", self.wms_profile.id)])
         )
-        service = self.get_service("menu", profile=self.wms_profile2)
+        # ensures expected counters are in the expected menu items
+        self.assertIn(self.menu1, expected_menu_items)
+        self.assertIn(self.menu2, expected_menu_items)
+        service = self.get_service("menu", profile=self.wms_profile)
         response = service.dispatch("search")
         self._assert_menu_response(
             response,

--- a/shopfloor/tests/test_menu_counters.py
+++ b/shopfloor/tests/test_menu_counters.py
@@ -110,3 +110,62 @@ class TestMenuCountersCommonCase(MenuCountersCommonCase):
             expected_menu_items.sorted("sequence"),
             expected_counters=expected_counters,
         )
+
+    def test_menu_search_additional_domain(self):
+        self.menu1.sudo().move_line_search_additional_domain = [
+            ("picking_id.priority", "=", "1")
+        ]
+
+        expected_counters = {
+            self.menu1.id: {
+                "lines_count": 0,
+                "picking_count": 0,
+                "priority_lines_count": 0,
+                "priority_picking_count": 0,
+            },
+            self.menu2.id: {
+                "lines_count": 6,
+                "picking_count": 3,
+                "priority_lines_count": 0,
+                "priority_picking_count": 0,
+            },
+        }
+        expected_menu_items = (
+            self.env["shopfloor.menu"]
+            .sudo()
+            .search([("profile_id", "=", self.wms_profile.id)])
+        )
+        # ensures expected counters are in the expected menu items
+        self.assertIn(self.menu1, expected_menu_items)
+        self.assertIn(self.menu2, expected_menu_items)
+        service = self.get_service("menu", profile=self.wms_profile)
+        response = service.dispatch("search")
+        self._assert_menu_response(
+            response,
+            expected_menu_items.sorted("sequence"),
+            expected_counters=expected_counters,
+        )
+
+        self.menu1.sudo().move_line_search_additional_domain = [
+            ("picking_id.priority", "=", "0")
+        ]
+        expected_counters = {
+            self.menu1.id: {
+                "lines_count": 2,
+                "picking_count": 2,
+                "priority_lines_count": 0,
+                "priority_picking_count": 0,
+            },
+            self.menu2.id: {
+                "lines_count": 6,
+                "picking_count": 3,
+                "priority_lines_count": 0,
+                "priority_picking_count": 0,
+            },
+        }
+        response = service.dispatch("search")
+        self._assert_menu_response(
+            response,
+            expected_menu_items.sorted("sequence"),
+            expected_counters=expected_counters,
+        )

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -169,6 +169,60 @@
                     />
                     <field name="allow_alternative_destination_package" />
                 </group>
+                <group
+                    name="search_move_line"
+                    attrs="{'invisible': [('move_line_search_sort_order_is_possible', '=', False), ('move_line_search_additional_domain_is_possible', '=', False)]}"
+                >
+                <field
+                        name="move_line_search_additional_domain_is_possible"
+                        invisible="1"
+                    />
+                  <field
+                        name="move_line_search_additional_domain"
+                        widget="domain"
+                        options="{'model': 'stock.move.line'}"
+                        attrs="{'invisible': [('move_line_search_additional_domain_is_possible', '=', False)]}"
+                    />
+                  <field name="move_line_search_sort_order_is_possible" invisible="1" />
+                  <field
+                        name="move_line_search_sort_order"
+                        attrs="{'invisible': [('move_line_search_sort_order_is_possible', '=', False)]}"
+                    />
+                  <div
+                        class="o_cell o_wrap_label"
+                        style="margin-top: 4px;"
+                        colspan="2"
+                        attrs="{'invisible': ['|', ('move_line_search_sort_order_is_possible', '=', False), ('move_line_search_sort_order', '!=', 'custom_code')]}"
+                    >
+                    <label
+                            class="text-900"
+                            for="move_line_search_sort_order_custom_code"
+                        >Custom code to construct the key to sort move lines</label>
+                    <p>Three variables are available:</p>
+                    <ul>
+                        <li><code
+                                >line</code>: The move line for with the key must be computed.
+                        </li>
+                        <li><code
+                                >get_sort_key_priority</code>: Return sort key to sort by priority. (return a tuple)
+                        </li>
+                        <li><code
+                                >get_sort_key_location</code>: Return sort key to sort by location. (return a tuple)
+                        </li>
+                        <li><code
+                                >get_sort_key_assigned_to_current_user</code>: Return sort key to get line assigned to current user first. (return a tuple)
+                        </li>
+                        <li>To assign the key value: <code
+                                >key = get_sort_key_assigned_to_current_user(line) + (line.x, )</code></li>
+                    </ul>
+                    <field
+                            name="move_line_search_sort_order_custom_code"
+                            attrs="{'invisible': ['|', ('move_line_search_sort_order_is_possible', '=', False), ('move_line_search_sort_order', '!=', 'custom_code')]}"
+                            nolabel="1"
+                        />
+                  </div>
+
+            </group>
             </group>
         </field>
     </record>


### PR DESCRIPTION
The initial aim of this PR is to enable the 'location_content_transfer' scenario to be configured more precisely. 
It aims to:

* allow additional criteria to be configured to be applied when the user searches for work to be done (example of use: a menu for processing urgent transfers only)
* allow you to configure a different sort to be applied to the operations to be performed than the one based on priority. (by location, for example)
 
When analysing the code, I found that there was an inconsistency between the code used to create the menu counters and the one used to find the transactions in the 'location_content_transfer' scenario. The code in the latter scenario was functionally identical to the one used for menus and zone_picking. Harmonisation work has therefore been carried out to eliminate this inconsistency.

As result, a generic solution has been put in place for scenarios using the 'search_move_line' action to find the operations to be carried out, so that the menus can be used to configure an additional domain to be applied by default and the method for sorting operations.