### PR TITLE
[14.0][FIX] shopfloor: cluster_picking do not create a new move line

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -696,16 +696,32 @@ class ClusterPicking(Component):
         if not product:
             packaging = search.packaging_from_scan(barcode)
             product = packaging.product_id
-        if product and move_line.product_id == product:
-            quantity += packaging.qty or 1.0
-            response = self._response_for_scan_destination(move_line, qty_done=quantity)
-            return response
+        if product:
+            if move_line.product_id == product:
+                quantity += packaging.qty or 1.0
+                response = self._response_for_scan_destination(
+                    move_line, qty_done=quantity
+                )
+                return response
+            return self._response_for_scan_destination(
+                move_line,
+                message=self.msg_store.wrong_record(product),
+                qty_done=quantity,
+            )
         # Handle barcode of a lot
         lot = search.lot_from_scan(barcode)
-        if lot and move_line.lot_id == lot:
-            quantity += 1.0
-            response = self._response_for_scan_destination(move_line, qty_done=quantity)
-            return response
+        if lot:
+            if move_line.lot_id == lot:
+                quantity += 1.0
+                response = self._response_for_scan_destination(
+                    move_line, qty_done=quantity
+                )
+                return response
+            return self._response_for_scan_destination(
+                move_line,
+                message=self.msg_store.wrong_record(lot),
+                qty_done=quantity,
+            )
         return response
 
     def scan_destination_pack(self, picking_batch_id, move_line_id, barcode, quantity):

--- a/shopfloor/tests/test_cluster_picking_scan_destination_no_prefill_qty.py
+++ b/shopfloor/tests/test_cluster_picking_scan_destination_no_prefill_qty.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from .test_cluster_picking_base import ClusterPickingCommonCase
@@ -76,15 +77,16 @@ class ClusterPickingScanDestinationPackPrefillQtyCase(ClusterPickingCommonCase):
         )
         # Ensure the qty has not changed.
         self.assertEqual(line.qty_done, previous_qty_done)
-
+        new_move_line = self.env["stock.move.line"].search(
+            [("move_id", "=", line.move_id.id), ("id", ">", line.id)]
+        )
+        self.assertFalse(new_move_line)
         expected_qty_done = qty_done
         self.assert_response(
             response,
             next_state="scan_destination",
             data=self._line_data(line, qty_done=expected_qty_done),
-            message=self.service.msg_store.bin_not_found_for_barcode(
-                self.product_b.barcode
-            ),
+            message=self.service.msg_store.wrong_record(self.product_b),
         )
 
     def test_scan_destination_pack_increment_with_packaging(self):


### PR DESCRIPTION
When a wrong product is scanned, while setting the qty_done. 
The qty done is not changed and no response was returned. 
This leads to the error, that a new move line is created. 

Now it would be returning that this scanned product is not in the picking
and will not create a new move line. 