### PR TITLE
[16.0][FW] stock_storage_type: port changes from 14 

### DIFF
--- a/.oca/oca-port/blacklist/stock_storage_type.json
+++ b/.oca/oca-port/blacklist/stock_storage_type.json
@@ -1,0 +1,8 @@
+{
+  "pull_requests": {
+    "264": "(auto) Nothing to port from PR #264",
+    "269": "(auto) Nothing to port from PR #269",
+    "723": "(auto) Nothing to port from PR #723",
+    "772": "dotfiles"
+  }
+}


### PR DESCRIPTION
Port changes from 14.0 to 16.0. (No PRs)

The following PRs have been blacklisted:
- #264: (auto) Nothing to port from PR #264
- #269: (auto) Nothing to port from PR #269
- #723: (auto) Nothing to port from PR #723
- #772: dotfiles
