### PR TITLE
[14.0][IMP] delivery_carrier_preference: Do not align group carrier

### DIFF
--- a/delivery_carrier_preference/models/stock_picking.py
+++ b/delivery_carrier_preference/models/stock_picking.py
@@ -39,7 +39,9 @@ class StockPicking(models.Model):
                 }
             }
         else:
-            self.carrier_id = carrier
+            # Set a context key to not trigger a carrier change on the
+            # procurement group.
+            self.with_context(skip_align_group_carrier=True).carrier_id = carrier
 
     def get_preferred_carriers(self):
         # TODO Check possible conflicting settings between doc company and


### PR DESCRIPTION
As stated by @jbaudoux on this PR https://github.com/OCA/stock-logistics-workflow/pull/1895
After it is merged, procurement group carrier will be aligned when picking carrier will be updated.
This feature is incompatible with delivery_carrier_preference.
Add a context key to disable the feature.