### PR TITLE
[16.0][FW] shopfloor: multiple ports from 14.0

### DIFF
--- a/.oca/oca-port/blacklist/shopfloor.json
+++ b/.oca/oca-port/blacklist/shopfloor.json
@@ -1,0 +1,11 @@
+{
+  "pull_requests": {
+    "OCA/wms#545": "(auto) Nothing to port from PR #545",
+    "OCA/wms#641": "(auto) Nothing to port from PR #641",
+    "OCA/wms#606": "(auto) Nothing to port from PR #606",
+    "OCA/wms#623": "already ported",
+    "OCA/wms#637": "already ported",
+    "OCA/wms#656": "already ported",
+    "OCA/wms#945": "ported into 'stock_move_line_change_lot' in OCA/stock-logistics-workflow#1825"
+  }
+}

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -695,16 +695,32 @@ class ClusterPicking(Component):
         if not product:
             packaging = search.packaging_from_scan(barcode)
             product = packaging.product_id
-        if product and move_line.product_id == product:
-            quantity += packaging.qty or 1.0
-            response = self._response_for_scan_destination(move_line, qty_done=quantity)
-            return response
+        if product:
+            if move_line.product_id == product:
+                quantity += packaging.qty or 1.0
+                response = self._response_for_scan_destination(
+                    move_line, qty_done=quantity
+                )
+                return response
+            return self._response_for_scan_destination(
+                move_line,
+                message=self.msg_store.wrong_record(product),
+                qty_done=quantity,
+            )
         # Handle barcode of a lot
         lot = search.lot_from_scan(barcode)
-        if lot and move_line.lot_id == lot:
-            quantity += 1.0
-            response = self._response_for_scan_destination(move_line, qty_done=quantity)
-            return response
+        if lot:
+            if move_line.lot_id == lot:
+                quantity += 1.0
+                response = self._response_for_scan_destination(
+                    move_line, qty_done=quantity
+                )
+                return response
+            return self._response_for_scan_destination(
+                move_line,
+                message=self.msg_store.wrong_record(lot),
+                qty_done=quantity,
+            )
         return response
 
     def scan_destination_pack(self, picking_batch_id, move_line_id, barcode, quantity):

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -894,29 +894,25 @@ class ZonePicking(Component):
             base_response=response, message=self.msg_store.barcode_not_found()
         )
 
-    def _set_destination_location(
+    def _check_set_destination_location(
         self, move_line, package, quantity, confirmation, location, barcode
     ):
-        location_changed = False
-        response = None
-
         # A valid location is a sub-location of the original destination, or a
         # any sub-location of the picking type's default destination location
         # if `confirmation is equal to the barcode scanned.
         # Ask confirmation to the user if the scanned location is not in the
         # expected ones but is valid (in picking type's default destination)
         if not self.is_dest_location_valid(move_line.move_id, location):
-            response = self._response_for_set_line_destination(
+            return self._response_for_set_line_destination(
                 move_line,
                 message=self.msg_store.dest_location_not_allowed(),
                 qty_done=quantity,
             )
-            return (location_changed, response)
 
         if confirmation != barcode and self.is_dest_location_to_confirm(
             move_line.location_dest_id, location
         ):
-            response = self._response_for_set_line_destination(
+            return self._response_for_set_line_destination(
                 move_line,
                 message=self.msg_store.confirm_location_changed(
                     move_line.location_dest_id, location
@@ -924,15 +920,23 @@ class ZonePicking(Component):
                 confirmation_required=barcode,
                 qty_done=quantity,
             )
-            return (location_changed, response)
 
         # If no destination package
         if self._packing_required() and not move_line.result_package_id:
-            response = self._response_for_set_line_destination(
+            return self._response_for_set_line_destination(
                 move_line,
                 message=self.msg_store.dest_package_required(),
                 qty_done=quantity,
             )
+
+    def _set_destination_location(
+        self, move_line, package, quantity, confirmation, location, barcode
+    ):
+        location_changed = False
+        response = self._check_set_destination_location(
+            move_line, package, quantity, confirmation, location, barcode
+        )
+        if response:
             return (location_changed, response)
         # destination location set to the scanned one
 

--- a/shopfloor/tests/test_cluster_picking_scan_destination_no_prefill_qty.py
+++ b/shopfloor/tests/test_cluster_picking_scan_destination_no_prefill_qty.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from .test_cluster_picking_base import ClusterPickingCommonCase
@@ -78,15 +79,16 @@ class ClusterPickingScanDestinationPackPrefillQtyCase(ClusterPickingCommonCase):
         )
         # Ensure the qty has not changed.
         self.assertEqual(line.qty_done, previous_qty_done)
-
+        new_move_line = self.env["stock.move.line"].search(
+            [("move_id", "=", line.move_id.id), ("id", ">", line.id)]
+        )
+        self.assertFalse(new_move_line)
         expected_qty_done = qty_done
         self.assert_response(
             response,
             next_state="scan_destination",
             data=self._line_data(line, qty_done=expected_qty_done),
-            message=self.service.msg_store.bin_not_found_for_barcode(
-                self.product_b.barcode
-            ),
+            message=self.service.msg_store.wrong_record(self.product_b),
         )
 
     def test_scan_destination_pack_increment_with_packaging(self):


### PR DESCRIPTION
Port from 14.0 to 16.0:
- <s>#712</s> Done here: #977
- #879
- #950

The following PRs have been blacklisted:
- #545: (auto) Nothing to port
- #641: (auto) Nothing to port
- #606: (auto) Nothing to port
- #623: already ported
- #637: already ported
- #656: already ported
- #945: ported into `stock_move_line_change_lot` in OCA/stock-logistics-workflow#1825

### TODO:
- [ ] port https://github.com/OCA/wms/pull/645