### PR TITLE
[16.0][FIX] sale_stock_release_channel_partner_by_date: Avoid release channel reset

### DIFF
--- a/sale_stock_release_channel_partner_by_date/models/sale_order.py
+++ b/sale_stock_release_channel_partner_by_date/models/sale_order.py
@@ -42,6 +42,8 @@ class SaleOrder(models.Model):
             if not rec._check_release_channel_partner_date_requirements():
                 continue
             channel_date = rec.release_channel_partner_date_id
+            if not channel_date:
+                continue
             rec.release_channel_id = channel_date.release_channel_id
 
     @api.depends(

--- a/sale_stock_release_channel_partner_by_date/tests/test_sale_release_channel.py
+++ b/sale_stock_release_channel_partner_by_date/tests/test_sale_release_channel.py
@@ -1,6 +1,8 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import fields
 
 from .common import SaleReleaseChannelCase
@@ -37,6 +39,28 @@ class TestSaleReleaseChannel(SaleReleaseChannelCase):
         order.with_context(disable_cancel_warning=True).action_cancel()
         channel_date = order._get_release_channel_partner_date()
         self.assertFalse(channel_date)
+
+    def test_sale_force_release_channel_on_create(self):
+        order = self._create_sale_order()
+        order_release_channel_id = {order.id: self.test_channel.id}
+        order = order.with_context(order_release_channel_id=order_release_channel_id)
+        # Write delivery date to trigger the channel assignment
+        order.commitment_date = fields.Date.today() + relativedelta(month=1)
+        channel_date = order._get_release_channel_partner_date()
+        self.assertFalse(channel_date)
+        # No channel can be proposed by the assignment mechanism.
+        # Then current release channel should be kept.
+        self.assertEqual(order.release_channel_id, self.test_channel)
+
+        order = self._create_sale_order()
+        # Force the channel on order
+        order.release_channel_id = self.default_channel
+        # Assign commitment date to trigger the channel assignment
+        order_release_channel_id = {order.id: self.test_channel.id}
+        order = order.with_context(order_release_channel_id=order_release_channel_id)
+        order.commitment_date = fields.Datetime.now()
+        # Specific release channel is set by the channel assignment mechanism
+        self.assertEqual(order.release_channel_id, self.test_channel)
 
     def test_sale_computed_release_channel(self):
         # Create a specific channel entry from an order, and check if it is


### PR DESCRIPTION
Avoid release channel reset when creating a SO.

Steps to replicate:

1. create a new sale order
2. select a customer
3. select a commitment date (Delivery Date) in the future that does not propose any release channel
4. select a release channel (any)
5. save

Results: on save, release channel is reset to empty
Expected behavior:  on save, the release channel is kept  