### PR TITLE
[14.0][FIX] shopfloor: compatibility location barcode with barcodes_generator_location

### DIFF
--- a/shopfloor/views/stock_location.xml
+++ b/shopfloor/views/stock_location.xml
@@ -5,12 +5,11 @@
         <field name="model">stock.location</field>
         <field name="inherit_id" ref="stock.view_location_form" />
         <field name="arch" type="xml">
-            <!-- show barcode because it's handy -->
-            <xpath expr="//field[@name='location_id']/.." position="after">
-                <label for="barcode" />
-                <field name="barcode" />
-            </xpath>
             <xpath expr="//group[@name='additional_info']/.." position="inside">
+                <!-- show barcode because it's handy -->
+                <group name="barcode" string="Barcode">
+                    <field name="barcode" />
+                </group>
                 <group string="Shopfloor">
                     <field name="shopfloor_picking_sequence" />
                 </group>


### PR DESCRIPTION
When using wms/shopfloor with [stock-logistics-barcode/barcodes_generator_location](https://github.com/OCA/stock-logistics-barcode/tree/14.0/barcodes_generator_location), the location's view is getting unusable because the module barcodes_generator_location is awaiting to have the barcode field in a dedicated group like in [stock-logistics-barcode/stock_barcodes](https://github.com/OCA/stock-logistics-barcode/blob/14.0/stock_barcodes/views/stock_location_views.xml#L12C13-L16C21) :
![image](https://github.com/user-attachments/assets/8b73249a-7dc2-47e5-963c-ffcd9eddb8b3)



This PR creates a dedicated group for the barcode field, making **the 2 modules shopfloor and barcodes_generator_location compatible**:
![image](https://github.com/user-attachments/assets/8a9a03a1-6bc6-4a44-8815-e84e848a7276)


cc @Kev-Roche 
