### PR TITLE
[IMP] shopfloor: Improve message for location content transfer items

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -637,10 +637,14 @@ class MessageAction(Component):
             "body": _("Transfer {} complete").format(picking.name),
         }
 
-    def location_content_transfer_item_complete(self, location_dest):
+    def location_content_transfer_item_complete(self, location_src, location_dest):
         return {
             "message_type": "success",
-            "body": _("Content transfer to {} completed").format(location_dest.name),
+            "body": _(
+                "Content line transferred from %(location_name)s to %(location_dest_name)s",
+                location_name=location_src.name,
+                location_dest_name=location_dest.name,
+            ),
         }
 
     def location_content_transfer_complete(self, location_src, location_dest):

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -709,7 +709,7 @@ class LocationContentTransfer(Component):
         stock.validate_moves(package_moves)
         move_lines = self._find_transfer_move_lines(location)
         message = self.msg_store.location_content_transfer_item_complete(
-            scanned_location
+            location, scanned_location
         )
         completion_info = self._actions_for("completion.info")
         completion_info_popup = completion_info.popup(package_moves.move_line_ids)
@@ -776,7 +776,7 @@ class LocationContentTransfer(Component):
         else:
             move_lines = self._find_transfer_move_lines(move_line.location_id)
         message = self.msg_store.location_content_transfer_item_complete(
-            scanned_location
+            location, scanned_location
         )
         completion_info = self._actions_for("completion.info")
         completion_info_popup = completion_info.popup(move_line)

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -187,7 +187,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
         )
         for move in package_level.move_line_ids.mapped("move_id"):
@@ -235,7 +235,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
             popup=completion_info_popup,
         )
@@ -385,7 +385,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
         )
 
@@ -436,7 +436,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
             popup=completion_info_popup,
         )
@@ -485,7 +485,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             response,
             done_picking.backorder_ids,
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
         )
         self.assertEqual(move_line_c.move_id.state, "done")
@@ -754,7 +754,7 @@ class LocationContentTransferSetDestinationXSpecialCase(
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
         )
 
@@ -812,7 +812,7 @@ class LocationContentTransferSetDestinationXSpecialCase(
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
         )
         # Process the other move lines (lines w/o package + package levels)
@@ -1047,7 +1047,7 @@ class LocationContentTransferSetDestinationNextOperationSpecialCase(
             response,
             backorder,
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
         )
         # check that the next operation has the appropriate attributes
@@ -1071,6 +1071,6 @@ class LocationContentTransferSetDestinationNextOperationSpecialCase(
             response,
             self.picking,
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.dest_location
+                self.content_loc, self.dest_location
             ),
         )

--- a/shopfloor/tests/test_location_content_transfer_single.py
+++ b/shopfloor/tests/test_location_content_transfer_single.py
@@ -573,7 +573,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         backorder = self.picking3.backorder_ids
         self.assertTrue(backorder)
         message = {
-            "body": "Content transfer to Shelf 1 completed",
+            "body": "Content line transferred from Content Location to Shelf 1",
             "message_type": "success",
         }
 


### PR DESCRIPTION
In case of content transfer line by line, user wants to be recalled which origin location he comes from if he wants to transfer partially and put the remaining products back to source (e.g.: no more space on destination location)

@phschmidt @jbaudoux @sbejaoui @lmignon 

An easy one :sweat_smile: 