### PR TITLE
[FIX][14.0] shopfloor cluster_picking: fix line split

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -952,3 +952,6 @@ class MessageAction(Component):
             "message_type": "error",
             "body": _("Unable to find a line with the same product but different lot."),
         }
+
+    def quantity_must_be_positive(self):
+        return {"message_type": "error", "body": _("Quantity must be positive.")}

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -686,43 +686,65 @@ class ClusterPicking(Component):
 
     def _set_destination_pack_update_quantity(self, move_line, quantity, barcode):
         """Handle the done quantity increment on set_destination end point."""
-        response = None
         if not self.work.menu.no_prefill_qty:
-            return response
+            return None
+        handlers = {
+            "product": self._set_destination_update_quantity__by_product,
+            "packaging": self._set_destination_update_quantity__by_packaging,
+            "lot": self._set_destination_update_quantity__by_lot,
+            "none": self._set_destination_update_quantity__fallback,
+        }
+        search_result = self._set_destination_pack_update_quantity__find(
+            barcode, handlers.keys()
+        )
+        handler = handlers.get(
+            search_result.type, self._set_destination_update_quantity__fallback
+        )
+        return handler(move_line, search_result.record, quantity)
+
+    def _set_destination_pack_update_quantity__find(self, barcode, search_types):
         search = self._actions_for("search")
-        # Handle barcode of product or packaging
-        product = search.product_from_scan(barcode)
-        packaging = self.env["product.packaging"].browse()
-        if not product:
-            packaging = search.packaging_from_scan(barcode)
-            product = packaging.product_id
-        if product:
-            if move_line.product_id == product:
-                quantity += packaging.qty or 1.0
-                response = self._response_for_scan_destination(
-                    move_line, qty_done=quantity
-                )
-                return response
-            return self._response_for_scan_destination(
-                move_line,
-                message=self.msg_store.wrong_record(product),
-                qty_done=quantity,
-            )
-        # Handle barcode of a lot
-        lot = search.lot_from_scan(barcode)
-        if lot:
-            if move_line.lot_id == lot:
-                quantity += 1.0
-                response = self._response_for_scan_destination(
-                    move_line, qty_done=quantity
-                )
-                return response
-            return self._response_for_scan_destination(
-                move_line,
-                message=self.msg_store.wrong_record(lot),
-                qty_done=quantity,
-            )
-        return response
+        return search.find(barcode, types=search_types)
+
+    def _set_destination_update_quantity__by_product(
+        self, move_line, product, quantity
+    ):
+        if move_line.product_id == product:
+            quantity += 1.0
+            return self._response_for_scan_destination(move_line, qty_done=quantity)
+        return self._response_for_scan_destination(
+            move_line,
+            message=self.msg_store.wrong_record(product),
+            qty_done=quantity,
+        )
+
+    def _set_destination_update_quantity__by_packaging(
+        self, move_line, packaging, quantity
+    ):
+        product = packaging.product_id
+        if move_line.product_id == product:
+            quantity += packaging.qty
+            return self._response_for_scan_destination(move_line, qty_done=quantity)
+        return self._response_for_scan_destination(
+            move_line,
+            message=self.msg_store.wrong_record(product),
+            qty_done=quantity,
+        )
+
+    def _set_destination_update_quantity__by_lot(self, move_line, lot, quantity):
+        if move_line.lot_id == lot:
+            quantity += 1.0
+            return self._response_for_scan_destination(move_line, qty_done=quantity)
+        return self._response_for_scan_destination(
+            move_line,
+            message=self.msg_store.wrong_record(lot),
+            qty_done=quantity,
+        )
+
+    def _set_destination_update_quantity__fallback(
+        self, move_line, empty_rec, quantity
+    ):
+        return None
 
     def scan_destination_pack(self, picking_batch_id, move_line_id, barcode, quantity):
         """Scan the destination package (bin) for a move line

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -759,11 +759,11 @@ class ClusterPicking(Component):
         if response:
             return response
 
-        new_line, qty_check = move_line._split_qty_to_be_done(quantity)
-        if qty_check == "greater":
+        message = self._check_line_qty_processible(move_line, quantity)
+        if message:
             return self._response_for_scan_destination(
                 move_line,
-                message=self.msg_store.unable_to_pick_more(move_line.product_uom_qty),
+                message=message,
                 qty_done=quantity,
             )
 
@@ -795,6 +795,11 @@ class ClusterPicking(Component):
                 },
                 qty_done=quantity,
             )
+
+        # Keeping second return value for compatibility
+        # Quantity already checked at _check_line_qty_processible
+        new_line, __ = move_line._split_qty_to_be_done(quantity)
+
         move_line.write({"qty_done": quantity, "result_package_id": bin_package.id})
         # Only apply zero check if the product is of type "product".
         zero_check = (

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -3,6 +3,7 @@
 # Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, exceptions
+from odoo.tools.float_utils import float_compare
 
 from odoo.addons.component.core import AbstractComponent
 
@@ -45,6 +46,20 @@ class BaseShopfloorProcess(AbstractComponent):
         # we can remove this override and the need to call `_get_process_picking_types`
         # every time.
         return self._actions_for("search_move_line", picking_types=self.picking_types)
+
+    def _check_line_qty_processible(self, move_line, quantity):
+        """Checks that a given quantity is processible for a move line."""
+        rounding = move_line.product_uom_id.rounding
+        qty_todo = move_line.product_uom_qty
+        qty_positive = float_compare(quantity, 0, precision_rounding=rounding) == 1
+        if not qty_positive:
+            return self.msg_store.quantity_must_be_positive()
+
+        qty_greater = (
+            float_compare(quantity, qty_todo, precision_rounding=rounding) == 1
+        )
+        if qty_greater:
+            return self.msg_store.unable_to_pick_more(move_line.product_uom_qty)
 
     def _check_picking_status(self, pickings, states=("assigned",)):
         """Check if given pickings can be processed.

--- a/shopfloor/tests/test_cluster_picking_scan_destination.py
+++ b/shopfloor/tests/test_cluster_picking_scan_destination.py
@@ -237,6 +237,31 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
             },
         )
 
+    def test_scan_destination_pack_no_quantity(self):
+        line = self.one_line_picking.move_line_ids
+        response = self.service.dispatch(
+            "scan_destination_pack",
+            params={
+                "picking_batch_id": self.batch.id,
+                "move_line_id": line.id,
+                "barcode": self.bin1.name,
+                "quantity": 0,
+            },
+        )
+        # Since we processed no quantity, we shouldn't have a new line
+        new_line = self.one_line_picking.move_line_ids - line
+        self.assertFalse(new_line)
+        # However, an error should have been returned
+        self.assert_response(
+            response,
+            next_state="scan_destination",
+            data=self._line_data(line),
+            message={
+                "message_type": "error",
+                "body": "Quantity must be positive.",
+            },
+        )
+
     def test_scan_destination_pack_quantity_less(self):
         """Pick less units than expected"""
         line = self.one_line_picking.move_line_ids


### PR DESCRIPTION
At `scan_destination_pack` when a destination package is scanned without any qty processed (especially when no prefill quantity is enabled), we would end up with a new move line with qty = 0.

Instead, return an error to the user.