### PR TITLE
[14.0][IMP] shopfloor_base: Propagate the shopfloor.app to actions

### DIFF
--- a/shopfloor_base/services/service.py
+++ b/shopfloor_base/services/service.py
@@ -28,6 +28,11 @@ class BaseShopfloorService(AbstractComponent):
         # User private attributes to not mess up w/ public endpoints
         self._profile = getattr(self.work, "profile", self.env["shopfloor.profile"])
         self._menu = getattr(self.work, "menu", self.env["shopfloor.menu"])
+        app = self.env["shopfloor.app"]
+        if self.collection._name == app._name:
+            app = self.collection
+        self.work.app = app
+        self.work._propagate_kwargs.append("app")
 
     def _get_api_spec(self, **params):
         return ShopfloorRestServiceAPISpec(self, **params)


### PR DESCRIPTION
At the moment there is no property on the actions which represents the app. 
Since i'm extending right now the scan everything screens, i need to know the warehouse. 
Because by scanning a product i want to show the quants. But not all quants only the configured ones on the app. 
The warehouse would then be reachable by `self.work.app.profile_ids.menu_ids.picking_type_ids.warehouse_id`

@simahawk could you maybe give some more information about this?
Why was this https://github.com/OCA/wms/commit/f6f54b0f266c3457b70fab74362e18dd47c59b95 necessary?
Would i be a problem to set the actions_collection like this `actions_collection = collection or component_instance.collection`

cc @jbaudoux 