### PR TITLE
[16.0][FW] shopfloor_base: Blacklist of some PRs from 14.0

### DIFF
--- a/.oca/oca-port/blacklist/shopfloor_base.json
+++ b/.oca/oca-port/blacklist/shopfloor_base.json
@@ -1,0 +1,10 @@
+{
+  "pull_requests": {
+    "316": "(auto) Nothing to port from PR #316",
+    "402": "Nothing to port",
+    "405": "(auto) Nothing to port from PR #405",
+    "479": "(auto) Nothing to port from PR #479",
+    "575": "(auto) Nothing to port from PR #575",
+    "574": "(auto) Nothing to port from PR #574"
+  }
+}


### PR DESCRIPTION
The following PRs have been blacklisted:
- #316: (auto) Nothing to port from PR #316
- #402: Nothing to port
- #405: (auto) Nothing to port from PR #405
- #479: (auto) Nothing to port from PR #479
- #575: (auto) Nothing to port from PR #575
- #574: (auto) Nothing to port from PR #574
