### PR TITLE
[14.0] stock_available_to_promise_release: Allow unrelease processed qties

### DIFF
--- a/stock_available_to_promise_release/models/stock_location_route.py
+++ b/stock_available_to_promise_release/models/stock_location_route.py
@@ -7,6 +7,16 @@ from odoo import fields, models
 class Route(models.Model):
     _inherit = "stock.location.route"
 
+    allow_unrelease_return_done_move = fields.Boolean(
+        string="Reverse done transfer on cancellation",
+        default=False,
+        help=(
+            "If checked, unreleasing the delivery may create a new inverse "
+            "internal operation on the last done pulled transfer. "
+            "Otherwise, you won't be able to unrelease as soon as one of "
+            "the pulled transfer is done"
+        ),
+    )
     available_to_promise_defer_pull = fields.Boolean(
         string="Release based on Available to Promise",
         default=False,

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -5,11 +5,12 @@
 import itertools
 import logging
 import operator as py_operator
+from collections import defaultdict
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.osv import expression
-from odoo.tools import date_utils, float_compare, float_round, groupby
+from odoo.tools import date_utils, float_compare, float_is_zero, float_round, groupby
 
 _logger = logging.getLogger(__name__)
 
@@ -96,12 +97,22 @@ class StockMove(models.Model):
         """
         self.ensure_one()
         pickings = origin_moves.mapped("picking_id")
-        if pickings.filtered("printed"):
-            # The picking is printed, we can't unrelease the move
-            # because the processing of the origin moves is started.
+        ongoing_pickings = pickings.filtered(
+            lambda p: p.printed and p.state not in ("cancel", "done")
+        )
+        if ongoing_pickings:
+            # The picking is either printed or done/cancelled.
+            # We can't unrelease the move because the processing of the origin moves
+            # is either started or done.
             return False
+        # If allow_unrelease_on_cancel is not checked, only release assigned/waiting
+        # moves. If checked, also unrelease done moves.
+        if self.rule_id.allow_unrelease_return_done_move:
+            unreleasable_states = ("cancel",)
+        else:
+            unreleasable_states = ("done", "cancel")
         origin_moves = origin_moves.filtered(
-            lambda m: m.state not in ("done", "cancel")
+            lambda m: m.state not in unreleasable_states
         )
         origin_qty_todo = sum(origin_moves.mapped("product_qty"))
         return (
@@ -603,6 +614,81 @@ class StockMove(models.Model):
             yield moves
             moves = moves.mapped(chain_field)
 
+    def _return_quantity_in_stock(self, qty_to_return_per_move):
+        """Return a quantity from a list of moves.
+
+        The quantity to return is in the product uom"""
+        moves_to_return = self.browse([m_id for m_id in qty_to_return_per_move.keys()])
+        moves_per_type = groupby(moves_to_return, lambda m: m.picking_type_id)
+        for picking_type, moves_list in moves_per_type:
+            moves = self.browse().union(*moves_list)
+            pickings = moves.picking_id
+            if not pickings:
+                continue
+            return_type = picking_type.return_picking_type_id
+            wiz_values = {
+                "picking_id": fields.first(pickings).id,
+                "location_id": return_type.default_location_dest_id.id,
+            }
+            product_return_moves = []
+            if not return_type:
+                message = _(
+                    "The operation %(picking_names)s is done and cannot be returned",
+                    picking_names=", ".join(pickings.mapped("name")),
+                )
+                raise UserError(message)
+            for move in moves:
+                # Cannot return an unprocessed move
+                if move.state != "done":
+                    continue
+                product = move.product_id
+                uom = product.uom_id
+                qty_to_return = qty_to_return_per_move.get(move.id, 0)
+                # Cannot return 0 qty
+                if float_is_zero(qty_to_return, precision_rounding=uom.rounding):
+                    continue
+                return_move_vals = {
+                    "product_id": product.id,
+                    "quantity": qty_to_return,
+                    "uom_id": uom.id,
+                    "move_id": move.id,
+                }
+                product_return_moves.append((0, 0, return_move_vals))
+            if product_return_moves:
+                wiz_values["product_return_moves"] = product_return_moves
+                return_wiz = self.env["stock.return.picking"].create(wiz_values)
+                return_wiz.create_returns()
+        return True
+
+    def _unrelease_set_returnable_qty_per_move(
+        self, qty_to_return, qty_to_return_per_move
+    ):
+        returnable_qty = 0
+        for move in self:
+            rounding = move.product_id.uom_id.rounding
+            # As a move might have multiple dest ids, we might have
+            # already planned to return a few units already.
+            # Get it, and deduce it from the returnable qty
+            move_qty_planned = qty_to_return_per_move.get(move.id, 0)
+            # A move might already have return moves linked to it, deduce their quantity
+            move_returned_qty = sum(
+                move.returned_move_ids.filtered(lambda m: m.state != "cancel").mapped(
+                    "product_qty"
+                )
+            )
+            move_returnable_qty = min(
+                qty_to_return, move.product_qty - move_returned_qty - move_qty_planned
+            )
+            if float_is_zero(move_returnable_qty, precision_rounding=rounding):
+                continue
+            # Update the quantity
+            qty_to_return_per_move[move.id] += move_returnable_qty
+            qty_to_return -= move_returnable_qty
+            returnable_qty += move_returnable_qty
+            if float_is_zero(qty_to_return, precision_rounding=rounding):
+                break
+        return returnable_qty
+
     def unrelease(self, safe_unrelease=False):
         """Unrelease unreleasavbe moves
 
@@ -614,29 +700,74 @@ class StockMove(models.Model):
             moves_to_unrelease = self.filtered("unrelease_allowed")
         moves_to_unrelease._check_unrelease_allowed()
         moves_to_unrelease.write({"need_release": True})
-        impacted_picking_ids = set()
 
+        qty_to_return_per_move = defaultdict(float)
         for move in moves_to_unrelease:
+            rounding = move.product_id.uom_id.rounding
+            # When a move is returned, it is going straight to WH/Stock,
+            # skipping all intermediate zones (pick/pack).
+            # That is why we need to keep track of qty returned along the way.
+            # We do not want to return the same goods at each step.
+            # At a given step (pick/pack/ship), qty to return is
+            # move.product_uom_qty - cancelled_qty_at_step - already returned qties
+            qty_to_unrelease = move.product_qty
+            qty_returned_for_move = 0
             iterator = move._get_chained_moves_iterator("move_orig_ids")
-            moves_to_cancel = self.env["stock.move"]
+            moves_to_cancel_for_move = self.env["stock.move"]
             # backup procure_method as when you don't propagate cancel, the
             # destination move is forced to make_to_stock
             procure_method = move.procure_method
             next(iterator)  # skip the current move
             for origin_moves in iterator:
-                origin_moves = origin_moves.filtered(
+                qty_to_cancel = qty_to_unrelease - qty_returned_for_move
+                if float_is_zero(qty_to_cancel, precision_rounding=rounding):
+                    break
+                todo_origin_moves = origin_moves.filtered(
                     lambda m: m.state not in ("done", "cancel")
                 )
-                if origin_moves:
-                    origin_moves = move._split_origins(origin_moves)
-                    impacted_picking_ids.update(origin_moves.mapped("picking_id").ids)
+                qty_canceled = 0
+                if todo_origin_moves:
+                    moves_to_cancel = move._split_origins(
+                        todo_origin_moves, qty=qty_to_cancel
+                    )
                     # avoid to propagate cancel to the original move
-                    origin_moves.write({"propagate_cancel": False})
-                    # origin_moves._action_cancel()
-                    moves_to_cancel |= origin_moves
-            moves_to_cancel._action_cancel()
+                    moves_to_cancel.write({"propagate_cancel": False})
+                    moves_to_cancel_for_move |= moves_to_cancel
+                    qty_canceled = sum(moves_to_cancel.mapped("product_qty"))
+                # checking that for the current step (pick/pack/ship)
+                # move.product_uom_qty == step.cancelled_qty + move.returned_quanty
+                # If not the case, we have to move back goods in stock.
+                qty_to_return = qty_to_cancel - qty_canceled
+                if float_is_zero(qty_to_return, precision_rounding=rounding):
+                    continue
+                done_moves = origin_moves.filtered(lambda m: m.state == "done")
+                if not move.rule_id.allow_unrelease_return_done_move:
+                    # Without allow_unrelease_return_done_move enabled,
+                    # only moves that aren't done can be unreleased.
+                    msg_args = {
+                        "move_name": move.name,
+                        "done_move_names": ", ".join(done_moves.mapped("name")),
+                    }
+                    message = _(
+                        (
+                            "You cannot unrelease the move %(move_name)s "
+                            "because some origin moves %(done_move_names)s are done"
+                        ),
+                        **msg_args
+                    )
+                    raise UserError(message)
+                # Multiple pickings can satisfy a move
+                # -> len(move.move_orig_ids.picking_id) > 1
+                # Group done_moves per picking, and create returns
+                returnable_qty = done_moves._unrelease_set_returnable_qty_per_move(
+                    qty_to_return, qty_to_return_per_move
+                )
+                qty_returned_for_move += returnable_qty
+
+            moves_to_cancel_for_move._action_cancel()
             # restore the procure_method overwritten by _action_cancel()
             move.procure_method = procure_method
+        self._return_quantity_in_stock(qty_to_return_per_move)
         moves_to_unrelease.write({"need_release": True})
         for picking, moves in itertools.groupby(
             moves_to_unrelease, lambda m: m.picking_id
@@ -649,14 +780,15 @@ class StockMove(models.Model):
             picking.message_post(body=body)
             picking.last_release_date = False
 
-    def _split_origins(self, origins):
+    def _split_origins(self, origins, qty=None):
         """Split the origins of the move according to the quantity into the
         move and the quantity in the origin moves.
 
         Return the origins for the move's quantity.
         """
         self.ensure_one()
-        qty = self.product_qty
+        if not qty:
+            qty = self.product_qty
         # Unreserve goods before the split
         origins._do_unreserve()
         rounding = self.product_uom.rounding

--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -14,6 +14,10 @@ class StockRule(models.Model):
         related="route_id.available_to_promise_defer_pull", store=True
     )
 
+    allow_unrelease_return_done_move = fields.Boolean(
+        related="route_id.allow_unrelease_return_done_move", store=True
+    )
+
     no_backorder_at_release = fields.Boolean(
         related="route_id.no_backorder_at_release", store=True
     )

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -3,3 +3,4 @@ from . import test_unrelease
 from . import test_unrelease_2steps
 from . import test_unrelease_3steps
 from . import test_unrelease_merged_moves
+from . import test_unrelease_cancel

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -128,8 +128,18 @@ class PromiseReleaseCommonCase(common.SavepointCase):
         return pickings.filtered(lambda r: r.picking_type_code == "outgoing")
 
     @classmethod
-    def _deliver(cls, picking):
+    def _get_backorder_for_pickings(cls, pickings):
+        return cls.env["stock.picking"].search([("backorder_id", "in", pickings.ids)])
+
+    @classmethod
+    def _deliver(cls, picking, product_qty=None):
         picking.action_assign()
-        for line in picking.mapped("move_lines.move_line_ids"):
-            line.qty_done = line.product_uom_qty
+        if product_qty:
+            lines = picking.move_lines.move_line_ids
+            for product, qty in product_qty:
+                line = lines.filtered(lambda m: m.product_id == product)
+                line.qty_done = qty
+        else:
+            for line in picking.mapped("move_lines.move_line_ids"):
+                line.qty_done = line.product_uom_qty
         picking._action_done()

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel.py
@@ -1,0 +1,238 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from datetime import datetime
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.wh.delivery_steps = "pick_pack_ship"
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 50.0)
+        cls._update_qty_in_location(cls.loc_bin1, cls.product2, 50.0)
+
+        delivery_route = cls.wh.delivery_route_id
+        ship_rule = delivery_route.rule_ids.filtered(
+            lambda r: r.location_id == cls.loc_customer
+        )
+        cls.loc_output = ship_rule.location_src_id
+        pack_rule = delivery_route.rule_ids.filtered(
+            lambda r: r.location_id == cls.loc_output
+        )
+        cls.loc_pack = pack_rule.location_src_id
+        pick_rule = delivery_route.rule_ids.filtered(
+            lambda r: r.location_id == cls.loc_pack
+        )
+        cls.pick_type = pick_rule.picking_type_id
+        cls.pack_type = pack_rule.picking_type_id
+
+        cls.picking_chain = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 10)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.ship_picking = cls._out_picking(cls.picking_chain)
+        cls.pack_picking = cls._prev_picking(cls.ship_picking)
+        cls.pick_picking = cls._prev_picking(cls.pack_picking)
+
+        # Why is this not working when creating picking after enabling this setting?
+        delivery_route.write(
+            {
+                "available_to_promise_defer_pull": True,
+                "allow_unrelease_return_done_move": True,
+            }
+        )
+        cls.ship_picking.release_available_to_promise()
+        cls.cleanup_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Cancel Cleanup",
+                "default_location_dest_id": cls.loc_stock.id,
+                "sequence_code": "CCP",
+                "code": "internal",
+            }
+        )
+        cls.pick_type.return_picking_type_id = cls.cleanup_type
+        cls.pack_type.return_picking_type_id = cls.cleanup_type
+
+    @classmethod
+    def _get_cleanup_picking(cls):
+        return cls.env["stock.picking"].search(
+            [("picking_type_id", "=", cls.cleanup_type.id)]
+        )
+
+    def test_unrelease_picked(self):
+        # In this case, we should get 1 return picking from
+        # WH/PACK to WH/STOCK
+        self._deliver(self.pick_picking)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "cancel")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_picking = self._get_cleanup_picking()
+        self.assertEqual(len(cancel_picking), 1)
+        self.assertEqual(cancel_picking.location_id, self.loc_pack)
+        self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
+
+    def test_unrelease_packed(self):
+        # In this case, we should get 1 return picking from
+        # WH/OUT to WH/STOCK
+        self._deliver(self.pick_picking)
+        self._deliver(self.pack_picking)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "done")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_picking = self._get_cleanup_picking()
+        self.assertEqual(len(cancel_picking), 1)
+        self.assertEqual(cancel_picking.location_id, self.loc_output)
+        self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
+
+    def test_unrelease_picked_partial(self):
+        qty_picked = [(self.product1, 5.0)]
+        self._deliver(self.pick_picking, product_qty=qty_picked)
+        pick_backorder = self._get_backorder_for_pickings(self.pick_picking)
+        self.assertTrue(pick_backorder)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "cancel")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_picking = self._get_cleanup_picking()
+        # In the end, we cancelled 5 units for the pick backorder, and returned
+        # 5 units from pack -> stock
+        self.assertEqual(pick_backorder.state, "cancel")
+        self.assertEqual(cancel_picking.location_id, self.loc_pack)
+        self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
+        self.assertEqual(cancel_picking.move_lines.product_uom_qty, 5.0)
+
+    def test_unrelease_packed_partial(self):
+        self._deliver(self.pick_picking)
+        qty_packed = [(self.product1, 5.0)]
+        self._deliver(self.pack_picking, product_qty=qty_packed)
+        pack_backorder = self._get_backorder_for_pickings(self.pack_picking)
+        self.assertTrue(pack_backorder)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "done")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_pickings = self._get_cleanup_picking()
+        self.assertEqual(len(cancel_pickings), 2)
+        # In the end, we cancelled 5 units for the pack backorder, returned
+        # 5 units from pack -> stock, and 5 units from output -> stock
+        pack_cancel = cancel_pickings.filtered(lambda p: p.location_id == self.loc_pack)
+        ship_cancel = cancel_pickings.filtered(
+            lambda p: p.location_id == self.loc_output
+        )
+        self.assertEqual(pack_cancel.move_lines.product_uom_qty, 5.0)
+        self.assertEqual(ship_cancel.move_lines.product_uom_qty, 5.0)
+
+    @classmethod
+    def put_in_pack(cls, move):
+        # is it necessary to create stock moves?
+        move._action_assign()
+        pack = cls.env["stock.quant.package"].create({"name": move.name})
+        move.move_line_ids.result_package_id = pack
+        return pack
+
+    def test_unrelease_multiple_moves_same_product(self):
+        # Create a picking with twice the same move
+        product_qty = [
+            (self.product1, 20),
+        ]
+        picking_chain = self._create_picking_chain(self.wh, products=product_qty)
+        ship_picking = self._out_picking(picking_chain)
+        ship_picking.release_available_to_promise()
+        # Creating a second move. Both moves thave the same origin (pack.move_line)
+        self.env["stock.move"].create(ship_picking.move_lines._split(4))
+        pack_picking = self._prev_picking(ship_picking)
+        pick_picking = self._prev_picking(pack_picking)
+        self._deliver(pick_picking)
+        self._deliver(pack_picking)
+        ship_picking.unrelease()
+        cancel_pickings = self._get_cleanup_picking()
+        self.assertEqual(cancel_pickings.move_lines.product_qty, 20)
+
+    def test_unrelease_packed_multi(self):
+        # Pick and pack 2 pickings, unrelease both before shipping
+        # Both have same picking types, goods should be returned
+        # to stock in the same picking
+        ship_no_pack = self.ship_picking
+        pack_no_pack = self.pack_picking
+        pick_no_pack = self.pick_picking
+        # The new picking chain will have packages
+        product_qty = [(self.product1, 10), (self.product2, 10)]
+        picking_chain = self._create_picking_chain(self.wh, products=product_qty)
+        ship_with_pack = self._out_picking(picking_chain)
+        ship_with_pack.release_available_to_promise()
+        pack_with_pack = self._prev_picking(ship_with_pack)
+        pick_with_pack = self._prev_picking(pack_with_pack)
+        # Process pick pickings
+        self._deliver(pick_with_pack)
+        self._deliver(pick_no_pack)
+        # put pack moves in packages on pack_with_pack,
+        pack_moves = pack_with_pack.move_lines
+        pack_move1 = pack_moves.filtered(lambda m: m.product_id == self.product1)
+        pack_move2 = pack_moves.filtered(lambda m: m.product_id == self.product2)
+        self.put_in_pack(pack_move1)
+        self.put_in_pack(pack_move2)
+        # Process pack pickings
+        self._deliver(pack_with_pack)
+        self._deliver(pack_no_pack)
+        # unrelease both ship pickings at once
+        (ship_with_pack | ship_no_pack).unrelease()
+        cancel_pickings = self._get_cleanup_picking()
+        # We should have 1 return picking only
+        self.assertEqual(len(cancel_pickings), 1)
+        # We should have 3 moves
+        cancel_moves = cancel_pickings.move_lines
+        self.assertEqual(len(cancel_moves), 3)
+        # We should have:
+        # - 1 move for product1 without pack
+        # - 1 move for product1 with pack
+        # - 1 move for product2 with pack
+        cancel_move1_no_pack = cancel_moves.filtered(
+            lambda m: m.product_id == self.product1 and not m.move_line_ids.package_id
+        )
+        cancel_move1_with_pack = cancel_moves.filtered(
+            lambda m: m.product_id == self.product1 and m.move_line_ids.package_id
+        )
+        cancel_move2_with_pack = cancel_moves.filtered(
+            lambda m: m.product_id == self.product2 and m.move_line_ids.package_id
+        )
+        self.assertTrue(cancel_move1_no_pack)
+        self.assertEqual(cancel_move1_no_pack.product_qty, 10)
+        self.assertTrue(cancel_move1_with_pack)
+        self.assertEqual(cancel_move1_with_pack.product_qty, 10)
+        self.assertTrue(cancel_move2_with_pack)
+        self.assertEqual(cancel_move2_with_pack.product_qty, 10)
+
+    def test_return_quantity_in_stock(self):
+        move_model = self.env["stock.move"]
+        pack_move = self.pack_picking.move_lines
+        # process pick and pack, so pack is done and returnable
+        self._deliver(self.pick_picking)
+        self._deliver(self.pack_picking)
+        # Using empty_recordsets doesn't raises an exception and doesn't create
+        # a return picking
+        empty_args = {}
+        move_model._return_quantity_in_stock(empty_args)
+        self.assertFalse(self._get_cleanup_picking())
+        # Adding a move with no quantity
+        empty_args = {pack_move.id: 0}
+        move_model._return_quantity_in_stock(empty_args)
+        self.assertFalse(self._get_cleanup_picking())
+        # Adding a quantity should create a return picking
+        valid_args = {pack_move.id: 5}
+        move_model._return_quantity_in_stock(valid_args)
+        return_picking = self._get_cleanup_picking()
+        self.assertEqual(return_picking.move_lines.product_qty, 5)
+
+    def test_unrelease_shipped(self):
+        self._deliver(self.pick_picking)
+        self._deliver(self.pack_picking)
+        self._deliver(self.ship_picking)
+        self.ship_picking.unrelease()
+        # Did nothing
+        self.assertEqual(self.ship_picking.state, "done")
+        self.assertEqual(self.pack_picking.state, "done")
+        self.assertEqual(self.pick_picking.state, "done")

--- a/stock_available_to_promise_release/views/stock_location_route_views.xml
+++ b/stock_available_to_promise_release/views/stock_location_route_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group/field[@name='company_id']" position="after">
                 <field name="available_to_promise_defer_pull" />
+                <field name="allow_unrelease_return_done_move" />
                 <field name="no_backorder_at_release" />
             </xpath>
         </field>


### PR DESCRIPTION
This PR adds a new option on stock routes, allowing to unrelease a delivery even if some internal operations (e.g. pick) are already done, creating a return move to the stock location.