### PR TITLE
[16.0] stock_picking_batch_creation: Allows to split picking 

### DIFF
--- a/stock_picking_batch_creation/README.rst
+++ b/stock_picking_batch_creation/README.rst
@@ -140,6 +140,23 @@ are for the same partner. When activated, the computation of the
 number of bins consumed by the picking into the batch will take into account
 the volume of the pickings for the same partners already.
 
+Splitting picking if needed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also activate the option *Split picking exceeding the limits* on the
+wizard. In this case, when the system select the first picking to add to the
+batch, it will disable the criteria based on the volume, weight and number of
+lines. If the picking is exceeding the limits, the system will then try to split
+the picking so that the new picking fits the criteria and can be added to the
+batch. If the picking can't be split, an exception will be raised.
+
+This option is useful to allow to create a batch picking with pickings that
+are exceeding the limits defined in the wizard. It also ensures that the
+processing of pickings is done in the order of the pickings. If the option is
+not activated, the system will try to find a picking that fits the criteria
+and will ignore those that are exceeding the limits even if they are to be
+processed first.
+
 Bug Tracker
 ===========
 

--- a/stock_picking_batch_creation/__manifest__.py
+++ b/stock_picking_batch_creation/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Stock Picking Batch Creation",
     "summary": """
         Create a batch of pickings to be processed all together""",
-    "version": "16.0.1.0.0",
+    "version": "16.0.2.0.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",
@@ -16,6 +16,7 @@
         "delivery",  # weight on picking
         "stock_picking_batch",
         "stock_picking_volume",  # OCA/stock-logistics-warehouse
+        "stock_split_picking_dimension",  # OCA/stock-logistics-workflow
     ],
     "data": [
         "views/stock_device_type.xml",

--- a/stock_picking_batch_creation/exceptions.py
+++ b/stock_picking_batch_creation/exceptions.py
@@ -6,7 +6,8 @@ from odoo.exceptions import UserError
 
 
 class NoPickingCandidateError(UserError):
-    def __init__(self):
+    def __init__(self, env):
+        self.env = env
         super(NoPickingCandidateError, self).__init__(
             _("no candidate pickings to batch")
         )
@@ -14,6 +15,7 @@ class NoPickingCandidateError(UserError):
 
 class PickingCandidateNumberLineExceedError(UserError):
     def __init__(self, picking, max_line):
+        self.env = picking.env
         self.picking = picking
         super(PickingCandidateNumberLineExceedError, self).__init__(
             _(
@@ -28,7 +30,8 @@ class PickingCandidateNumberLineExceedError(UserError):
 
 
 class NoSuitableDeviceError(UserError):
-    def __init__(self, pickings):
+    def __init__(self, env, pickings):
+        self.env = env
         self.pickings = pickings
         message = _("No device found for batch picking.")
         if pickings:
@@ -37,3 +40,12 @@ class NoSuitableDeviceError(UserError):
                 names=", ".join(self.pickings.mapped("name")),
             )
         super(NoSuitableDeviceError, self).__init__(message)
+
+
+class PickingSplitNotPossibleError(UserError):
+    def __init__(self, picking):
+        self.env = picking.env
+        self.picking = picking
+        super(PickingSplitNotPossibleError, self).__init_(
+            _("Picking %(name)s cannot be split", name=self.picking.name)
+        )

--- a/stock_picking_batch_creation/readme/USAGE.rst
+++ b/stock_picking_batch_creation/readme/USAGE.rst
@@ -71,8 +71,15 @@ Splitting picking if needed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can also activate the option *Split picking exceeding the limits* on the
-wizard. This will allow, when the system is not able to find a picking that
-fits the criteria to create the batch, to lower the criteria by removing those
-based on the volume, weight and number of lines. If a picking is found and
-you allow to split it, the system will try to split the picking so that the
-new picking fits the criteria and can be added to the batch.
+wizard. In this case, when the system select the first picking to add to the
+batch, it will disable the criteria based on the volume, weight and number of
+lines. If the picking is exceeding the limits, the system will then try to split
+the picking so that the new picking fits the criteria and can be added to the
+batch. If the picking can't be split, an exception will be raised.
+
+This option is useful to allow to create a batch picking with pickings that
+are exceeding the limits defined in the wizard. It also ensures that the
+processing of pickings is done in the order of the pickings. If the option is
+not activated, the system will try to find a picking that fits the criteria
+and will ignore those that are exceeding the limits even if they are to be
+processed first.

--- a/stock_picking_batch_creation/readme/USAGE.rst
+++ b/stock_picking_batch_creation/readme/USAGE.rst
@@ -66,3 +66,13 @@ will prevent to consume at least one bin for each picking if pickings
 are for the same partner. When activated, the computation of the
 number of bins consumed by the picking into the batch will take into account
 the volume of the pickings for the same partners already.
+
+Splitting picking if needed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also activate the option *Split picking exceeding the limits* on the
+wizard. This will allow, when the system is not able to find a picking that
+fits the criteria to create the batch, to lower the criteria by removing those
+based on the volume, weight and number of lines. If a picking is found and
+you allow to split it, the system will try to split the picking so that the
+new picking fits the criteria and can be added to the batch.

--- a/stock_picking_batch_creation/static/description/index.html
+++ b/stock_picking_batch_creation/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -409,16 +409,17 @@ considered.</li>
 <li><a class="reference internal" href="#advanced-configuration" id="toc-entry-3">Advanced configuration</a><ul>
 <li><a class="reference internal" href="#locking" id="toc-entry-4">Locking</a></li>
 <li><a class="reference internal" href="#grouping-by-partner" id="toc-entry-5">Grouping by partner</a></li>
+<li><a class="reference internal" href="#splitting-picking-if-needed" id="toc-entry-6">Splitting picking if needed</a></li>
 </ul>
 </li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-6">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-7">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-8">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-9">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-10">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-11">Maintainers</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-7">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-8">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-9">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-10">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-11">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-12">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -483,10 +484,25 @@ are for the same partner. When activated, the computation of the
 number of bins consumed by the picking into the batch will take into account
 the volume of the pickings for the same partners already.</p>
 </div>
+<div class="section" id="splitting-picking-if-needed">
+<h4><a class="toc-backref" href="#toc-entry-6">Splitting picking if needed</a></h4>
+<p>You can also activate the option <em>Split picking exceeding the limits</em> on the
+wizard. In this case, when the system select the first picking to add to the
+batch, it will disable the criteria based on the volume, weight and number of
+lines. If the picking is exceeding the limits, the system will then try to split
+the picking so that the new picking fits the criteria and can be added to the
+batch. If the picking can’t be split, an exception will be raised.</p>
+<p>This option is useful to allow to create a batch picking with pickings that
+are exceeding the limits defined in the wizard. It also ensures that the
+processing of pickings is done in the order of the pickings. If the option is
+not activated, the system will try to find a picking that fits the criteria
+and will ignore those that are exceeding the limits even if they are to be
+processed first.</p>
+</div>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-6">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/wms/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -494,22 +510,22 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-7">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-8">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-9">Authors</a></h3>
 <ul class="simple">
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-9">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-10">Contributors</a></h3>
 <ul class="simple">
 <li>Laurent Mignon &lt;<a class="reference external" href="mailto:laurent.mignon&#64;acsone.eu">laurent.mignon&#64;acsone.eu</a>&gt; (<a class="reference external" href="https://www.acsone.eu/">https://www.acsone.eu/</a>)</li>
 <li>Lindsay Marion &lt;<a class="reference external" href="mailto:lindsay.marion&#64;acsone.eu">lindsay.marion&#64;acsone.eu</a>&gt; (<a class="reference external" href="https://www.acsone.eu/">https://www.acsone.eu/</a>)</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h3><a class="toc-backref" href="#toc-entry-10">Other credits</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-11">Other credits</a></h3>
 <p>The development of this module has been financially supported by:</p>
 <ul class="simple">
 <li>ACSONE SA/NV</li>
@@ -517,9 +533,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-11">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-12">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/stock_picking_batch_creation/wizards/make_picking_batch.xml
+++ b/stock_picking_batch_creation/wizards/make_picking_batch.xml
@@ -10,11 +10,10 @@
         <field name="arch" type="xml">
             <form string="Make Picking Batch">
                 <group>
-                    <group string="Criteria" name="criteria" colspan="4">
+                    <group string="Criteria" name="criteria" colspan="2">
                         <field name="user_id" />
                         <field name="picking_type_ids" widget="many2many_tags" />
                         <field name="maximum_number_of_preparation_lines" />
-                        <field name="no_line_limit_if_no_candidate" />
                     </group>
                     <group name="devices">
                         <label for="stock_device_type_ids" colspan="4" />
@@ -29,6 +28,7 @@
                         <field name="group_pickings_by_partner" />
                         <field name="restrict_to_same_partner" />
                         <field name="restrict_to_same_priority" />
+                        <field name="split_picking_exceeding_limits" />
                     </group>
                     <group string="Diagnostic" name="debug" colspan="4">
                         <field name="add_picking_list_in_error" />


### PR DESCRIPTION
A new option 'Split picking exceeding the limits' on the wizard allow, when the system is not able to find a picking that fits the criteria to create the batch, to lower the criteria by removing those based on the volume, weight and number of lines. If a picking is found and you allow to split it, the system will try to split the picking so that the new picking fits the criteria and can be added to the batch.

Depends on:
* [x] https://github.com/OCA/stock-logistics-workflow/pull/1741