### PR TITLE
[16.0][IMP] stock_release_channel_partner_by_date: add check_late parameter on _get_release_channel_partner_date_domain

### DIFF
--- a/stock_release_channel_partner_by_date/models/stock_picking.py
+++ b/stock_release_channel_partner_by_date/models/stock_picking.py
@@ -9,9 +9,12 @@ from odoo.osv import expression
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    def _get_release_channel_partner_date_domain(self):
+    def _get_release_channel_partner_date_domain(self, check_late=True):
         assert self.scheduled_date
-        scheduled_date = max(self.scheduled_date, fields.Datetime.now())
+        if check_late:
+            scheduled_date = max(self.scheduled_date, fields.Datetime.now())
+        else:
+            scheduled_date = self.scheduled_date
         tz = (
             self.picking_type_id.warehouse_id.partner_id.tz
             or self.env.company.partner_id.tz


### PR DESCRIPTION
Add optional parameter `check_late` `_get_release_channel_partner_date_domain`. It allows to search for release channels to process picking that are late => `max(self.scheduled_date, fields.Datetime.now())`
or for the effective scheduled_date => `self.scheduled_date`