### PR TITLE
[16.0][FIX] stock_available_to_promise_release: fix view

### DIFF
--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -42,9 +42,6 @@
         <field name="inherit_id" ref="stock.view_move_form" />
         <field eval="900" name="priority" />
         <field name="arch" type="xml">
-            <field name="date" position="attributes">
-                <attribute name="string">Shipment date</attribute>
-            </field>
             <group name="main_grp_col2" position="inside">
                 <field name="ordered_available_to_promise_uom_qty" />
                 <field name="date_priority" />


### PR DESCRIPTION
Drop label change on date label on stock move form view as the odoo standard view changed in v14 to display label according to state

* In odoo v13 : https://github.com/odoo/odoo/blob/13.0/addons/stock/views/stock_move_views.xml#L345
* since odoo v14, date is with `nolabel` : https://github.com/odoo/odoo/blob/16.0/addons/stock/views/stock_move_views.xml#L333

@rousseldenis @sebalix @i-vyshnevska @cyrilmanuel 