### PR TITLE
[14.0][FIX] delivery_carrier_preference: fix perf issue when editing packaging from product form

### DIFF
--- a/delivery_carrier_preference/models/stock_move.py
+++ b/delivery_carrier_preference/models/stock_move.py
@@ -18,10 +18,13 @@ class StockMove(models.Model):
     )
 
     @api.depends(
+        # NOTE: do not list 'product_id.weight' and 'product_id.packaging_ids'
+        # on purpose to not trigger heavy computation when triggering onchange
+        # on packaging subform from products.
+        # As this field is not stored, having only "product_id" to trigger the
+        # computation from a move form is enough (weight and packagings can be
+        # considered stable data and should not be edited from move).
         "product_id",
-        "product_id.packaging_ids",
-        "product_id.packaging_ids.max_weight",
-        "product_id.weight",
         "ordered_available_to_promise_uom_qty",
     )
     def _compute_estimated_shipping_weight(self):


### PR DESCRIPTION
On products having a lot of moves, editing packaging from product form is triggering heavy computation as a side-effect, even if the `estimated_shipping_weight` field is not stored.
Odoo is fetching moves and then pickings of these moves through this line:

https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/odoo/models.py#L5904

This can be reproduced on a demo DB with only `delivery_carrier_preference` installed (putting a `pdb` in the Odoo line above shows that `picking_id` is accessed and with enough moves in DB, a latency can be experienced).