### PR TITLE
[16.0][FIX] stock_release_channel_partner_by_date: properly detect the exception

### DIFF
--- a/sale_stock_release_channel_partner_by_date_delivery/tests/test_sale_release_channel.py
+++ b/sale_stock_release_channel_partner_by_date_delivery/tests/test_sale_release_channel.py
@@ -12,12 +12,14 @@ class TestSaleReleaseChannel(SaleReleaseChannelCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.wh = cls.env.ref("stock.warehouse0")
         cls.carrier = cls.env.ref("delivery.delivery_carrier")
         cls.carrier2 = cls.env.ref("delivery.delivery_local_delivery")
         cls.carrier_channel = cls.default_channel.copy(
             {
                 "name": "Test with carrier",
                 "sequence": 10,
+                "warehouse_id": cls.wh.id,
                 "carrier_ids": [(6, 0, cls.carrier.ids)],
             }
         )

--- a/stock_release_channel/models/stock_picking.py
+++ b/stock_release_channel/models/stock_picking.py
@@ -108,19 +108,33 @@ class StockPicking(models.Model):
         )
 
     def _get_release_channel_possible_candidate_domain_channel(self):
+        """Domain for finding channel candidates based on channel.
+
+        The condition is defined by the channel.
+        """
         return [
             ("is_manual_assignment", "=", False),
             ("state", "!=", "asleep"),
-        ]
-
-    def _get_release_channel_possible_candidate_domain_picking(self):
-        return [
-            ("company_id", "=", self.company_id.id),
             "|",
             ("picking_type_ids", "=", False),
             ("picking_type_ids", "in", self.picking_type_id.ids),
+        ]
+
+    def _get_release_channel_possible_candidate_domain_picking(self):
+        """Domain for finding channel candidates based on picking.
+
+        The condition is defined by the picking.
+        """
+        # when a warehouse is defined on the channel, it must always match
+        # otherwise fallback on the picking type
+        return [
+            ("company_id", "=", self.company_id.id),
             "|",
+            "&",
             ("warehouse_id", "=", False),
+            "|",
+            ("picking_type_ids", "=", False),
+            ("picking_type_ids", "in", self.picking_type_id.ids),
             ("warehouse_id", "=", self.picking_type_id.warehouse_id.id),
         ]
 

--- a/stock_release_channel_partner_by_date/tests/common.py
+++ b/stock_release_channel_partner_by_date/tests/common.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Camptocamp SA
+# Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+
+from odoo.addons.stock_release_channel.tests.test_release_channel_partner import (
+    ReleaseChannelPartnerCommon,
+)
+
+
+class ReleaseChannelPartnerDateCommon(ReleaseChannelPartnerCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.delivery_date_channel = cls.partner_channel.copy(
+            {
+                "name": "Specific Date Channel",
+                "warehouse_id": cls.wh.id,
+            }
+        )
+
+    def _create_channel_partner_date(self, channel, partner, date):
+        rc_date_model = self.env["stock.release.channel.partner.date"]
+        return rc_date_model.create(
+            {
+                "partner_id": partner.id,
+                "release_channel_id": channel.id,
+                "date": date,
+            }
+        )

--- a/stock_release_channel_partner_by_date/tests/test_release_channel_partner_date.py
+++ b/stock_release_channel_partner_by_date/tests/test_release_channel_partner_date.py
@@ -14,7 +14,10 @@ class TestReleaseChannelPartnerDate(ReleaseChannelPartnerCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.delivery_date_channel = cls.partner_channel.copy(
-            {"name": "Specific Date Channel"}
+            {
+                "name": "Specific Date Channel",
+                "warehouse_id": cls.wh.id,
+            }
         )
 
     def _create_channel_partner_date(self, channel, partner, date):
@@ -53,3 +56,21 @@ class TestReleaseChannelPartnerDate(ReleaseChannelPartnerCommon):
         self.assertTrue(channel_date.active)
         self.delivery_date_channel.action_sleep()
         self.assertFalse(channel_date.active)
+
+    def test_release_channel_on_specific_date_not_available(self):
+        """Test that when no release channel is available to satisfy
+        a specific partner date,no fallback release channel is
+        proposed."""
+        # Exclude delivery channel from possible candidates
+        self.delivery_date_channel.picking_type_ids = self.env[
+            "stock.picking.type"
+        ].search([("id", "!=", self.move.picking_id.picking_type_id.id)], limit=1)
+        scheduled_date = fields.Datetime.now()
+        self._create_channel_partner_date(
+            self.delivery_date_channel,
+            self.partner,
+            scheduled_date,
+        )
+        self.move.picking_id.scheduled_date = scheduled_date
+        self.move.picking_id.assign_release_channel()
+        self.assertFalse(self.move.picking_id.release_channel_id)

--- a/stock_release_channel_partner_by_date/tests/test_release_channel_partner_date.py
+++ b/stock_release_channel_partner_by_date/tests/test_release_channel_partner_date.py
@@ -4,32 +4,10 @@
 
 from odoo import fields
 
-from odoo.addons.stock_release_channel.tests.test_release_channel_partner import (
-    ReleaseChannelPartnerCommon,
-)
+from .common import ReleaseChannelPartnerDateCommon
 
 
-class TestReleaseChannelPartnerDate(ReleaseChannelPartnerCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.delivery_date_channel = cls.partner_channel.copy(
-            {
-                "name": "Specific Date Channel",
-                "warehouse_id": cls.wh.id,
-            }
-        )
-
-    def _create_channel_partner_date(self, channel, partner, date):
-        rc_date_model = self.env["stock.release.channel.partner.date"]
-        return rc_date_model.create(
-            {
-                "partner_id": partner.id,
-                "release_channel_id": channel.id,
-                "date": date,
-            }
-        )
-
+class TestReleaseChannelPartnerDate(ReleaseChannelPartnerDateCommon):
     def test_release_channel_on_specific_date(self):
         """partner specific date release channel is higher priority than other channels"""
         self.delivery_date_channel.action_wake_up()

--- a/stock_release_channel_shipment_lead_time/models/stock_picking.py
+++ b/stock_release_channel_shipment_lead_time/models/stock_picking.py
@@ -7,9 +7,9 @@ from odoo import api, fields, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    def _get_release_channel_possible_candidate_domain_picking(self):
+    def _get_release_channel_possible_candidate_domain_channel(self):
         # Exclude deliveries (OUT pickings) when the date_deadline is after the shipment date
-        domain = super()._get_release_channel_possible_candidate_domain_picking()
+        domain = super()._get_release_channel_possible_candidate_domain_channel()
 
         date = self.date_deadline
         if date:


### PR DESCRIPTION
Fixing compatibility with:
* stock_release_channel_shipment_lead_time
* stock_release_channel_partner_public_holidays
  * was already good
  * Added test for compatibility in:
    * https://github.com/OCA/wms/pull/1033

cc @sebalix @santostelmo 