### PR TITLE
[14.0][IMP] stock_reception_screen: Add index to last_move_line_lot_id

### DIFF
--- a/stock_reception_screen/models/stock_move.py
+++ b/stock_reception_screen/models/stock_move.py
@@ -12,6 +12,7 @@ class StockMove(models.Model):
     )
     last_move_line_lot_id = fields.Many2one(
         comodel_name="stock.production.lot",
+        index=True,
     )
     vendor_code = fields.Char(compute="_compute_vendor_code")
 


### PR DESCRIPTION
On a `DELETE FROM stock_production_lot ...`
Before:
`Trigger for constraint stock_move_last_move_line_lot_id_fkey: time=2521.017 calls=1`
After:
`Trigger for constraint stock_move_last_move_line_lot_id_fkey: time=1.278 calls=1`