### PR TITLE
[14.0] shopfloor: better messages when transfer has been cancel and product is reserved by a return

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -560,11 +560,9 @@ class MessageAction(Component):
             "body": _("Place it in {}?").format(location_name),
         }
 
-    def product_not_found_in_current_picking(self):
-        return {
-            "message_type": "error",
-            "body": _("Product is not in the current transfer."),
-        }
+    def product_not_found_in_current_picking(self, product):
+        body = _("Product %s is not in the current transfer.", product.name)
+        return {"message_type": "error", "body": body}
 
     def lot_mixed_package_scan_package(self):
         return {

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -961,3 +961,13 @@ class MessageAction(Component):
             "message_type": "error",
             "body": _("Unable to find a line with the same product but different lot."),
         }
+
+    def reserved_for_other_picking_type(self, picking):
+        body = _("Reserved for %(picking_type)s %(picking_name)s") % {
+            "picking_type": picking.picking_type_id.name,
+            "picking_name": picking.name,
+        }
+        return {
+            "message_type": "error",
+            "body": body,
+        }

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -216,6 +216,15 @@ class MessageAction(Component):
     def already_done(self):
         return {"message_type": "info", "body": _("Operation already processed.")}
 
+    def transfer_canceled(self):
+        return {
+            "message_type": "info",
+            "body": _(
+                "Transfer has been canceled. "
+                "This cannot be processed using this scenario"
+            ),
+        }
+
     def move_already_done(self):
         return {"message_type": "warning", "body": _("Move already processed.")}
 

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -468,6 +468,30 @@ class MessageAction(Component):
             "body": _("No transfer found for this product."),
         }
 
+    def transfer_not_found_for_barcode(self, barcode):
+        body = _("No transfer found for barcode %s", barcode)
+        return {
+            "message_type": "error",
+            "body": body,
+        }
+
+    def transfer_not_found_for_record(self, record):
+        model_mapping = {
+            "product.product": "product",
+            "stock.picking": "transfer",
+            "stock.quant.package": "package",
+            "product.packaging": "packaging",
+            "stock.location": "location",
+            "stock.production.lot": "lot",
+            "stock.move": "move",
+        }
+        model_name = model_mapping.get(record._name)
+        body = _("No transfer found for %s %s", model_name, record.name)
+        return {
+            "message_type": "error",
+            "body": body,
+        }
+
     def product_not_found_in_location_or_transfer(self, product, location, picking):
         return {
             "message_type": "error",

--- a/shopfloor/actions/stock_unreserve.py
+++ b/shopfloor/actions/stock_unreserve.py
@@ -10,7 +10,9 @@ class StockUnreserve(Component):
     _inherit = "shopfloor.process.action"
     _usage = "stock.unreserve"
 
-    def check_unreserve(self, location, move_lines, product=None, lot=None):
+    def check_unreserve(
+        self, location, move_lines, product=None, lot=None, allowed_types=None
+    ):
         """Return a message if there is an ongoing operation in the location.
 
         It could be a move line with some qty already processed or another
@@ -20,12 +22,17 @@ class StockUnreserve(Component):
         :param move_lines: move lines to unreserve
         :param product: optional product to limit the scope in the location
         """
+        if not allowed_types:
+            allowed_types = self.env["stock.picking.type"]
         location_move_lines = self._find_location_all_move_lines(location, product, lot)
         extra_move_lines = location_move_lines - move_lines
         if extra_move_lines:
-            return self.msg_store.picking_already_started_in_location(
-                extra_move_lines.picking_id
-            )
+            extra_pickings = extra_move_lines.picking_id
+            if allowed_types:
+                for picking in extra_pickings:
+                    if picking.picking_type_id not in allowed_types:
+                        return self.msg_store.reserved_for_other_picking_type(picking)
+            return self.msg_store.picking_already_started_in_location(extra_pickings)
 
     def unreserve_moves(self, move_lines, picking_types):
         """Unreserve moves from `move_lines'.

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -471,21 +471,31 @@ class Checkout(Component):
             return self._response_for_summary(picking)
 
         # Search of the destination package
-        search_result = self._scan_line_find(picking, barcode)
-        result_handler = getattr(self, "_select_lines_from_" + search_result.type)
-        kw = {"confirm_pack_all": confirm_pack_all, "confirm_lot": confirm_lot}
-        return result_handler(picking, selection_lines, search_result.record, **kw)
+        handlers = {
+            "package": self._select_lines_from_package,
+            "product": self._select_lines_from_product,
+            "packaging": self._select_lines_from_packaging,
+            "lot": self._select_lines_from_lot,
+            "serial": self._select_lines_from_serial,
+            "delivery_packaging": self._select_lines_from_delivery_packaging,
+            "none": self._select_lines_from_none,
+        }
+        search_result = self._scan_line_find(picking, barcode, handlers.keys())
+        # setting scanned record as kwarg in order to make better logs.
+        # The reason for this is that from a product we might select various records
+        # and lose track of what was initially scanned. This forces us to display
+        # standard messages that might have no meaning for the user.
+        kwargs = {
+            "confirm_pack_all": confirm_pack_all,
+            "confirm_lot": confirm_lot,
+            "scanned_record": search_result.record,
+            "barcode": barcode,
+        }
+        handler = handlers.get(search_result.type, self._select_lines_from_none)
+        return handler(picking, selection_lines, search_result.record, **kwargs)
 
-    def _scan_line_find(self, picking, barcode, search_types=None):
+    def _scan_line_find(self, picking, barcode, search_types):
         search = self._actions_for("search")
-        search_types = (
-            "package",
-            "product",
-            "packaging",
-            "lot",
-            "serial",
-            "delivery_packaging",
-        )
         return search.find(
             barcode,
             types=search_types,
@@ -508,15 +518,14 @@ class Checkout(Component):
             lambda l: l.package_id == package and not l.shopfloor_checkout_done
         )
         if not lines:
-            return self._response_for_select_line(
-                picking,
-                message={
-                    "message_type": "error",
-                    "body": _("Package {} is not in the current transfer.").format(
-                        package.name
-                    ),
-                },
-            )
+            # No line for scanned package in selected picking
+            # Check if there's any picking reserving this product.
+            return_picking = self._get_pickings_for_package(package, limit=1)
+            if return_picking:
+                message = self.msg_store.reserved_for_other_picking_type(return_picking)
+            else:
+                message = self.msg_store.package_not_found_in_picking(package, picking)
+            return self._response_for_select_line(picking, message=message)
         self._select_lines(lines, prefill_qty=prefill_qty)
         if self.work.menu.no_prefill_qty:
             lines = picking.move_line_ids
@@ -533,9 +542,12 @@ class Checkout(Component):
 
         lines = selection_lines.filtered(lambda l: l.product_id == product)
         if not lines:
-            return self._response_for_select_line(
-                picking, message=self.msg_store.product_not_found_in_current_picking()
-            )
+            return_picking = self._get_pickings_for_product(product, limit=1)
+            if return_picking:
+                message = self.msg_store.reserved_for_other_picking_type(return_picking)
+            else:
+                message = self.msg_store.product_not_found_in_current_picking(product)
+            return self._response_for_select_line(picking, message=message)
 
         # When products are as units outside of packages, we can select them for
         # packing, but if they are in a package, we want the user to scan the packages.
@@ -1047,18 +1059,21 @@ class Checkout(Component):
             return self._response_for_select_document(message=message)
 
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
-        search_result = self._scan_package_find(picking, barcode)
-        message = self._check_scan_package_find(picking, search_result)
-        if message:
-            return self._response_for_select_package(
-                picking,
-                selected_lines,
-                message=message,
-            )
-        result_handler = getattr(
-            self, "_scan_package_action_from_" + search_result.type
-        )
-        return result_handler(picking, selected_lines, search_result.record)
+        handlers = {
+            "package": self._scan_package_action_from_package,
+            "product": self._scan_package_action_from_product,
+            "packaging": self._scan_package_action_from_packaging,
+            "lot": self._scan_package_action_from_lot,
+            "serial": self._scan_package_action_from_serial,
+            "delivery_packaging": self._scan_package_action_from_delivery_packaging,
+        }
+        search_result = self._scan_package_find(picking, barcode, handlers.keys())
+        handler = handlers.get(search_result.type, self._scan_package_action_from_none)
+        kwargs = {
+            "barcode": barcode,
+            "scanned_record": search_result.record,
+        }
+        return handler(picking, selected_lines, search_result.record, **kwargs)
 
     def _scan_package_find(self, picking, barcode, search_types):
         search = self._actions_for("search")
@@ -1078,10 +1093,6 @@ class Checkout(Component):
                 serial=dict(products=picking.move_lines.product_id),
             ),
         )
-
-    def _check_scan_package_find(self, picking, search_result):
-        # Used by inheriting modules
-        return False
 
     def _find_line_to_increment(self, product_lines):
         """Find which line should have its qty incremented.

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -212,25 +212,29 @@ class Checkout(Component):
         * summary: stock.picking is selected and all its lines have a
           destination pack set
         """
-        search_result = self._scan_document_find(barcode)
-        result_handler = getattr(self, "_select_document_from_" + search_result.type)
-        return result_handler(search_result.record)
+        handlers = {
+            "picking": self._select_document_from_picking,
+            "location": self._select_document_from_location,
+            "package": self._select_document_from_package,
+            "packaging": self._select_document_from_packaging,
+            "product": self._select_document_from_product,
+            "none": self._select_document_from_none,
+        }
+        if self.work.menu.scan_location_or_pack_first:
+            handlers.pop("product")
+        search_result = self._scan_document_find(barcode, handlers.keys())
+        # Keep track of what has been initially scan, and forward it through kwargs
+        kwargs = {
+            "barcode": barcode,
+            "current_state": "select_document",
+            "scanned_record": search_result.record,
+        }
+        handler = handlers.get(search_result.type, self._select_document_from_none)
+        return handler(search_result.record, **kwargs)
 
-    def _scan_document_find(self, barcode, search_types=None):
+    def _scan_document_find(self, barcode, search_types):
         search = self._actions_for("search")
-        search_types = (
-            "picking",
-            "location",
-            "package",
-            "packaging",
-        ) + (("product",) if not self.work.menu.scan_location_or_pack_first else ())
-        return search.find(
-            barcode,
-            types=search_types,
-        )
-
-    def _select_document_from_picking(self, picking, **kw):
-        return self._select_picking(picking, "select_document")
+        return search.find(barcode, types=search_types)
 
     def _select_document_from_location(self, location, **kw):
         if not self.is_src_location_valid(location):
@@ -249,7 +253,9 @@ class Checkout(Component):
                     ),
                 }
             )
-        return self._select_picking(pickings, "select_document")
+        # Keep track of what has been initially scan, and forward it through kwargs
+        kwargs = {**kw, "current_state": "select_document"}
+        return self._select_document_from_picking(pickings, **kwargs)
 
     def _select_document_from_package(self, package, **kw):
         pickings = package.move_line_ids.filtered(
@@ -258,14 +264,15 @@ class Checkout(Component):
         if len(pickings) > 1:
             # Filter only if we find several pickings to narrow the
             # selection to one of the good type. If we have one picking
-            # of the wrong type, it will be caught in _select_picking
+            # of the wrong type, it will be caught in _select_document_from_picking
             # with the proper error message.
             # Side note: rather unlikely to have several transfers ready
             # and moving the same things
             pickings = pickings.filtered(
                 lambda p: p.picking_type_id in self.picking_types
             )
-        return self._select_picking(fields.first(pickings), "select_document")
+        kwargs = {**kw, "current_state": "select_document"}
+        return self._select_document_from_picking(fields.first(pickings), **kwargs)
 
     def _select_document_from_product(self, product, line_domain=None, **kw):
         line_domain = line_domain or []
@@ -285,7 +292,8 @@ class Checkout(Component):
             order="priority desc, scheduled_date asc, id desc",
             limit=1,
         )
-        return self._select_picking(picking, "select_document")
+        kwargs = {**kw, "current_state": "select_document"}
+        return self._select_document_from_picking(picking, **kwargs)
 
     def _select_document_from_packaging(self, packaging, **kw):
         # And retrieve its product
@@ -296,35 +304,33 @@ class Checkout(Component):
         line_domain = [("product_uom_qty", ">=", packaging.qty)]
         return self._select_document_from_product(product, line_domain=line_domain)
 
-    def _select_document_from_none(self, picking, **kw):
+    def _select_document_from_none(self, *args, barcode=None, **kwargs):
         """Handle result when no record is found."""
-        return self._select_picking(picking, "select_document")
+        return self._response_for_select_document(
+            message=self.msg_store.transfer_not_found_for_barcode(barcode)
+        )
 
-    def _select_picking(self, picking, state_for_error):
+    def _select_document_from_picking(
+        self, picking, current_state=None, barcode=None, **kwargs
+    ):
+        # Get origin record to give more context to the user when raising an error
+        # as we got picking from product/package/packaging/...
+        scanned_record = kwargs.get("scanned_record")
         if not picking:
-            if state_for_error == "manual_selection":
-                return self._response_for_manual_selection(
-                    message=self.msg_store.stock_picking_not_found()
-                )
-            return self._response_for_select_document(
-                message=self.msg_store.barcode_not_found()
-            )
+            message = self.msg_store.transfer_not_found_for_record(scanned_record)
+            if current_state == "manual_selection":
+                return self._response_for_manual_selection(message=message)
+            return self._response_for_select_document(message=message)
         if picking.picking_type_id not in self.picking_types:
-            if state_for_error == "manual_selection":
-                return self._response_for_manual_selection(
-                    message=self.msg_store.cannot_move_something_in_picking_type()
-                )
-            return self._response_for_select_document(
-                message=self.msg_store.cannot_move_something_in_picking_type()
-            )
+            message = self.msg_store.reserved_for_other_picking_type(picking)
+            if current_state == "manual_selection":
+                return self._response_for_manual_selection(message=message)
+            return self._response_for_select_document(message=message)
         if picking.state != "assigned":
-            if state_for_error == "manual_selection":
-                return self._response_for_manual_selection(
-                    message=self.msg_store.stock_picking_not_available(picking)
-                )
-            return self._response_for_select_document(
-                message=self.msg_store.stock_picking_not_available(picking)
-            )
+            message = self.msg_store.stock_picking_not_available(picking)
+            if current_state == "manual_selection":
+                return self._response_for_manual_selection(message=message)
+            return self._response_for_select_document(message=message)
         return self._response_for_select_line(picking)
 
     def _data_for_move_lines(self, lines, **kw):
@@ -403,7 +409,14 @@ class Checkout(Component):
         message = self._check_picking_processible(picking)
         if message:
             return self._response_for_manual_selection(message=message)
-        return self._select_picking(picking, "manual_selection")
+        # Because _select_document_from_picking expects some context
+        # to give meaningful infos to the user, add some here.
+        kwargs = {
+            "current_state": "manual_selection",
+            "barcode": picking.name,
+            "scanned_record": picking,
+        }
+        return self._select_document_from_picking(picking, **kwargs)
 
     def _select_lines(self, lines, prefill_qty=0, related_lines=None):
         for i, line in enumerate(lines):
@@ -1047,7 +1060,7 @@ class Checkout(Component):
         )
         return result_handler(picking, selected_lines, search_result.record)
 
-    def _scan_package_find(self, picking, barcode, search_types=None):
+    def _scan_package_find(self, picking, barcode, search_types):
         search = self._actions_for("search")
         search_types = (
             "package",

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -400,7 +400,7 @@ class Checkout(Component):
           lines
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_manual_selection(message=message)
         return self._select_picking(picking, "manual_selection")
@@ -449,7 +449,7 @@ class Checkout(Component):
         screen to change the qty done and destination pack if needed
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -772,7 +772,7 @@ class Checkout(Component):
         assert package_id or move_line_id
 
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -791,7 +791,7 @@ class Checkout(Component):
         self, picking_id, selected_line_ids, move_line_ids, quantity_func
     ):
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1029,7 +1029,7 @@ class Checkout(Component):
         to close the stock picking
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1183,7 +1183,7 @@ class Checkout(Component):
         * select_package: when no delivery packaging is available
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1213,7 +1213,7 @@ class Checkout(Component):
         * select_line: goes back to selection of lines to work on next lines
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         packaging = None
@@ -1235,7 +1235,7 @@ class Checkout(Component):
         if self.options.get("checkout__disable_no_package"):
             raise BadRequest("`checkout.no_package` endpoint is not enabled")
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1267,7 +1267,7 @@ class Checkout(Component):
         * select_package: when no package is available
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1315,7 +1315,7 @@ class Checkout(Component):
         * summary: all lines are put in packages
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1342,7 +1342,7 @@ class Checkout(Component):
         * summary: all lines are put in packages
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
@@ -1369,7 +1369,7 @@ class Checkout(Component):
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         return self._response_for_summary(picking)
@@ -1388,7 +1388,7 @@ class Checkout(Component):
         * summary: if the package_id no longer exists
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
@@ -1403,7 +1403,7 @@ class Checkout(Component):
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1440,7 +1440,7 @@ class Checkout(Component):
         * select_line: when package or line has been canceled
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
 
@@ -1485,7 +1485,7 @@ class Checkout(Component):
         * select_child_location: there are child destination locations
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         lines = picking.move_line_ids
@@ -1528,7 +1528,7 @@ class Checkout(Component):
         * select_child_location: in case of error
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         search = self._actions_for("search")

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -140,7 +140,7 @@ class Delivery(Component):
         barcode_valid = bool(picking)
 
         if picking:
-            message = self._check_picking_status(picking)
+            message = self._check_picking_processible(picking)
             if message:
                 return self._response_for_deliver(location=location, message=message)
 
@@ -235,6 +235,12 @@ class Delivery(Component):
         lines = package.move_line_ids.filtered(
             lambda l: l.state in ("assigned", "partially_available")
         )
+        if not lines:
+            return self._response_for_deliver(
+                picking=picking,
+                location=location,
+                message=self.msg_store.cannot_move_something_in_picking_type(),
+            )
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
@@ -247,12 +253,9 @@ class Delivery(Component):
                 ]
             )
             return self._response_for_deliver(location=location, message=message)
-        if not lines:
-            return self._response_for_deliver(
-                picking=picking,
-                location=location,
-                message=self.msg_store.cannot_move_something_in_picking_type(),
-            )
+        message = self._check_picking_type(lines.mapped("picking_id"))
+        if message:
+            return self._response_for_deliver(location=location, message=message)
         # TODO add a message if any of the lines already had a qty_done > 0
         new_picking = fields.first(lines.mapped("picking_id"))
         if self._set_lines_done(lines):
@@ -264,19 +267,7 @@ class Delivery(Component):
     def _lines_base_domain(self, no_qty_done=True):
         # we added auto_join for this, otherwise, the ORM would search all pickings
         # in the picking type, and then use IN (ids)
-        domain = [
-            # Accepting return_picking_types in order to display meaningful
-            # messages when trying to process a return move.
-            # Those returns are blocked later in `_check_picking_status`
-            "|",
-            ("picking_id.picking_type_id", "in", self.picking_types.ids),
-            (
-                "picking_id.picking_type_id",
-                "in",
-                self.picking_types.return_picking_type_id.ids,
-            ),
-            ("picking_id.state", "not in", ("done",)),
-        ]
+        domain = []
         if no_qty_done:
             domain.append(("qty_done", "=", 0))
         return domain
@@ -313,6 +304,16 @@ class Delivery(Component):
         )
         if location:
             domain.extend([("location_id", "=", location.id)])
+        else:
+            domain.extend(
+                [
+                    (
+                        "location_id",
+                        "child_of",
+                        self.picking_types.default_location_src_id.ids,
+                    )
+                ]
+            )
         if product_qty:
             domain.extend(
                 [
@@ -367,6 +368,12 @@ class Delivery(Component):
                 message=self.msg_store.product_in_multiple_sublocation(product),
             )
 
+        message = self._check_picking_type(lines.mapped("picking_id"))
+        if message:
+            return self._response_for_deliver(location=location, message=message)
+        lines = lines.filtered(
+            lambda l: l.move_id.picking_type_id in self.picking_types
+        )
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
@@ -429,15 +436,14 @@ class Delivery(Component):
         return self._response_for_deliver(new_picking, location=location)
 
     def _deliver_lot(self, picking, lot, product_qty=None, location=None):
-        lines = self.env["stock.move.line"].search(
-            self._lines_from_lot_domain(
-                lot,
-                no_qty_done=False,
-                product_qty=product_qty,
-                location=location,
-                picking=picking,
-            )
+        domain = self._lines_from_lot_domain(
+            lot,
+            no_qty_done=False,
+            product_qty=product_qty,
+            location=location,
+            picking=picking,
         )
+        lines = self.env["stock.move.line"].search(domain)
         if not lines:
             return self._response_for_deliver(
                 picking,
@@ -455,6 +461,9 @@ class Delivery(Component):
                 message=self.msg_store.lot_in_multiple_sublocation(lot),
             )
 
+        message = self._check_picking_type(lines.mapped("picking_id"))
+        if message:
+            return self._response_for_deliver(location=location, message=message)
         # State of the picking might change while we reach this point: check again!
         message = self._check_picking_status(lines.mapped("picking_id"))
         if message:
@@ -565,7 +574,7 @@ class Delivery(Component):
         * deliver: with information about the stock.picking
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self.list_stock_picking(message=message)
         if picking:
@@ -582,7 +591,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
@@ -607,7 +616,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         line = self.env["stock.move.line"].browse(move_line_id).exists()
@@ -634,7 +643,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
@@ -667,7 +676,7 @@ class Delivery(Component):
         * deliver: always return here with updated data
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         line = self.env["stock.move.line"].browse(move_line_id).exists()
@@ -697,7 +706,7 @@ class Delivery(Component):
         * confirm_done: when not all lines of the stock.picking are done
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_deliver(message=message)
         if self._action_picking_done(picking):

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -147,47 +147,54 @@ class Delivery(Component):
         if picking_id:
             picking = self.env["stock.picking"].browse(picking_id)
 
-        # Validate picking anyway
         if not barcode_valid:
-            package = search.package_from_scan(barcode)
-            if package:
-                return self._deliver_package(picking, package, location)
+            handlers_by_type = {
+                "package": self._scan_deliver__by_package,
+                "product": self._scan_deliver__by_product,
+                "packaging": self._scan_deliver__by_packaging,
+                "lot": self._scan_deliver__by_lot,
+                "location": self._scan_deliver__by_location,
+            }
+            search_result = search.find(barcode, handlers_by_type.keys())
+            handler = handlers_by_type.get(search_result.type)
+            if handler:
+                result = handler(search_result.record, picking, location)
+                if result:
+                    return result
+        return self._scan_deliver__fallback(picking, location, barcode_valid)
 
-        if not barcode_valid:
-            product = search.product_from_scan(barcode)
-            if product:
-                return self._deliver_product(
-                    picking, product, product_qty=1, location=location
-                )
+    def _scan_deliver__by_package(self, package, picking, location):
+        return self._deliver_package(picking, package, location)
 
-        if not barcode_valid:
-            packaging = search.packaging_from_scan(barcode)
-            if packaging:
-                # By scanning a packaging, we want to process
-                # the full quantity of the packaging
-                packaging_qty = packaging.product_uom_id._compute_quantity(
-                    packaging.qty, packaging.product_id.uom_id
-                )
-                return self._deliver_product(
-                    picking,
-                    packaging.product_id,
-                    product_qty=packaging_qty,
-                    location=location,
-                )
+    def _scan_deliver__by_product(self, product, picking, location):
+        return self._deliver_product(picking, product, product_qty=1, location=location)
 
-        if not barcode_valid:
-            lot = search.lot_from_scan(barcode)
-            if lot:
-                return self._deliver_lot(picking, lot, product_qty=1, location=location)
+    def _scan_deliver__by_packaging(self, packaging, picking, location):
+        # By scanning a packaging, we want to process
+        # the full quantity of the packaging
+        packaging_qty = packaging.product_uom_id._compute_quantity(
+            packaging.qty, packaging.product_id.uom_id
+        )
+        return self._deliver_product(
+            picking,
+            packaging.product_id,
+            product_qty=packaging_qty,
+            location=location,
+        )
 
-        if not barcode_valid:
-            sublocation = search.location_from_scan(barcode)
-            if sublocation and sublocation.is_sublocation_of(
-                self.picking_types.mapped("default_location_src_id")
-            ):
-                message = self.msg_store.location_src_set_to_sublocation(sublocation)
-                return self._response_for_deliver(location=sublocation, message=message)
+    def _scan_deliver__by_lot(self, lot, picking, location):
+        return self._deliver_lot(picking, lot, product_qty=1, location=location)
 
+    def _scan_deliver__by_location(self, scanned_location, picking, location):
+        if scanned_location.is_sublocation_of(
+            self.picking_types.mapped("default_location_src_id")
+        ):
+            message = self.msg_store.location_src_set_to_sublocation(scanned_location)
+            return self._response_for_deliver(
+                location=scanned_location, message=message
+            )
+
+    def _scan_deliver__fallback(self, picking, location, barcode_valid):
         message = self.msg_store.barcode_not_found() if not barcode_valid else None
         return self._response_for_deliver(
             picking=picking, location=location, message=message

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -255,11 +255,20 @@ class Delivery(Component):
         return self._response_for_deliver(picking=new_picking, location=location)
 
     def _lines_base_domain(self, no_qty_done=True):
+        # we added auto_join for this, otherwise, the ORM would search all pickings
+        # in the picking type, and then use IN (ids)
         domain = [
-            # we added auto_join for this, otherwise, the ORM would search all pickings
-            # in the picking type, and then use IN (ids)
+            # Accepting return_picking_types in order to display meaningful
+            # messages when trying to process a return move.
+            # Those returns are blocked later in `_check_picking_status`
+            "|",
             ("picking_id.picking_type_id", "in", self.picking_types.ids),
-            ("picking_id.state", "not in", ("done", "cancel")),
+            (
+                "picking_id.picking_type_id",
+                "in",
+                self.picking_types.return_picking_type_id.ids,
+            ),
+            ("picking_id.state", "not in", ("done",)),
         ]
         if no_qty_done:
             domain.append(("qty_done", "=", 0))

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -372,7 +372,9 @@ class LocationContentTransfer(Component):
 
         unreserved_moves = self.env["stock.move"].browse()
         if self.work.menu.allow_unreserve_other_moves:
-            message = unreserve.check_unreserve(location, move_lines)
+            message = unreserve.check_unreserve(
+                location, move_lines, allowed_types=self.picking_types
+            )
             if message:
                 return self._response_for_start(message=message)
             move_lines, unreserved_moves = unreserve.unreserve_moves(
@@ -728,20 +730,31 @@ class LocationContentTransfer(Component):
             )
 
         search = self._actions_for("search")
+        handlers = {
+            "package": self._scan_line__by_package,
+            "product": self._scan_line__by_product,
+            "packaging": self._scan_line__by_packaging,
+            "lot": self._scan_line__by_lot,
+            "none": self._scan_line__fallback,
+        }
+        search_result = search.find(barcode, types=handlers.keys())
+        handler = handlers.get(search_result.type, self._scan_line__fallback)
+        # handler might've been called but returned no response.
+        # I.E. package is scanned but doesn't matches move_line's package.
+        # Call explicitely fallback in such case
+        response = handler(search_result.record, move_line, location)
+        return response or self._scan_line__fallback(
+            search_result.record, move_line, location
+        )
 
-        package = search.package_from_scan(barcode)
-        if package and move_line.package_id == package:
+    def _scan_line__by_package(self, package, move_line, location):
+        if move_line.package_id == package:
             # In case we have a source package but no package level because if
             # we have a package level, we would use "scan_package".
             return self._response_for_scan_destination(location, move_line)
 
-        product = search.product_from_scan(barcode)
-        if not product:
-            packaging = search.packaging_from_scan(barcode)
-            if packaging:
-                product = packaging.product_id
-
-        if product and product == move_line.product_id:
+    def _scan_line__by_product(self, product, move_line, location):
+        if product == move_line.product_id:
             if product.tracking in ("lot", "serial"):
                 move_lines = self._find_transfer_move_lines(location)
                 return self._response_for_start_single(
@@ -751,18 +764,21 @@ class LocationContentTransfer(Component):
             else:
                 return self._response_for_scan_destination(location, move_line)
 
-        lot = search.lot_from_scan(barcode, products=move_line.product_id)
-        if lot and lot == move_line.lot_id:
+    def _scan_line__by_packaging(self, packaging, move_line, location):
+        return self._scan_line__by_product(packaging.product_id, move_line, location)
+
+    def _scan_line__by_lot(self, lot, move_line, location):
+        if lot == move_line.lot_id:
             return self._response_for_scan_destination(location, move_line)
 
+    def _scan_line__fallback(self, record, move_line, location):
         # Nothing matches what is expected from the move line.
         move_lines = self._find_transfer_move_lines(location)
-        for rec in (package, product, lot):
-            if rec:
-                return self._response_for_start_single(
-                    move_lines.mapped("picking_id"),
-                    message=self.msg_store.wrong_record(rec),
-                )
+        if record:
+            return self._response_for_start_single(
+                move_lines.mapped("picking_id"),
+                message=self.msg_store.wrong_record(record),
+            )
         return self._response_for_start_single(
             move_lines.mapped("picking_id"), message=self.msg_store.barcode_not_found()
         )

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -3,6 +3,7 @@
 # Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, exceptions, fields
+from odoo.osv.expression import AND
 
 from odoo.addons.component.core import AbstractComponent
 
@@ -25,6 +26,22 @@ class BaseShopfloorProcess(AbstractComponent):
     def _get_process_picking_types(self):
         """Return picking types for the menu"""
         return self.work.menu.picking_type_ids
+
+    def _get_pickings_base_domain(self):
+        return [
+            ("state", "not in", ("done", "cancel")),
+            ("location_id", "child_of", self.picking_types.default_location_src_id.ids),
+        ]
+
+    def _get_pickings_for_package(self, package, **kwargs):
+        domain = self._get_pickings_base_domain()
+        package_domain = [("move_line_ids.package_id", "=", package.id)]
+        return self.env["stock.picking"].search(AND([domain, package_domain]), **kwargs)
+
+    def _get_pickings_for_product(self, product, **kwargs):
+        domain = self._get_pickings_base_domain()
+        product_domain = [("move_line_ids.product_id", "=", product.id)]
+        return self.env["stock.picking"].search(AND([domain, product_domain]), **kwargs)
 
     @property
     def picking_types(self):

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -2,7 +2,7 @@
 # Copyright 2020 Akretion (http://www.akretion.com)
 # Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import _, exceptions
+from odoo import _, exceptions, fields
 
 from odoo.addons.component.core import AbstractComponent
 
@@ -46,25 +46,41 @@ class BaseShopfloorProcess(AbstractComponent):
         # every time.
         return self._actions_for("search_move_line", picking_types=self.picking_types)
 
-    def _check_picking_status(self, pickings, states=("assigned",)):
-        """Check if given pickings can be processed.
+    def _check_picking_consistency(self, pickings):
+        if not pickings.exists():
+            return self.msg_store.stock_picking_not_found()
 
-        If the picking is already done, canceled or didn't belong to the
-        expected picking type, a message is returned.
-        """
-        for picking in pickings:
-            if not picking.exists():
-                return self.msg_store.stock_picking_not_found()
-            if picking.state == "done":
-                return self.msg_store.already_done()
-            if picking.state == "cancel":
-                return self.msg_store.transfer_cancelled()
-            if picking.state not in states:  # the picking must be ready
-                return self.msg_store.stock_picking_not_available(picking)
-            if picking.picking_type_id in self.picking_types.return_picking_type_id:
-                return self.msg_store.picking_type_is_return()
-            if picking.picking_type_id not in self.picking_types:
-                return self.msg_store.cannot_move_something_in_picking_type()
+    def _check_picking_type(self, pickings):
+        """Check if the pickings have the right expected type."""
+        if not any(
+            picking.picking_type_id in self.picking_types for picking in pickings
+        ):
+            return self.msg_store.reserved_for_other_picking_type(
+                fields.first(pickings)
+            )
+
+    def _check_picking_status(self, pickings, states=("assigned",)):
+        """Checks if the picking exists, is already done or canceled."""
+        if not any(picking.state != "done" for picking in pickings):
+            return self.msg_store.already_done()
+        if not any(picking.state != "cancel" for picking in pickings):
+            return self.msg_store.transfer_canceled()
+        if not any(
+            picking.state in states for picking in pickings
+        ):  # the picking must be ready
+            return self.msg_store.stock_picking_not_available(fields.first(pickings))
+
+    def _check_picking_processible(self, pickings, states=("assigned",)):
+        """Check if given pickings can be processed"""
+        message = self._check_picking_consistency(pickings)
+        if message:
+            return message
+        message = self._check_picking_type(pickings)
+        if message:
+            return message
+        message = self._check_picking_status(pickings, states=states)
+        if message:
+            return message
 
     def is_src_location_valid(self, location):
         """Check the source location is valid for given process.

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -61,6 +61,8 @@ class BaseShopfloorProcess(AbstractComponent):
                 return self.msg_store.transfer_cancelled()
             if picking.state not in states:  # the picking must be ready
                 return self.msg_store.stock_picking_not_available(picking)
+            if picking.picking_type_id in self.picking_types.return_picking_type_id:
+                return self.msg_store.picking_type_is_return()
             if picking.picking_type_id not in self.picking_types:
                 return self.msg_store.cannot_move_something_in_picking_type()
 

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -57,6 +57,8 @@ class BaseShopfloorProcess(AbstractComponent):
                 return self.msg_store.stock_picking_not_found()
             if picking.state == "done":
                 return self.msg_store.already_done()
+            if picking.state == "cancel":
+                return self.msg_store.transfer_cancelled()
             if picking.state not in states:  # the picking must be ready
                 return self.msg_store.stock_picking_not_available(picking)
             if picking.picking_type_id not in self.picking_types:

--- a/shopfloor/tests/test_checkout_scan.py
+++ b/shopfloor/tests/test_checkout_scan.py
@@ -41,7 +41,10 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={"message_type": "error", "body": "Barcode not found"},
+            message={
+                "message_type": "error",
+                "body": "No transfer found for barcode A",
+            },
             data={"restrict_scan_first": True},
         )
 
@@ -56,7 +59,10 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={"message_type": "error", "body": "Barcode not found"},
+            message={
+                "message_type": "error",
+                "body": "No transfer found for barcode NOPE",
+            },
             data={"restrict_scan_first": False},
         )
 
@@ -117,12 +123,14 @@ class CheckoutScanCase(CheckoutCommonCase):
         picking.action_assign()
         barcode = barcode_func(picking)
         response = self.service.dispatch("scan_document", params={"barcode": barcode})
+        picking_name = picking.name
+        type_name = picking.picking_type_id.name
         self.assert_response(
             response,
             next_state="select_document",
             message={
                 "message_type": "error",
-                "body": "You cannot move this using this menu.",
+                "body": f"Reserved for {type_name} {picking_name}",
             },
             data={"restrict_scan_first": False},
         )

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -166,6 +166,24 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
     def test_scan_line_error_package_not_in_picking(self):
         picking = self._create_picking(lines=[(self.product_a, 10)])
         self._fill_stock_for_moves(picking.move_lines, in_package=True)
+        picking.action_assign()
+        # Create a package for product_a
+        package = self._create_package_in_location(
+            picking.location_id, [(self.product_a, 10, None)]
+        )
+        # we work with picking, but we scan another package (not in a pick)
+        self._test_scan_line_error(
+            picking,
+            package.name,
+            {
+                "message_type": "error",
+                "body": f"Package {package.name} not found in transfer {picking.name}",
+            },
+        )
+
+    def test_scan_line_error_package_reserved_by_another_picking(self):
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        self._fill_stock_for_moves(picking.move_lines, in_package=True)
         picking2 = self._create_picking(lines=[(self.product_a, 10)])
         self._fill_stock_for_moves(picking2.move_lines, in_package=True)
         (picking | picking2).action_assign()
@@ -176,9 +194,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
             package.name,
             {
                 "message_type": "error",
-                "body": "Package {} is not in the current transfer.".format(
-                    package.name
-                ),
+                "body": f"Reserved for Checkout {picking2.name}",
             },
         )
 
@@ -247,7 +263,22 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
             self.product_b.barcode,
             {
                 "message_type": "error",
-                "body": "Product is not in the current transfer.",
+                "body": "Product Product B is not in the current transfer.",
+            },
+        )
+
+    def test_scan_line_error_product_in_another_picking(self):
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        self._fill_stock_for_moves(picking.move_lines, in_package=True)
+        picking2 = self._create_picking(lines=[(self.product_b, 10)])
+        self._fill_stock_for_moves(picking2.move_lines, in_package=True)
+        (picking | picking2).action_assign()
+        self._test_scan_line_error(
+            picking,
+            self.product_b.barcode,
+            {
+                "message_type": "error",
+                "body": f"Reserved for Checkout {picking2.name}",
             },
         )
 

--- a/shopfloor/tests/test_checkout_select.py
+++ b/shopfloor/tests/test_checkout_select.py
@@ -66,7 +66,9 @@ class CheckoutSelectCase(CheckoutCommonCase):
         )
 
     def test_select_error_not_allowed(self):
+        # Trying to pick a picking with wrong picking type
         picking = self._create_picking(picking_type=self.wh.pick_type_id)
         self._fill_stock_for_moves(picking.move_lines, in_package=True)
         picking.action_assign()
-        self._test_error(picking, "You cannot move this using this menu.")
+        expected_message = f"Reserved for {picking.picking_type_id.name} {picking.name}"
+        self._test_error(picking, expected_message)

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -504,9 +504,9 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.move_line_ids.package_id = cleanup_package
         params = {"barcode": "CLEANUP_PACKAGE"}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_deliver_return_product(self):
@@ -517,35 +517,34 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.action_assign()
         params = {"barcode": self.product_a.barcode}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_deliver_return_packaging(self):
         self.picking.action_cancel()
         cleanup_picking = self._create_picking(
-            picking_type=self.cleanup_type, lines=[(self.product_a, 1)],
+            picking_type=self.cleanup_type,
+            lines=[(self.product_a, 1)],
         )
         cleanup_picking.action_assign()
-        packaging = (
-            self.env["product.packaging"]
-            .sudo()
-            .create(
-                {
-                    "name": "CLEANUP PACKAGING",
-                    "product_id": self.product_a.id,
-                    "qty": 1,
-                    "product_uom_id": self.product_a.id,
-                    "barcode": "CLEANUP_PACKAGING",
-                }
-            )
+
+        packaging_model = self.env["product.packaging"].sudo()
+        packaging_model.create(
+            {
+                "name": "CLEANUP PACKAGING",
+                "product_id": self.product_a.id,
+                "qty": 1,
+                "product_uom_id": self.product_a.id,
+                "barcode": "CLEANUP_PACKAGING",
+            }
         )
         params = {"barcode": "CLEANUP_PACKAGING"}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_deliver_return_lot(self):
@@ -568,9 +567,9 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.move_line_ids.product_uom_qty = 1.0
         params = {"barcode": "CLEANUP_LOT"}
         response = self.service.dispatch("scan_deliver", params=params)
-        expected_body = (
-            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
-        )
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
         self.assertEqual(response.get("message").get("body"), expected_body)
 
     def test_scan_delivery_return_picking(self):
@@ -666,7 +665,7 @@ class DeliveryScanDeliverSpecialCase(DeliveryCommonCase):
             response,
             message={
                 "message_type": "error",
-                "body": "You cannot move this using this menu.",
+                "body": f"Reserved for {picking.picking_type_id.name} {picking.name}",
             },
         )
 

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -10,6 +10,20 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
     @classmethod
     def setUpClassBaseData(cls):
         super().setUpClassBaseData()
+        cls.out_location = cls.env.ref("stock.stock_location_output")
+        cls.cleanup_type = (
+            cls.env["stock.picking.type"]
+            .sudo()
+            .create(
+                {
+                    "name": "Cancel Cleanup",
+                    "default_location_src_id": cls.out_location.id,
+                    "default_location_dest_id": cls.stock_location.id,
+                    "sequence_code": "CCP",
+                    "code": "internal",
+                }
+            )
+        )
         cls.product_e.tracking = "lot"
         cls.picking = picking = cls._create_picking(
             lines=[
@@ -452,6 +466,126 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         self.assert_response_deliver(
             response,
             message=self.service.msg_store.transfer_canceled(),
+        )
+
+    def test_scan_deliver_return_partial_package(self):
+        move_a = self.picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_a
+        )
+        move_a._action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)]
+        )
+        package_vals = [(self.product_a, 1, None)]
+        cleanup_package = self._create_package_in_location(
+            cleanup_picking.location_id, package_vals
+        )
+        cleanup_package.name = "CLEANUP_PACKAGE"
+        cleanup_picking.action_assign()
+        cleanup_picking.move_line_ids.package_id = cleanup_package
+        params = {"barcode": "CLEANUP_PACKAGE"}
+        response = self.service.dispatch("scan_deliver", params=params)
+        type_name = cleanup_picking.picking_type_id.name
+        pick_name = cleanup_picking.name
+        expected_body = f"Reserved for {type_name} {pick_name}"
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_deliver_return_package(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)]
+        )
+        package_vals = [(self.product_a, 1, None)]
+        cleanup_package = self._create_package_in_location(
+            cleanup_picking.location_id, package_vals
+        )
+        cleanup_package.name = "CLEANUP_PACKAGE"
+        cleanup_picking.action_assign()
+        cleanup_picking.move_line_ids.package_id = cleanup_package
+        params = {"barcode": "CLEANUP_PACKAGE"}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_deliver_return_product(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)]
+        )
+        cleanup_picking.action_assign()
+        params = {"barcode": self.product_a.barcode}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_deliver_return_packaging(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)],
+        )
+        cleanup_picking.action_assign()
+        packaging = (
+            self.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "CLEANUP PACKAGING",
+                    "product_id": self.product_a.id,
+                    "qty": 1,
+                    "product_uom_id": self.product_a.id,
+                    "barcode": "CLEANUP_PACKAGING",
+                }
+            )
+        )
+        params = {"barcode": "CLEANUP_PACKAGING"}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_deliver_return_lot(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_a, 1)]
+        )
+        # Create move lines and set lot
+        cleanup_picking.action_assign()
+        cleanup_lot = self.env["stock.production.lot"].create(
+            {
+                "product_id": self.product_a.id,
+                "company_id": self.env.company.id,
+                "name": "CLEANUP_LOT",
+                "ref": "CLEANUP_LOT",
+            }
+        )
+        # Re-force qty to 1, as setting the lot resets qty to 0
+        cleanup_picking.move_line_ids.lot_id = cleanup_lot
+        cleanup_picking.move_line_ids.product_uom_qty = 1.0
+        params = {"barcode": "CLEANUP_LOT"}
+        response = self.service.dispatch("scan_deliver", params=params)
+        expected_body = (
+            f"Reserved for {cleanup_picking.picking_type_id.name} {cleanup_picking.name}"
+        )
+        self.assertEqual(response.get("message").get("body"), expected_body)
+
+    def test_scan_delivery_return_picking(self):
+        self.picking.action_cancel()
+        cleanup_picking = self._create_picking(
+            picking_type=self.cleanup_type, lines=[(self.product_c, 1)]
+        )
+        cleanup_picking.action_assign()
+        params = {"barcode": cleanup_picking.name}
+        response = self.service.dispatch("scan_deliver", params=params)
+        self.assert_response_deliver(
+            response,
+            message=self.service.msg_store.reserved_for_other_picking_type(
+                cleanup_picking
+            ),
         )
 
     def test_scan_deliver_picking_done(self):

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -445,6 +445,15 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         move_lines = pick.move_lines.mapped("move_line_ids")
         self._test_scan_set_done_ok(move_lines, self.product_c.barcode, [1])
 
+    def test_scan_deliver_picking_canceled(self):
+        self.picking.action_cancel()
+        params = {"barcode": self.picking.name}
+        response = self.service.dispatch("scan_deliver", params=params)
+        self.assert_response_deliver(
+            response,
+            message=self.service.msg_store.transfer_canceled(),
+        )
+
     def test_scan_deliver_picking_done(self):
         # Set qty done for all lines (packages/raw product/lot...), picking is
         # automatically set to done when the last line is completed

--- a/shopfloor/tests/test_delivery_set_qty_done_line.py
+++ b/shopfloor/tests/test_delivery_set_qty_done_line.py
@@ -50,7 +50,7 @@ class DeliverySetQtyDoneLineCase(DeliveryCommonCase):
         )
         self.assert_response_deliver(
             response,
-            message=self.service.msg_store.stock_picking_not_available(self.picking),
+            message=self.service.msg_store.transfer_canceled(),
         )
 
     def test_set_qty_done_line_line_not_found(self):

--- a/shopfloor/tests/test_delivery_set_qty_done_pack.py
+++ b/shopfloor/tests/test_delivery_set_qty_done_pack.py
@@ -65,7 +65,7 @@ class DeliverySetQtyDonePackCase(DeliveryCommonCase):
         )
         self.assert_response_deliver(
             response,
-            message=self.service.msg_store.stock_picking_not_available(self.picking),
+            message=self.service.msg_store.transfer_canceled(),
         )
 
     def test_set_qty_done_pack_package_not_found(self):

--- a/shopfloor/tests/test_location_content_transfer_start.py
+++ b/shopfloor/tests/test_location_content_transfer_start.py
@@ -273,6 +273,29 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
             message=self.service.msg_store.location_empty(self.content_loc),
         )
 
+    def test_scan_location_picking_already_started(self):
+        self.menu.sudo().allow_unreserve_other_moves = True
+        picking = self._create_picking(
+            picking_type=self.menu.picking_type_ids,
+            lines=[(self.product_a, 10), (self.product_b, 10)],
+        )
+        self._fill_stock_for_moves(
+            picking.move_lines, in_package=True, location=self.content_loc
+        )
+        picking.action_assign()
+        picking.move_line_ids[0].qty_done = 10
+        response = self.service.dispatch(
+            "scan_location", params={"barcode": self.content_loc.barcode}
+        )
+        self.assert_response_start(
+            response,
+            message=self.service.msg_store.picking_already_started_in_location(picking),
+        )
+        # check that the original moves are still assigned
+        self.assertRecordValues(
+            picking.move_lines, [{"state": "assigned"}, {"state": "assigned"}]
+        )
+
     def test_scan_location_wrong_picking_type_allow_unreserve_error(self):
         """Content has different picking type than menu, option to unreserve
 
@@ -296,7 +319,7 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
         )
         self.assert_response_start(
             response,
-            message=self.service.msg_store.picking_already_started_in_location(picking),
+            message=self.service.msg_store.reserved_for_other_picking_type(picking),
         )
         # check that the original moves are still assigned
         self.assertRecordValues(

--- a/shopfloor_checkout_package_measurement/services/checkout.py
+++ b/shopfloor_checkout_package_measurement/services/checkout.py
@@ -38,7 +38,7 @@ class Checkout(Component):
     ):
         """Set measurements on a package."""
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()

--- a/shopfloor_checkout_putinpack_restriction/services/checkout.py
+++ b/shopfloor_checkout_putinpack_restriction/services/checkout.py
@@ -16,8 +16,28 @@ class Checkout(Component):
             res["no_package_enabled"] = False
         return res
 
-    def _check_scan_package_find(self, picking, search_result):
-        if search_result.type in ["package", "delivery_packaging"]:
-            if picking.put_in_pack_restriction == "no_package":
-                return self.msg_store.package_not_allowed_for_operation()
-        return super()._check_scan_package_find(picking, search_result)
+    def _scan_package_action_from_package(
+        self, picking, selected_lines, record, **kwargs
+    ):
+        if picking.put_in_pack_restriction == "no_package":
+            return self._response_for_select_package(
+                picking,
+                selected_lines,
+                message=self.msg_store.package_not_allowed_for_operation(),
+            )
+        return super()._scan_package_action_from_package(
+            picking, selected_lines, record, **kwargs
+        )
+
+    def _scan_package_action_from_delivery_packaging(
+        self, picking, selected_lines, record, **kwargs
+    ):
+        if picking.put_in_pack_restriction == "no_package":
+            return self._response_for_select_package(
+                picking,
+                selected_lines,
+                message=self.msg_store.package_not_allowed_for_operation(),
+            )
+        return super()._scan_package_action_from_delivery_packaging(
+            picking, selected_lines, record, **kwargs
+        )

--- a/shopfloor_delivery_shipment/actions/message.py
+++ b/shopfloor_delivery_shipment/actions/message.py
@@ -168,3 +168,16 @@ class MessageAction(Component):
             "message_type": "info",
             "body": _("Shipment {} is validated.").format(shipment_advice.name),
         }
+
+    def package_partially_reserved_in_picking(self, pickings):
+        picking_names = ", ".join(pickings.mapped("name"))
+        body = _(
+            "Scanned barcode is partially reserved for multiple pickings "
+            "%(picking_names)s"
+        ) % {
+            "picking_names": picking_names,
+        }
+        return {
+            "message_type": "error",
+            "body": body,
+        }

--- a/shopfloor_delivery_shipment/services/delivery_shipment.py
+++ b/shopfloor_delivery_shipment/services/delivery_shipment.py
@@ -117,7 +117,7 @@ class DeliveryShipment(Component):
                 return self._response_for_scan_document(
                     shipment_advice, message=self.msg_store.stock_picking_not_found()
                 )
-            message = self._check_picking_status(picking, shipment_advice)
+            message = self._check_picking_processible(picking, shipment_advice)
             if message:
                 return self._response_for_scan_document(
                     shipment_advice, message=message
@@ -181,7 +181,7 @@ class DeliveryShipment(Component):
         If the shipment advice had planned content and that the scanned delivery
         is not part of it, returns an error message.
         """
-        message = self._check_picking_status(picking, shipment_advice)
+        message = self._check_picking_processible(picking, shipment_advice)
         if message:
             return self._response_for_scan_document(shipment_advice, message=message)
         else:
@@ -208,7 +208,9 @@ class DeliveryShipment(Component):
         )
         if move_lines:
             # Check transfer status
-            message = self._check_picking_status(move_lines.picking_id, shipment_advice)
+            message = self._check_picking_processible(
+                move_lines.picking_id, shipment_advice
+            )
             if message:
                 return self._response_for_scan_document(
                     shipment_advice,
@@ -262,7 +264,9 @@ class DeliveryShipment(Component):
         )
         if move_lines:
             # Check transfer status
-            message = self._check_picking_status(move_lines.picking_id, shipment_advice)
+            message = self._check_picking_processible(
+                move_lines.picking_id, shipment_advice
+            )
             if message:
                 return self._response_for_scan_document(
                     shipment_advice, location=location, message=message
@@ -327,7 +331,9 @@ class DeliveryShipment(Component):
         )
         if move_lines:
             # Check transfer status
-            message = self._check_picking_status(move_lines.picking_id, shipment_advice)
+            message = self._check_picking_processible(
+                move_lines.picking_id, shipment_advice
+            )
             if message:
                 return self._response_for_scan_document(
                     shipment_advice, message=message
@@ -841,9 +847,9 @@ class DeliveryShipment(Component):
             )
         return pickings_not_loaded
 
-    def _check_picking_status(self, pickings, shipment_advice):
+    def _check_picking_processible(self, pickings, shipment_advice):
         # Overloaded to add checks against a shipment advice
-        message = super()._check_picking_status(pickings)
+        message = super()._check_picking_processible(pickings)
         if message:
             return message
         for picking in pickings:

--- a/shopfloor_delivery_shipment/services/delivery_shipment.py
+++ b/shopfloor_delivery_shipment/services/delivery_shipment.py
@@ -206,6 +206,7 @@ class DeliveryShipment(Component):
         move_lines = self._find_move_lines_from_package(
             shipment_advice, package, picking, location
         )
+        # import pdb; pdb.set_trace()
         if move_lines:
             # Check transfer status
             message = self._check_picking_processible(
@@ -759,9 +760,20 @@ class DeliveryShipment(Component):
         self, shipment_advice, package, picking, location
     ):
         """Returns the move line corresponding to `package` for the given shipment."""
-        domain = self._find_move_lines_domain(shipment_advice)
         # FIXME should we check also result package here?
-        domain.append(("package_id", "=", package.id))
+        domain = [
+            ("state", "in", ("assigned", "partially_available")),
+            ("package_id", "=", package.id),
+            "|",
+            ("shipment_advice_id", "=", False),
+            ("shipment_advice_id", "=", shipment_advice.id),
+        ]
+        if shipment_advice.planned_move_ids:
+            domain.append(("move_id.shipment_advice_id", "=", shipment_advice.id))
+        else:
+            domain.append(
+                ("move_id.shipment_advice_id", "=", False),
+            )
         if location:
             domain.append(
                 ("location_id", "child_of", location.id),
@@ -847,9 +859,21 @@ class DeliveryShipment(Component):
             )
         return pickings_not_loaded
 
+    def _check_picking_type_unique(self, pickings, shipment_advice):
+        if len(pickings.picking_type_id) != 1:
+            # Check that pickings have the same picking type.
+            # This might happen if a sale order line is canceled while
+            # transfers are being processed.
+            # Package is ready to ship, but some products in it have to go back in
+            # stock.
+            return self.msg_store.package_partially_reserved_in_picking(pickings)
+
     def _check_picking_processible(self, pickings, shipment_advice):
-        # Overloaded to add checks against a shipment advice
+        message = self._check_picking_type_unique(pickings, shipment_advice)
+        if message:
+            return message
         message = super()._check_picking_processible(pickings)
+        # Overloaded to add checks against a shipment advice
         if message:
             return message
         for picking in pickings:

--- a/shopfloor_delivery_shipment/tests/test_delivery_shipment_base.py
+++ b/shopfloor_delivery_shipment/tests/test_delivery_shipment_base.py
@@ -20,6 +20,7 @@ class DeliveryShipmentCommonCase(common.CommonCase):
         cls.dock = cls.env.ref("shipment_advice.stock_dock_demo")
         cls.dock.sudo().barcode = "DOCK"
         cls.dock2 = cls.dock.sudo().copy({"barcode": "DOCK2"})
+        cls.loc_customers = cls.env.ref("stock.stock_location_customers")
 
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):

--- a/shopfloor_delivery_shipment/tests/test_delivery_shipment_scan_document_package.py
+++ b/shopfloor_delivery_shipment/tests/test_delivery_shipment_scan_document_package.py
@@ -1,5 +1,7 @@
 # Copyright 2021 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo import fields
+
 from .test_delivery_shipment_base import DeliveryShipmentCommonCase
 
 
@@ -144,6 +146,97 @@ class DeliveryShipmentScanDocumentPackageCase(DeliveryShipmentCommonCase):
         self.assertEqual(
             content[location_src]["package_levels"],
             self.service.data.package_levels(package_level),
+        )
+
+    @classmethod
+    def _create_picking_chain(cls, wh, products):
+        if products is None:
+            products = []
+        group = cls.env["procurement.group"].create(
+            {
+                "name": "TEST",
+                "move_type": "direct",
+                "partner_id": cls.customer.id,
+            }
+        )
+        values = {
+            "company_id": wh.company_id,
+            "group_id": group,
+            "date_planned": fields.Datetime.now(),
+            "warehouse_id": wh,
+        }
+        for product, qty in products:
+            uom = product.uom_id
+            cls.env["procurement.group"].run(
+                [
+                    cls.env["procurement.group"].Procurement(
+                        product,
+                        qty,
+                        uom,
+                        cls.loc_customers,
+                        "TEST",
+                        "TEST",
+                        wh.company_id,
+                        values,
+                    )
+                ]
+            )
+        return cls.env["stock.picking"].search([("group_id", "=", group.id)])
+
+    def test_scan_document_package_partially_reserved(self):
+        wh = self.wh
+        wh.sudo().delivery_steps = "pick_ship"
+        pickings = self._create_picking_chain(
+            wh, [(self.product_a, 10.0), (self.product_b, 10.0)]
+        )
+        out_picking = pickings.filtered(lambda p: p.picking_type_id.code == "outgoing")
+        pick_picking = pickings.filtered(lambda p: p.picking_type_id.code == "internal")
+        package = self.env["stock.quant.package"].create({})
+        self._fill_stock_for_moves(pick_picking.move_lines, in_package=package)
+        pick_picking.action_assign()
+        for move in pick_picking.move_lines:
+            move.quantity_done = move.product_uom_qty
+            move.move_line_ids.qty_done = move.product_uom_qty
+        pick_picking._action_done()
+        # create shipment
+        shipment = self._create_shipment()
+        # Create return for product a
+        move_a = pick_picking.move_lines.filtered(
+            lambda m: m.product_id == self.product_a
+        )
+        wiz_vals = {
+            "picking_id": pick_picking.id,
+            "location_id": pick_picking.location_id.id,
+            "product_return_moves": [
+                (
+                    0,
+                    0,
+                    {
+                        "product_id": move_a.product_id.id,
+                        "quantity": move_a.quantity_done,
+                        "uom_id": move_a.product_uom.id,
+                        "move_id": move_a.id,
+                    },
+                )
+            ],
+        }
+        wiz = self.env["stock.return.picking"].create(wiz_vals)
+        res = wiz.create_returns()
+        return_picking = self.env["stock.picking"].browse(res["res_id"])
+        # Try to ship the goods, it should be prevented
+        response = self.service.dispatch(
+            "scan_document",
+            params={
+                "shipment_advice_id": shipment.id,
+                "barcode": package.name,
+            },
+        )
+        self.assert_response_scan_document(
+            response,
+            shipment,
+            message=self.service.msg_store.package_partially_reserved_in_picking(
+                return_picking | out_picking
+            ),
         )
 
     def test_scan_document_shipment_not_planned_package_planned(self):

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -48,13 +48,13 @@ class Reception(Component):
     _usage = "reception"
     _description = __doc__
 
-    def _check_picking_status(self, pickings):
+    def _check_picking_processible(self, pickings):
         # When returns are allowed,
         # the created picking might be empty and cannot be assigned.
         states = ["assigned"]
         if self.work.menu.allow_return:
             states.append("draft")
-        return super()._check_picking_status(pickings, states=states)
+        return super()._check_picking_processible(pickings, states=states)
 
     def _move_line_by_product(self, product):
         return self.env["stock.move.line"].search(
@@ -328,7 +328,7 @@ class Reception(Component):
                 message=self.msg_store.cannot_move_something_in_picking_type()
             )
         if reception_pickings:
-            message = self._check_picking_status(reception_pickings)
+            message = self._check_picking_processible(reception_pickings)
             if message:
                 return self._response_for_select_document(
                     pickings=reception_pickings, message=message
@@ -939,7 +939,7 @@ class Reception(Component):
           - set_quantity: Packaging / Product has been scanned. Not tracked product
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_move(picking, message=message)
         handlers_by_type = {
@@ -973,7 +973,7 @@ class Reception(Component):
           - select_document: Mark as done
         """
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_move(picking, message=message)
         if all(line.qty_done == 0 for line in picking.move_line_ids):
@@ -1029,7 +1029,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_lot(picking, selected_line, message=message)
         if not selected_line.exists():
@@ -1060,7 +1060,7 @@ class Reception(Component):
 
     def set_lot_confirm_action(self, picking_id, selected_line_id):
         picking = self.env["stock.picking"].browse(picking_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
         if message:
             return self._response_for_set_lot(picking, selected_line, message=message)
@@ -1145,7 +1145,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1174,7 +1174,7 @@ class Reception(Component):
     def set_quantity__cancel_action(self, picking_id, selected_line_id):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1212,7 +1212,7 @@ class Reception(Component):
     def process_with_existing_pack(self, picking_id, selected_line_id, quantity):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1227,7 +1227,7 @@ class Reception(Component):
     def process_with_new_pack(self, picking_id, selected_line_id, quantity):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1243,7 +1243,7 @@ class Reception(Component):
     def process_without_pack(self, picking_id, selected_line_id, quantity):
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_quantity(
                 picking, selected_line, message=message
@@ -1337,7 +1337,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_set_destination(
                 picking, selected_line, message=message
@@ -1399,7 +1399,7 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
-        message = self._check_picking_status(picking)
+        message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_dest_package(
                 picking, selected_line, message=message

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -412,7 +412,7 @@ class Reception(Component):
         # If we have an origin picking but no origin move, then user
         # scanned a wrong product. Warn him about this.
         if origin_moves and not origin_moves_for_product:
-            message = self.msg_store.product_not_found_in_current_picking()
+            message = self.msg_store.product_not_found_in_current_picking(product)
             return self._response_for_select_move(picking, message=message)
         if origin_moves_for_product:
             return_move = self._scan_line__create_return_move(

--- a/shopfloor_reception/tests/test_return_scan_line.py
+++ b/shopfloor_reception/tests/test_return_scan_line.py
@@ -22,7 +22,7 @@ class TestScanLineReturn(CommonCaseReturn):
             data={"picking": self._data_for_picking_with_moves(return_picking)},
             message={
                 "message_type": "error",
-                "body": "Product is not in the current transfer.",
+                "body": f"Product {wrong_product.name} is not in the current transfer.",
             },
         )
 

--- a/shopfloor_single_product_transfer/services/single_product_transfer.py
+++ b/shopfloor_single_product_transfer/services/single_product_transfer.py
@@ -5,6 +5,7 @@
 import logging
 from functools import wraps
 
+from odoo import fields
 from odoo.osv.expression import AND
 from odoo.tools import float_compare
 
@@ -292,14 +293,25 @@ class ShopfloorSingleProductTransfer(Component):
         self, product, location=None, package=None, lot=None, packaging=None
     ):
         unreserve = self._actions_for("stock.unreserve")
+        move_lines = self._find_location_or_package_move_lines(
+            product, location=location, package=package, lot=lot
+        )
         if self.work.menu.allow_unreserve_other_moves:
-            move_lines = self._find_location_or_package_move_lines(
-                product, location=location, package=package, lot=lot
-            )
             response = unreserve.check_unreserve(location, move_lines, product, lot)
             if response:
                 return response
             unreserve.unreserve_moves(move_lines, self.picking_types)
+        elif move_lines:
+            # This happens when unreserve disallowed, but goods are reserved
+            # for another operation
+            return self._scan_product__product_reserved_by_another_operation(
+                product,
+                fields.first(move_lines.picking_id),
+                location=location,
+                package=package,
+                lot=lot,
+                packaging=packaging,
+            )
         else:
             # If we get there then no qty is available, and we are not allowed to unreserve
             # other moves. No stock available for product.
@@ -342,6 +354,14 @@ class ShopfloorSingleProductTransfer(Component):
             if response:
                 return response
             return self._response_for_set_quantity(move_line)
+
+    def _scan_product__product_reserved_by_another_operation(
+        self, product, picking, location=None, package=None, lot=None, packaging=None
+    ):
+        message = self.msg_store.reserved_for_other_picking_type(picking)
+        return self._response_for_select_product(
+            location=location, package=package, message=message
+        )
 
     def _scan_product__no_stock_available(
         self, product, location=None, package=None, lot=None, packaging=None

--- a/shopfloor_single_product_transfer/tests/test_scan_product.py
+++ b/shopfloor_single_product_transfer/tests/test_scan_product.py
@@ -165,6 +165,25 @@ class TestScanProduct(CommonCase):
         }
         self.assert_response(response, next_state="set_quantity", data=data)
 
+    def test_scan_product_no_stock(self):
+        location = self.location_src
+        product = self.product_a
+        with self.assertLogs(LOGGER_NAME) as log_catcher:
+            response = self.service.dispatch(
+                "scan_product",
+                params={"location_id": location.id, "barcode": product.barcode},
+            )
+            self.assertIn(ROLLBACK_LOG, log_catcher.output)
+        self.assertFalse(self.get_new_move_line())
+        expected_message = {
+            "message_type": "error",
+            "body": "No operation found for this menu and profile.",
+        }
+        data = {"location": self._data_for_location(location)}
+        self.assert_response(
+            response, next_state="select_product", message=expected_message, data=data
+        )
+
     def test_scan_product_with_reserved_stock_unreserve_move_disabled(self):
         # No move with product in location, create move line is enabled but
         # there's no stock.
@@ -174,7 +193,7 @@ class TestScanProduct(CommonCase):
         self._add_stock_to_product(product, location, 10)
         self._enable_create_move_line()
         # This picking has reserved the only available goods
-        self._create_picking(
+        other_picking = self._create_picking(
             lines=[(product, 10)], picking_type=self.other_picking_type
         )
         with self.assertLogs(LOGGER_NAME) as log_catcher:
@@ -186,7 +205,7 @@ class TestScanProduct(CommonCase):
         self.assertFalse(self.get_new_move_line())
         expected_message = {
             "message_type": "error",
-            "body": "No operation found for this menu and profile.",
+            "body": f"Reserved for {self.other_picking_type.name} {other_picking.name}",
         }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
@@ -313,7 +332,7 @@ class TestScanProduct(CommonCase):
         lot = self._create_lot_for_product(product, "LOT_BARCODE")
         self._add_stock_to_product(product, location, 10, lot=lot)
         # This picking has reserved the only available goods
-        self._create_picking(
+        other_picking = self._create_picking(
             lines=[(product, 10)], picking_type=self.other_picking_type
         )
         with self.assertLogs(LOGGER_NAME) as log_catcher:
@@ -324,7 +343,7 @@ class TestScanProduct(CommonCase):
         self.assertFalse(self.get_new_move_line())
         expected_message = {
             "message_type": "error",
-            "body": "No operation found for this menu and profile.",
+            "body": f"Reserved for {self.other_picking_type.name} {other_picking.name}",
         }
         data = {"location": self._data_for_location(location)}
         self.assert_response(


### PR DESCRIPTION
Attempt to make shopfloor messages more meaningful, especially when scanning an unexpected record.
The general idea is too avoid those `barcode not found` errors in cases where the barcode was found, but not relevant.

Relates to:
 -  https://github.com/OCA/wms/pull/971
 
Supersedes:
 - https://github.com/OCA/wms/pull/983
 - https://github.com/OCA/wms/pull/972