### PR TITLE
[16.0][FIX] stock_release_channel: do not `write` records in `_compute_picking_count`

### DIFF
--- a/stock_release_channel/models/stock_release_channel.py
+++ b/stock_release_channel/models/stock_release_channel.py
@@ -450,7 +450,7 @@ class StockReleaseChannel(models.Model):
                     + values[f"{prefix}_picking_released"]
                     + values[f"{prefix}_picking_done"]
                 )
-            record.write(values)
+            record.update(values)
 
     def _query_get_chain(self, pickings):
         """Get all stock.picking before an outgoing one


### PR DESCRIPTION
This is triggering concurrency updates on release channel records while reading them in the dashboard (updating `write_date` + `write_uid` fields).