### PR TITLE
[IMP][14.0] shopfloor delivery: Better messages

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -216,6 +216,15 @@ class MessageAction(Component):
     def already_done(self):
         return {"message_type": "info", "body": _("Operation already processed.")}
 
+    def transfer_cancelled(self):
+        return {
+            "message_type": "info",
+            "body": _(
+                "Transfer has been cancelled. "
+                "This cannot be processed using this scenario"
+            ),
+        }
+
     def move_already_done(self):
         return {"message_type": "warning", "body": _("Move already processed.")}
 

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -961,3 +961,13 @@ class MessageAction(Component):
             "message_type": "error",
             "body": _("Unable to find a line with the same product but different lot."),
         }
+
+    def picking_type_is_return(self, picking):
+        body = _("Reserved for %(picking_type)s %(picking_name)s") % {
+            "picking_type": picking.picking_type_id.name,
+            "picking_name": picking.name,
+        }
+        return {
+            "message_type": "error",
+            "body": body,
+        }

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -400,7 +400,7 @@ class Checkout(Component):
           lines
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_manual_selection(message=message)
         return self._select_picking(picking, "manual_selection")
@@ -449,7 +449,7 @@ class Checkout(Component):
         screen to change the qty done and destination pack if needed
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -772,7 +772,7 @@ class Checkout(Component):
         assert package_id or move_line_id
 
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -791,7 +791,7 @@ class Checkout(Component):
         self, picking_id, selected_line_ids, move_line_ids, quantity_func
     ):
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1029,7 +1029,7 @@ class Checkout(Component):
         to close the stock picking
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1183,7 +1183,7 @@ class Checkout(Component):
         * select_package: when no delivery packaging is available
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1213,7 +1213,7 @@ class Checkout(Component):
         * select_line: goes back to selection of lines to work on next lines
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         packaging = None
@@ -1235,7 +1235,7 @@ class Checkout(Component):
         if self.options.get("checkout__disable_no_package"):
             raise BadRequest("`checkout.no_package` endpoint is not enabled")
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1267,7 +1267,7 @@ class Checkout(Component):
         * select_package: when no package is available
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1315,7 +1315,7 @@ class Checkout(Component):
         * summary: all lines are put in packages
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1342,7 +1342,7 @@ class Checkout(Component):
         * summary: all lines are put in packages
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1369,7 +1369,7 @@ class Checkout(Component):
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         return self._response_for_summary(picking)
@@ -1388,7 +1388,7 @@ class Checkout(Component):
         * summary: if the package_id no longer exists
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
@@ -1403,7 +1403,7 @@ class Checkout(Component):
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1440,7 +1440,7 @@ class Checkout(Component):
         * select_line: when package or line has been canceled
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1485,7 +1485,7 @@ class Checkout(Component):
         * select_child_location: there are child destination locations
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = picking.move_line_ids
@@ -1528,7 +1528,7 @@ class Checkout(Component):
         * select_child_location: in case of error
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         search = self._actions_for("search")

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -140,7 +140,7 @@ class Delivery(Component):
         barcode_valid = bool(picking)
 
         if picking:
-            message = self._check_picking_status(picking)
+            message = self._check_picking_processible(picking)
             if message:
                 return self._response_for_deliver(location=location, message=message)
 
@@ -235,6 +235,12 @@ class Delivery(Component):
         lines = package.move_line_ids.filtered(
             lambda l: l.state in ("assigned", "partially_available")
         )
+        if not lines:
+            return self._response_for_deliver(
+                picking=picking,
+                location=location,
+                message=self.msg_store.cannot_move_something_in_picking_type(),
+            )
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
@@ -247,12 +253,9 @@ class Delivery(Component):
                 ]
             )
             return self._response_for_deliver(location=location, message=message)
-        if not lines:
-            return self._response_for_deliver(
-                picking=picking,
-                location=location,
-                message=self.msg_store.cannot_move_something_in_picking_type(),
-            )
+        message = self._check_picking_type(lines.mapped("picking_id"))
+        if message:
+            return self._response_for_deliver(location=location, message=message)
         # TODO add a message if any of the lines already had a qty_done > 0
         new_picking = fields.first(lines.mapped("picking_id"))
         if self._set_lines_done(lines):
@@ -264,19 +267,7 @@ class Delivery(Component):
     def _lines_base_domain(self, no_qty_done=True):
         # we added auto_join for this, otherwise, the ORM would search all pickings
         # in the picking type, and then use IN (ids)
-        domain = [
-            # Accepting return_picking_types in order to display meaningful
-            # messages when trying to process a return move.
-            # Those returns are blocked later in `_check_picking_status`
-            "|",
-            ("picking_id.picking_type_id", "in", self.picking_types.ids),
-            (
-                "picking_id.picking_type_id",
-                "in",
-                self.picking_types.return_picking_type_id.ids,
-            ),
-            ("picking_id.state", "not in", ("done",)),
-        ]
+        domain = []
         if no_qty_done:
             domain.append(("qty_done", "=", 0))
         return domain
@@ -313,6 +304,16 @@ class Delivery(Component):
         )
         if location:
             domain.extend([("location_id", "=", location.id)])
+        else:
+            domain.extend(
+                [
+                    (
+                        "location_id",
+                        "child_of",
+                        self.picking_types.default_location_src_id.ids,
+                    )
+                ]
+            )
         if product_qty:
             domain.extend(
                 [
@@ -367,6 +368,12 @@ class Delivery(Component):
                 message=self.msg_store.product_in_multiple_sublocation(product),
             )
 
+        message = self._check_picking_type(lines.mapped("picking_id"))
+        if message:
+            return self._response_for_deliver(location=location, message=message)
+        lines = lines.filtered(
+            lambda l: l.move_id.picking_type_id in self.picking_types
+        )
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
@@ -429,15 +436,14 @@ class Delivery(Component):
         return self._response_for_deliver(new_picking, location=location)
 
     def _deliver_lot(self, picking, lot, product_qty=None, location=None):
-        lines = self.env["stock.move.line"].search(
-            self._lines_from_lot_domain(
-                lot,
-                no_qty_done=False,
-                product_qty=product_qty,
-                location=location,
-                picking=picking,
-            )
+        domain = self._lines_from_lot_domain(
+            lot,
+            no_qty_done=False,
+            product_qty=product_qty,
+            location=location,
+            picking=picking,
         )
+        lines = self.env["stock.move.line"].search(domain)
         if not lines:
             return self._response_for_deliver(
                 picking,
@@ -455,6 +461,9 @@ class Delivery(Component):
                 message=self.msg_store.lot_in_multiple_sublocation(lot),
             )
 
+        message = self._check_picking_type(lines.mapped("picking_id"))
+        if message:
+            return self._response_for_deliver(location=location, message=message)
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
@@ -565,7 +574,7 @@ class Delivery(Component):
         * deliver: with information about the stock.picking
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self.list_stock_picking(message=message)
         if picking:
@@ -582,7 +591,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
@@ -607,7 +616,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         line = self.env["stock.move.line"].browse(move_line_id).exists()
@@ -634,7 +643,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
@@ -667,7 +676,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         line = self.env["stock.move.line"].browse(move_line_id).exists()
@@ -697,7 +706,7 @@ class Delivery(Component):
         * confirm_done: when not all lines of the stock.picking are done
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         if self._action_picking_done(picking):

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -147,47 +147,54 @@ class Delivery(Component):
         if picking_id:
             picking = self.env["stock.picking"].browse(picking_id)
 
-        # Validate picking anyway
         if not barcode_valid:
-            package = search.package_from_scan(barcode)
-            if package:
-                return self._deliver_package(picking, package, location)
+            handlers_by_type = {
+                "package": self._scan_deliver__by_package,
+                "product": self._scan_deliver__by_product,
+                "packaging": self._scan_deliver__by_packaging,
+                "lot": self._scan_deliver__by_lot,
+                "location": self._scan_deliver__by_location,
+            }
+            search_result = search.find(barcode, handlers_by_type.keys())
+            handler = handlers_by_type.get(search_result.type)
+            if handler:
+                result = handler(search_result.record, picking, location)
+                if result:
+                    return result
+        return self._scan_deliver__fallback(picking, location, barcode_valid)
 
-        if not barcode_valid:
-            product = search.product_from_scan(barcode)
-            if product:
-                return self._deliver_product(
-                    picking, product, product_qty=1, location=location
-                )
+    def _scan_deliver__by_package(self, package, picking, location):
+        return self._deliver_package(picking, package, location)
 
-        if not barcode_valid:
-            packaging = search.packaging_from_scan(barcode)
-            if packaging:
-                # By scanning a packaging, we want to process
-                # the full quantity of the packaging
-                packaging_qty = packaging.product_uom_id._compute_quantity(
-                    packaging.qty, packaging.product_id.uom_id
-                )
-                return self._deliver_product(
-                    picking,
-                    packaging.product_id,
-                    product_qty=packaging_qty,
-                    location=location,
-                )
+    def _scan_deliver__by_product(self, product, picking, location):
+        return self._deliver_product(picking, product, product_qty=1, location=location)
 
-        if not barcode_valid:
-            lot = search.lot_from_scan(barcode)
-            if lot:
-                return self._deliver_lot(picking, lot, product_qty=1, location=location)
+    def _scan_deliver__by_packaging(self, packaging, picking, location):
+        # By scanning a packaging, we want to process
+        # the full quantity of the packaging
+        packaging_qty = packaging.product_uom_id._compute_quantity(
+            packaging.qty, packaging.product_id.uom_id
+        )
+        return self._deliver_product(
+            picking,
+            packaging.product_id,
+            product_qty=packaging_qty,
+            location=location,
+        )
 
-        if not barcode_valid:
-            sublocation = search.location_from_scan(barcode)
-            if sublocation and sublocation.is_sublocation_of(
-                self.picking_types.mapped("default_location_src_id")
-            ):
-                message = self.msg_store.location_src_set_to_sublocation(sublocation)
-                return self._response_for_deliver(location=sublocation, message=message)
+    def _scan_deliver__by_lot(self, lot, picking, location):
+        return self._deliver_lot(picking, lot, product_qty=1, location=location)
 
+    def _scan_deliver__by_location(self, scanned_location, picking, location):
+        if scanned_location.is_sublocation_of(
+            self.picking_types.mapped("default_location_src_id")
+        ):
+            message = self.msg_store.location_src_set_to_sublocation(scanned_location)
+            return self._response_for_deliver(
+                location=scanned_location, message=message
+            )
+
+    def _scan_deliver__fallback(self, picking, location, barcode_valid):
         message = self.msg_store.barcode_not_found() if not barcode_valid else None
         return self._response_for_deliver(
             picking=picking, location=location, message=message

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -255,11 +255,20 @@ class Delivery(Component):
         return self._response_for_deliver(picking=new_picking, location=location)
 
     def _lines_base_domain(self, no_qty_done=True):
+        # we added auto_join for this, otherwise, the ORM would search all pickings
+        # in the picking type, and then use IN (ids)
         domain = [
-            # we added auto_join for this, otherwise, the ORM would search all pickings
-            # in the picking type, and then use IN (ids)
+            # Accepting return_picking_types in order to display meaningful
+            # messages when trying to process a return move.
+            # Those returns are blocked later in `_check_picking_status`
+            "|",
             ("picking_id.picking_type_id", "in", self.picking_types.ids),
-            ("picking_id.state", "not in", ("done", "cancel")),
+            (
+                "picking_id.picking_type_id",
+                "in",
+                self.picking_types.return_picking_type_id.ids,
+            ),
+            ("picking_id.state", "not in", ("done",)),
         ]
         if no_qty_done:
             domain.append(("qty_done", "=", 0))

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -2,7 +2,7 @@
 # Copyright 2020 Akretion (http://www.akretion.com)
 # Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import _, exceptions
+from odoo import _, exceptions, fields
 
 from odoo.addons.component.core import AbstractComponent
 
@@ -46,25 +46,34 @@ class BaseShopfloorProcess(AbstractComponent):
         # every time.
         return self._actions_for("search_move_line", picking_types=self.picking_types)
 
-    def _check_picking_status(self, pickings, states=("assigned",)):
-        """Check if given pickings can be processed.
+    def _check_picking_type(self, pickings):
+        """Check if the pickings have the right expected type."""
+        if not any(
+            picking.picking_type_id in self.picking_types for picking in pickings
+        ):
+            return self.msg_store.picking_type_is_return(fields.first(pickings))
 
-        If the picking is already done, canceled or didn't belong to the
-        expected picking type, a message is returned.
-        """
-        for picking in pickings:
-            if not picking.exists():
-                return self.msg_store.stock_picking_not_found()
-            if picking.state == "done":
-                return self.msg_store.already_done()
-            if picking.state == "cancel":
-                return self.msg_store.transfer_cancelled()
-            if picking.state not in states:  # the picking must be ready
-                return self.msg_store.stock_picking_not_available(picking)
-            if picking.picking_type_id in self.picking_types.return_picking_type_id:
-                return self.msg_store.picking_type_is_return()
-            if picking.picking_type_id not in self.picking_types:
-                return self.msg_store.cannot_move_something_in_picking_type()
+    def _check_picking_status(self, pickings, states=("assigned",)):
+        """Checks if the picking exists, is already done or canceled."""
+        if not pickings.exists():
+            return self.msg_store.stock_picking_not_found()
+        if not any(picking.state != "done" for picking in pickings):
+            return self.msg_store.already_done()
+        if not any(picking.state != "cancel" for picking in pickings):
+            return self.msg_store.transfer_cancelled()
+        if not any(
+            picking.state in states for picking in pickings
+        ):  # the picking must be ready
+            return self.msg_store.stock_picking_not_available(fields.first(pickings))
+
+    def _check_picking_processible(self, pickings, states=("assigned",)):
+        """Check if given pickings can be processed"""
+        message = self._check_picking_status(pickings, states=states)
+        if message:
+            return message
+        message = self._check_picking_type(pickings)
+        if message:
+            return message
 
     def is_src_location_valid(self, location):
         """Check the source location is valid for given process.

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -61,6 +61,8 @@ class BaseShopfloorProcess(AbstractComponent):
                 return self.msg_store.transfer_cancelled()
             if picking.state not in states:  # the picking must be ready
                 return self.msg_store.stock_picking_not_available(picking)
+            if picking.picking_type_id in self.picking_types.return_picking_type_id:
+                return self.msg_store.picking_type_is_return()
             if picking.picking_type_id not in self.picking_types:
                 return self.msg_store.cannot_move_something_in_picking_type()
 

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -57,6 +57,8 @@ class BaseShopfloorProcess(AbstractComponent):
                 return self.msg_store.stock_picking_not_found()
             if picking.state == "done":
                 return self.msg_store.already_done()
+            if picking.state == "cancel":
+                return self.msg_store.transfer_cancelled()
             if picking.state not in states:  # the picking must be ready
                 return self.msg_store.stock_picking_not_available(picking)
             if picking.picking_type_id not in self.picking_types:

--- a/shopfloor/tests/test_checkout_select.py
+++ b/shopfloor/tests/test_checkout_select.py
@@ -66,7 +66,9 @@ class CheckoutSelectCase(CheckoutCommonCase):
         )
 
     def test_select_error_not_allowed(self):
+        # Trying to pick a picking with wrong picking type
         picking = self._create_picking(picking_type=self.wh.pick_type_id)
         self._fill_stock_for_moves(picking.move_lines, in_package=True)
         picking.action_assign()
-        self._test_error(picking, "You cannot move this using this menu.")
+        expected_message = f"Reserved for {picking.picking_type_id.name} {picking.name}"
+        self._test_error(picking, expected_message)

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -10,6 +10,21 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
     @classmethod
     def setUpClassBaseData(cls):
         super().setUpClassBaseData()
+        cls.out_location = cls.env.ref("stock.stock_location_output")
+        cls.cleanup_type = (
+            cls.env["stock.picking.type"]
+            .sudo()
+            .create(
+                {
+                    "name": "Cancel Cleanup",
+                    "default_location_src_id": cls.out_location.id,
+                    "default_location_dest_id": cls.stock_location.id,
+                    "sequence_code": "CCP",
+                    "code": "internal",
+                }
+            )
+        )
+        cls.picking_type.sudo().return_picking_type_id = cls.cleanup_type
         cls.product_e.tracking = "lot"
         cls.picking = picking = cls._create_picking(
             lines=[
@@ -452,6 +467,102 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         self.assert_response_deliver(
             response,
             message=self.service.msg_store.transfer_cancelled(),
+        )
+
+    def test_scan_deliver_return_package(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)]
+        )
+        package_vals = [(self.product_a, 1, None)]
+        cleanup_package = self._create_package_in_location(
+            cleanup_picking.location_id, package_vals
+        )
+        cleanup_package.name = "CLEANUP_PACKAGE"
+        cleanup_picking.action_assign()
+        cleanup_picking.move_line_ids.package_id = cleanup_package
+        params = {"barcode": "CLEANUP_PACKAGE"}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_deliver_return_product(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)]
+        )
+        cleanup_picking.action_assign()
+        params = {"barcode": self.product_a.barcode}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_deliver_return_packaging(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)],
+        )
+        cleanup_picking.action_assign()
+        packaging = (
+            self.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "CLEANUP PACKAGING",
+                    "product_id": self.product_a.id,
+                    "qty": 1,
+                    "product_uom_id": self.product_a.id,
+                    "barcode": "CLEANUP_PACKAGING",
+                }
+            )
+        )
+        params = {"barcode": "CLEANUP_PACKAGING"}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_deliver_return_lot(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)]
+        )
+        # Create move lines and set lot
+        cleanup_picking.action_assign()
+        cleanup_lot = self.env["stock.production.lot"].create(
+            {
+                "product_id": self.product_a.id,
+                "company_id": self.env.company.id,
+                "name": "CLEANUP_LOT",
+                "ref": "CLEANUP_LOT",
+            }
+        )
+        # Re-force qty to 1, as setting the lot resets qty to 0
+        cleanup_picking.move_line_ids.lot_id = cleanup_lot
+        cleanup_picking.move_line_ids.product_uom_qty = 1.0
+        params = {"barcode": "CLEANUP_LOT"}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_delivery_return_picking(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_c, 1)]
+        )
+        cleanup_picking.action_assign()
+        params = {"barcode": cleanup_picking.name}
+        response = self.service.dispatch("scan_deliver", params=params)
+        self.assert_response_deliver(
+            response,
+            message=self.service.msg_store.picking_type_is_return(cleanup_picking),
         )
 
     def test_scan_deliver_picking_done(self):

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -445,6 +445,15 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         move_lines = pick.move_lines.mapped("move_line_ids")
         self._test_scan_set_done_ok(move_lines, self.product_c.barcode, [1])
 
+    def test_scan_deliver_picking_cancelled(self):
+        self.picking.action_cancel()
+        params = {"barcode": self.picking.name}
+        response = self.service.dispatch("scan_deliver", params=params)
+        self.assert_response_deliver(
+            response,
+            message=self.service.msg_store.transfer_cancelled(),
+        )
+
     def test_scan_deliver_picking_done(self):
         # Set qty done for all lines (packages/raw product/lot...), picking is
         # automatically set to done when the last line is completed

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -483,9 +483,9 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.move_line_ids.package_id = cleanup_package
         params = {"barcode": "CLEANUP_PACKAGE"}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_deliver_return_product(self):
@@ -496,35 +496,34 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.action_assign()
         params = {"barcode": self.product_a.barcode}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_deliver_return_packaging(self):
         self.picking.action_cancel()
         cleanup_picking = self._create_picking(
-            picking_type=self.cleanup_type, lines=[(self.product_a, 1)],
+            picking_type=self.cleanup_type,
+            lines=[(self.product_a, 1)],
         )
         cleanup_picking.action_assign()
-        packaging = (
-            self.env["product.packaging"]
-            .sudo()
-            .create(
-                {
-                    "name": "CLEANUP PACKAGING",
-                    "product_id": self.product_a.id,
-                    "qty": 1,
-                    "product_uom_id": self.product_a.id,
-                    "barcode": "CLEANUP_PACKAGING",
-                }
-            )
+
+        packaging_model = self.env["product.packaging"].sudo()
+        packaging_model.create(
+            {
+                "name": "CLEANUP PACKAGING",
+                "product_id": self.product_a.id,
+                "qty": 1,
+                "product_uom_id": self.product_a.id,
+                "barcode": "CLEANUP_PACKAGING",
+            }
         )
         params = {"barcode": "CLEANUP_PACKAGING"}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_deliver_return_lot(self):
@@ -547,9 +546,9 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.move_line_ids.product_uom_qty = 1.0
         params = {"barcode": "CLEANUP_LOT"}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_delivery_return_picking(self):
@@ -643,7 +642,7 @@ class DeliveryScanDeliverSpecialCase(DeliveryCommonCase):
             response,
             message={
                 "message_type": "error",
-                "body": "You cannot move this using this menu.",
+                "body": f"Reserved for {picking.picking_type_id.name} {picking.name}",
             },
         )
 

--- a/shopfloor/tests/test_delivery_set_qty_done_line.py
+++ b/shopfloor/tests/test_delivery_set_qty_done_line.py
@@ -50,7 +50,7 @@ class DeliverySetQtyDoneLineCase(DeliveryCommonCase):
         )
         self.assert_response_deliver(
             response,
-            message=self.service.msg_store.stock_picking_not_available(self.picking),
+            message=self.service.msg_store.transfer_cancelled(),
         )
 
     def test_set_qty_done_line_line_not_found(self):

--- a/shopfloor/tests/test_delivery_set_qty_done_pack.py
+++ b/shopfloor/tests/test_delivery_set_qty_done_pack.py
@@ -65,7 +65,7 @@ class DeliverySetQtyDonePackCase(DeliveryCommonCase):
         )
         self.assert_response_deliver(
             response,
-            message=self.service.msg_store.stock_picking_not_available(self.picking),
+            message=self.service.msg_store.transfer_cancelled(),
         )
 
     def test_set_qty_done_pack_package_not_found(self):

--- a/shopfloor_checkout_package_measurement/services/checkout.py
+++ b/shopfloor_checkout_package_measurement/services/checkout.py
@@ -38,7 +38,7 @@ class Checkout(Component):
     ):
         """Set measurements on a package."""
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()

--- a/shopfloor_delivery_shipment/services/delivery_shipment.py
+++ b/shopfloor_delivery_shipment/services/delivery_shipment.py
@@ -117,7 +117,7 @@ class DeliveryShipment(Component):
                 return self._response_for_scan_document(
                     shipment_advice, message=self.msg_store.stock_picking_not_found()
                 )
-            message = self._check_picking_status(picking, shipment_advice)
+            message = self._check_picking_processible(picking, shipment_advice)
             if message:
                 return self._response_for_scan_document(
                     shipment_advice, message=message
@@ -181,7 +181,7 @@ class DeliveryShipment(Component):
         If the shipment advice had planned content and that the scanned delivery
         is not part of it, returns an error message.
         """
-        message = self._check_picking_status(picking, shipment_advice)
+        message = self._check_picking_processible(picking, shipment_advice)
         if message:
             return self._response_for_scan_document(shipment_advice, message=message)
         else:
@@ -208,7 +208,9 @@ class DeliveryShipment(Component):
         )
         if move_lines:
             # Check transfer status
-            message = self._check_picking_status(move_lines.picking_id, shipment_advice)
+            message = self._check_picking_processible(
+                move_lines.picking_id, shipment_advice
+            )
             if message:
                 return self._response_for_scan_document(
                     shipment_advice,
@@ -262,7 +264,9 @@ class DeliveryShipment(Component):
         )
         if move_lines:
             # Check transfer status
-            message = self._check_picking_status(move_lines.picking_id, shipment_advice)
+            message = self._check_picking_processible(
+                move_lines.picking_id, shipment_advice
+            )
             if message:
                 return self._response_for_scan_document(
                     shipment_advice, location=location, message=message
@@ -327,7 +331,9 @@ class DeliveryShipment(Component):
         )
         if move_lines:
             # Check transfer status
-            message = self._check_picking_status(move_lines.picking_id, shipment_advice)
+            message = self._check_picking_processible(
+                move_lines.picking_id, shipment_advice
+            )
             if message:
                 return self._response_for_scan_document(
                     shipment_advice, message=message
@@ -841,9 +847,9 @@ class DeliveryShipment(Component):
             )
         return pickings_not_loaded
 
-    def _check_picking_status(self, pickings, shipment_advice):
+    def _check_picking_processible(self, pickings, shipment_advice):
         # Overloaded to add checks against a shipment advice
-        message = super()._check_picking_status(pickings)
+        message = super()._check_picking_processible(pickings)
         if message:
             return message
         for picking in pickings:

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -48,13 +48,13 @@ class Reception(Component):
     _usage = "reception"
     _description = __doc__
 
-    def _check_picking_status(self, pickings):
+    def _check_picking_processible(self, pickings):
         # When returns are allowed,
         # the created picking might be empty and cannot be assigned.
         states = ["assigned"]
         if self.work.menu.allow_return:
             states.append("draft")
-        return super()._check_picking_status(pickings, states=states)
+        return super()._check_picking_processible(pickings, states=states)
 
     def _move_line_by_product(self, product):
         return self.env["stock.move.line"].search(
@@ -328,7 +328,7 @@ class Reception(Component):
                 message=self.msg_store.cannot_move_something_in_picking_type()
             )
         if reception_pickings:
-            message = self._check_picking_status(reception_pickings)
+            message = self._check_picking_processible(reception_pickings)
             if message:
                 return self._response_for_select_document(
                     pickings=reception_pickings, message=message
@@ -939,7 +939,7 @@ class Reception(Component):
           - set_quantity: Packaging / Product has been scanned. Not tracked product
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_move(picking, message=message)
         handlers_by_type = {
@@ -973,7 +973,7 @@ class Reception(Component):
           - select_document: Mark as done
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_move(picking, message=message)
         if all(line.qty_done == 0 for line in picking.move_line_ids):
@@ -1029,7 +1029,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_lot(picking, selected_line, message=message)
         if not selected_line.exists():
@@ -1060,7 +1060,7 @@ class Reception(Component):
 
     def set_lot_confirm_action(self, picking_id, selected_line_id):
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
         if message:
             return self._response_for_set_lot(picking, selected_line, message=message)
@@ -1145,7 +1145,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1174,7 +1174,7 @@ class Reception(Component):
     def set_quantity__cancel_action(self, picking_id, selected_line_id):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1212,7 +1212,7 @@ class Reception(Component):
     def process_with_existing_pack(self, picking_id, selected_line_id, quantity):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1227,7 +1227,7 @@ class Reception(Component):
     def process_with_new_pack(self, picking_id, selected_line_id, quantity):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1243,7 +1243,7 @@ class Reception(Component):
     def process_without_pack(self, picking_id, selected_line_id, quantity):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1337,7 +1337,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_destination(
                 picking, selected_line, message=message
@@ -1399,7 +1399,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_dest_package(
                 picking, selected_line, message=message

--- a/stock_available_to_promise_release/models/stock_location_route.py
+++ b/stock_available_to_promise_release/models/stock_location_route.py
@@ -7,6 +7,16 @@ from odoo import fields, models
 class Route(models.Model):
     _inherit = "stock.location.route"
 
+    allow_unrelease_return_done_move = fields.Boolean(
+        string="Reverse done transfer on cancellation",
+        default=False,
+        help=(
+            "If checked, unreleasing the delivery may create a new inverse "
+            "internal operation on the last done pulled transfer. "
+            "Otherwise, you won't be able to unrelease as soon as one of "
+            "the pulled transfer is done"
+        ),
+    )
     available_to_promise_defer_pull = fields.Boolean(
         string="Release based on Available to Promise",
         default=False,

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -9,7 +9,7 @@ import operator as py_operator
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.osv import expression
-from odoo.tools import date_utils, float_compare, float_round, groupby
+from odoo.tools import date_utils, float_compare, float_is_zero, float_round, groupby
 
 _logger = logging.getLogger(__name__)
 
@@ -100,8 +100,14 @@ class StockMove(models.Model):
             # The picking is printed, we can't unrelease the move
             # because the processing of the origin moves is started.
             return False
+        # If allow_unrelease_on_cancel is not checked, only release assigned/waiting
+        # moves. If checked, also unrelease done moves.
+        if self.rule_id.allow_unrelease_return_done_move:
+            unreleasable_states = ("cancel",)
+        else:
+            unreleasable_states = ("done", "cancel")
         origin_moves = origin_moves.filtered(
-            lambda m: m.state not in ("done", "cancel")
+            lambda m: m.state not in unreleasable_states
         )
         origin_qty_todo = sum(origin_moves.mapped("product_qty"))
         return (
@@ -591,6 +597,39 @@ class StockMove(models.Model):
             yield moves
             moves = moves.mapped(chain_field)
 
+    def _return_quantity_in_stock(self, quantity_to_return):
+        picking = self.picking_id
+        picking.ensure_one()
+
+        returned_quantity = 0
+        # create return
+        return_type = picking.picking_type_id.return_picking_type_id
+        wiz_values = {
+            "picking_id": picking.id,
+            "original_location_id": picking.location_dest_id.id,
+            "location_id": return_type.default_location_dest_id.id,
+        }
+        product_return_moves = []
+        for move in self:
+            if not move.state == "done":
+                continue
+            move_qty = min(quantity_to_return - returned_quantity, move.quantity_done)
+            return_move_vals = {
+                "product_id": move.product_id.id,
+                "quantity": move_qty,
+                "uom_id": move.product_id.uom_id.id,
+                "move_id": move.id,
+            }
+            product_return_moves.append((0, 0, return_move_vals))
+            returned_quantity += move_qty
+            if returned_quantity == quantity_to_return:
+                break
+        if product_return_moves:
+            wiz_values["product_return_moves"] = product_return_moves
+            return_wiz = self.env["stock.return.picking"].create(wiz_values)
+            return_wiz.create_returns()
+        return returned_quantity
+
     def unrelease(self, safe_unrelease=False):
         """Unrelease unreleasavbe moves
 
@@ -605,24 +644,66 @@ class StockMove(models.Model):
         impacted_picking_ids = set()
 
         for move in moves_to_unrelease:
+            rounding = move.product_id.uom_id.rounding
+            # When a move is returned, it is going straight to WH/Stock,
+            # skipping all intermediate zones (pick/pack).
+            # That is why we need to keep track of qty returned along the way.
+            # We do not want to return the same goods at each step.
+            # At a given step (pick/pack/ship), qty to return is
+            # move.product_uom_qty - cancelled_qty_at_step - already returned qties
+            qty_to_unrelease = move.product_qty
+            qty_returned_for_move = 0
             iterator = move._get_chained_moves_iterator("move_orig_ids")
-            moves_to_cancel = self.env["stock.move"]
+            moves_to_cancel_for_move = self.env["stock.move"]
             # backup procure_method as when you don't propagate cancel, the
             # destination move is forced to make_to_stock
             procure_method = move.procure_method
             next(iterator)  # skip the current move
             for origin_moves in iterator:
+                done_moves = origin_moves.filtered(lambda m: m.state == "done")
                 origin_moves = origin_moves.filtered(
                     lambda m: m.state not in ("done", "cancel")
                 )
+                qty_cancelled_at_step = 0
                 if origin_moves:
-                    origin_moves = move._split_origins(origin_moves)
-                    impacted_picking_ids.update(origin_moves.mapped("picking_id").ids)
+                    qty_to_split = qty_to_unrelease - qty_returned_for_move
+                    # TODO find new name
+                    moves_to_cancel = move._split_origins(
+                        origin_moves, qty=qty_to_split
+                    )
+                    impacted_picking_ids.update(
+                        moves_to_cancel.mapped("picking_id").ids
+                    )
                     # avoid to propagate cancel to the original move
-                    origin_moves.write({"propagate_cancel": False})
+                    moves_to_cancel.write({"propagate_cancel": False})
                     # origin_moves._action_cancel()
-                    moves_to_cancel |= origin_moves
-            moves_to_cancel._action_cancel()
+                    moves_to_cancel_for_move |= moves_to_cancel
+                    qty_cancelled_at_step = sum(moves_to_cancel.mapped("product_qty"))
+                # checking that for the current step (pick/pack/ship)
+                # move.product_uom_qty == step.cancelled_qty + move.returned_quanty
+                # If not the case, we have to move back goods in stock.
+                qty_to_return_at_step = (
+                    qty_to_unrelease - qty_cancelled_at_step - qty_returned_for_move
+                )
+                if float_is_zero(qty_to_return_at_step, precision_rounding=rounding):
+                    continue
+                # Multiple pickings can satisfy a move
+                # -> len(move.move_orig_ids.picking_id) > 1
+                # Group done_moves per picking, and create returns
+                groups_iterator = groupby(done_moves, key=lambda m: m.picking_id)
+                for __, moves_list in groups_iterator:
+                    moves_to_return = self.browse([move.id for move in moves_list])
+                    returned_qty = moves_to_return._return_quantity_in_stock(
+                        qty_to_return_at_step
+                    )
+                    qty_returned_for_move += returned_qty
+                    qty_to_return_at_step -= returned_qty
+                    if float_is_zero(
+                        qty_to_return_at_step, precision_rounding=rounding
+                    ):
+                        break
+
+            moves_to_cancel_for_move._action_cancel()
             # restore the procure_method overwritten by _action_cancel()
             move.procure_method = procure_method
         moves_to_unrelease.write({"need_release": True})
@@ -637,14 +718,15 @@ class StockMove(models.Model):
             picking.message_post(body=body)
             picking.last_release_date = False
 
-    def _split_origins(self, origins):
+    def _split_origins(self, origins, qty=None):
         """Split the origins of the move according to the quantity into the
         move and the quantity in the origin moves.
 
         Return the origins for the move's quantity.
         """
         self.ensure_one()
-        qty = self.product_qty
+        if not qty:
+            qty = self.product_qty
         # Unreserve goods before the split
         origins._do_unreserve()
         rounding = self.product_uom.rounding

--- a/stock_available_to_promise_release/models/stock_rule.py
+++ b/stock_available_to_promise_release/models/stock_rule.py
@@ -14,6 +14,10 @@ class StockRule(models.Model):
         related="route_id.available_to_promise_defer_pull", store=True
     )
 
+    allow_unrelease_return_done_move = fields.Boolean(
+        related="route_id.allow_unrelease_return_done_move", store=True
+    )
+
     no_backorder_at_release = fields.Boolean(
         related="route_id.no_backorder_at_release", store=True
     )

--- a/stock_available_to_promise_release/tests/common.py
+++ b/stock_available_to_promise_release/tests/common.py
@@ -128,8 +128,18 @@ class PromiseReleaseCommonCase(common.SavepointCase):
         return pickings.filtered(lambda r: r.picking_type_code == "outgoing")
 
     @classmethod
-    def _deliver(cls, picking):
+    def _get_backorder_for_pickings(cls, pickings):
+        return cls.env["stock.picking"].search([("backorder_id", "in", pickings.ids)])
+
+    @classmethod
+    def _deliver(cls, picking, product_qty=None):
         picking.action_assign()
-        for line in picking.mapped("move_lines.move_line_ids"):
-            line.qty_done = line.product_uom_qty
+        if product_qty:
+            lines = picking.move_lines.move_line_ids
+            for product, qty in product_qty:
+                line = lines.filtered(lambda m: m.product_id == product)
+                line.qty_done = qty
+        else:
+            for line in picking.mapped("move_lines.move_line_ids"):
+                line.qty_done = line.product_uom_qty
         picking._action_done()

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel.py
@@ -1,0 +1,136 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from datetime import datetime
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.wh.delivery_steps = "pick_pack_ship"
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 15.0)
+
+        delivery_route = cls.wh.delivery_route_id
+        ship_rule = delivery_route.rule_ids.filtered(
+            lambda r: r.location_id == cls.loc_customer
+        )
+        cls.loc_output = ship_rule.location_src_id
+        pack_rule = delivery_route.rule_ids.filtered(
+            lambda r: r.location_id == cls.loc_output
+        )
+        cls.loc_pack = pack_rule.location_src_id
+        pick_rule = delivery_route.rule_ids.filtered(
+            lambda r: r.location_id == cls.loc_pack
+        )
+        cls.pick_type = pick_rule.picking_type_id
+        cls.pack_type = pack_rule.picking_type_id
+
+        cls.picking_chain = cls._create_picking_chain(
+            cls.wh, [(cls.product1, 10)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        cls.ship_picking = cls._out_picking(cls.picking_chain)
+        cls.pack_picking = cls._prev_picking(cls.ship_picking)
+        cls.pick_picking = cls._prev_picking(cls.pack_picking)
+
+        # Why is this not working when creating picking after enabling this setting?
+        delivery_route.write(
+            {
+                "available_to_promise_defer_pull": True,
+                "allow_unrelease_return_done_move": True,
+            }
+        )
+        cls.ship_picking.release_available_to_promise()
+        cls.cleanup_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Cancel Cleanup",
+                "default_location_dest_id": cls.loc_stock.id,
+                "sequence_code": "CCP",
+                "code": "internal",
+            }
+        )
+        cls.pick_type.return_picking_type_id = cls.cleanup_type
+        cls.pack_type.return_picking_type_id = cls.cleanup_type
+
+    @classmethod
+    def _get_cleanup_picking(cls):
+        return cls.env["stock.picking"].search(
+            [("picking_type_id", "=", cls.cleanup_type.id)]
+        )
+
+    def test_unrelease_picked(self):
+        # In this case, we should get 1 return picking from
+        # WH/PACK to WH/STOCK
+        self._deliver(self.pick_picking)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "cancel")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_picking = self._get_cleanup_picking()
+        self.assertEqual(len(cancel_picking), 1)
+        self.assertEqual(cancel_picking.location_id, self.loc_pack)
+        self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
+
+    def test_unrelease_packed(self):
+        # In this case, we should get 1 return picking from
+        # WH/OUT to WH/STOCK
+        self._deliver(self.pick_picking)
+        self._deliver(self.pack_picking)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "done")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_picking = self._get_cleanup_picking()
+        self.assertEqual(len(cancel_picking), 1)
+        self.assertEqual(cancel_picking.location_id, self.loc_output)
+        self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
+
+    def test_unrelease_picked_partial(self):
+        qty_picked = [(self.product1, 5.0)]
+        self._deliver(self.pick_picking, product_qty=qty_picked)
+        pick_backorder = self._get_backorder_for_pickings(self.pick_picking)
+        self.assertTrue(pick_backorder)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "cancel")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_picking = self._get_cleanup_picking()
+        # In the end, we cancelled 5 units for the pick backorder, and returned
+        # 5 units from pack -> stock
+        self.assertEqual(pick_backorder.state, "cancel")
+        self.assertEqual(cancel_picking.location_id, self.loc_pack)
+        self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
+        self.assertEqual(cancel_picking.move_lines.product_uom_qty, 5.0)
+
+    def test_unrelease_packed_partial(self):
+        self._deliver(self.pick_picking)
+        qty_packed = [(self.product1, 5.0)]
+        self._deliver(self.pack_picking, product_qty=qty_packed)
+        pack_backorder = self._get_backorder_for_pickings(self.pack_picking)
+        self.assertTrue(pack_backorder)
+        self.ship_picking.unrelease()
+        self.assertTrue(self.ship_picking.need_release)
+        self.assertEqual(self.pack_picking.state, "done")
+        self.assertEqual(self.pick_picking.state, "done")
+        cancel_pickings = self._get_cleanup_picking()
+        self.assertEqual(len(cancel_pickings), 2)
+        # In the end, we cancelled 5 units for the pack backorder, returned
+        # 5 units from pack -> stock, and 5 units from output -> stock
+        pack_cancel = cancel_pickings.filtered(lambda p: p.location_id == self.loc_pack)
+        ship_cancel = cancel_pickings.filtered(
+            lambda p: p.location_id == self.loc_output
+        )
+        self.assertEqual(pack_cancel.move_lines.product_uom_qty, 5.0)
+        self.assertEqual(ship_cancel.move_lines.product_uom_qty, 5.0)
+
+    def test_unrelease_shipped(self):
+        self._deliver(self.pick_picking)
+        self._deliver(self.pack_picking)
+        self._deliver(self.ship_picking)
+        self.ship_picking.unrelease()
+        # Did nothing
+        self.assertEqual(self.ship_picking.state, "done")
+        self.assertEqual(self.pack_picking.state, "done")
+        self.assertEqual(self.pick_picking.state, "done")

--- a/stock_available_to_promise_release/views/stock_location_route_views.xml
+++ b/stock_available_to_promise_release/views/stock_location_route_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//group/field[@name='company_id']" position="after">
                 <field name="available_to_promise_defer_pull" />
+                <field name="allow_unrelease_return_done_move" />
                 <field name="no_backorder_at_release" />
             </xpath>
         </field>


### PR DESCRIPTION
Now that return moves are possibly being created when a picking is unreleased, display a nice message to the user when trying to process a product that should be returned in stock.

Based on https://github.com/OCA/wms/pull/971