### PR TITLE
[IMP] shopfloor_base: Don't filter for registry sync

### DIFF
--- a/shopfloor_base/data/server_action.xml
+++ b/shopfloor_base/data/server_action.xml
@@ -6,8 +6,7 @@
             <field name="model_id" ref="shopfloor_base.model_shopfloor_app" />
             <field name="binding_model_id" ref="shopfloor_base.model_shopfloor_app" />
             <field name="state">code</field>
-            <field name="code">
-records.filtered(lambda x: not x.registry_sync).write({"registry_sync": True})
+            <field name="code">records.write({"registry_sync": True})
             </field>
         </record>
 </odoo>


### PR DESCRIPTION
@jbaudoux @phschmidt @lmignon

The use case is :

- When adding new endpoints, shopfloor apps records registry should be updated through 'Actions > Sync registry'.

The shopfloor_base documentation lacks that usage. See: https://github.com/OCA/wms/blob/16.0/shopfloor_base/readme/USAGE.rst

If someone want to enrich it :smile: 