### PR TITLE
[16.0][IMP] shopfloor: Add a parser to searches

### DIFF
--- a/shopfloor/actions/__init__.py
+++ b/shopfloor/actions/__init__.py
@@ -1,3 +1,4 @@
+from . import barcode_parser
 from . import change_package_lot
 from . import data
 from . import data_detail

--- a/shopfloor/actions/barcode_parser.py
+++ b/shopfloor/actions/barcode_parser.py
@@ -1,0 +1,44 @@
+# Copyright 2025 ACSONE SA/NV (https://www.acsone.eu)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.addons.component.core import Component
+
+from ..actions.search import SearchAction
+
+
+class BarcodeResult:
+
+    __slots__ = ("type", "value", "raw")
+
+    def __init__(self, **kw) -> None:
+        for k in self.__slots__:
+            setattr(self, k, kw.get(k))
+
+
+class BarcodeParser(Component):
+    """
+    Some barcodes can have complex data structure
+    """
+
+    _name = "shopfloor.barcode.parser"
+    _inherit = "shopfloor.process.action"
+    _usage = "barcode"
+
+    def __init__(self, search_action: SearchAction):
+        # Get search action keys
+        self.search_action = search_action
+
+    @property
+    def _authorized_barcode_types(self):
+        return self.search_action._barcode_type_handler.keys()
+
+    def parse(self, barcode) -> list[BarcodeResult]:
+        """
+        This method will parse the barcode and return the
+        value with its type if determined.
+
+        Override this to implement specific parsing
+
+        """
+
+        return [BarcodeResult(type="unknown", value=barcode, raw=barcode)]

--- a/shopfloor/actions/barcode_parser.py
+++ b/shopfloor/actions/barcode_parser.py
@@ -32,7 +32,7 @@ class BarcodeParser(Component):
     def _authorized_barcode_types(self):
         return self.search_action._barcode_type_handler.keys()
 
-    def parse(self, barcode) -> list[BarcodeResult]:
+    def parse(self, barcode, types) -> list[BarcodeResult]:
         """
         This method will parse the barcode and return the
         value with its type if determined.

--- a/shopfloor/actions/search.py
+++ b/shopfloor/actions/search.py
@@ -57,6 +57,8 @@ class SearchAction(Component):
             "packaging": self.packaging_from_scan,
             "delivery_packaging": self.delivery_packaging_from_scan,
             "origin_move": self.origin_move_from_scan,
+            # Extra data can be contained in barcodes
+            "expiration_date": self.dummy_from_scan,
         }
 
     def _make_search_result(self, **kwargs):
@@ -188,3 +190,6 @@ class SearchAction(Component):
         if extra_domain:
             outgoing_move_domain = AND([outgoing_move_domain, extra_domain])
         return model.search(outgoing_move_domain)
+
+    def dummy_from_scan(self, barcode):
+        return None

--- a/shopfloor/actions/search.py
+++ b/shopfloor/actions/search.py
@@ -8,7 +8,8 @@ from odoo.addons.component.core import Component
 
 
 class SearchResult:
-    __slots__ = ("record", "type", "code")
+
+    __slots__ = ("record", "type", "code", "parse_result")
 
     def __init__(self, **kw) -> None:
         for k in self.__slots__:
@@ -43,6 +44,12 @@ class SearchAction(Component):
     """
 
     _inherit = "shopfloor.search.action"
+
+    @property
+    def parser(self):
+        parser = self._actions_for("barcode")
+        parser.search_action = self
+        return parser
 
     @property
     def _barcode_type_handler(self):
@@ -87,11 +94,20 @@ class SearchAction(Component):
     def generic_find(self, barcode, types=None, handler_kw=None):
         _types = types or self._barcode_type_handler.keys()
         # TODO: decide the best default order in case we don't pass `types`
-        for btype in _types:
-            record = self._find_record_by_type(barcode, btype, handler_kw)
-            if record:
-                return self._make_search_result(record=record, code=barcode, type=btype)
-        return self._make_search_result(type="none")
+        parse_results = self.parser.parse(barcode, types)
+        for parse_result in parse_results:
+            for btype in _types:
+                record = self._find_record_by_type(
+                    parse_result.value, btype, handler_kw
+                )
+                if record:
+                    return self._make_search_result(
+                        record=record,
+                        code=barcode,
+                        type=btype,
+                        parse_result=parse_results,
+                    )
+        return self._make_search_result(type="none", parse_result=parse_results)
 
     def location_from_scan(self, barcode, limit=1):
         model = self.env["stock.location"]

--- a/shopfloor/actions/search.py
+++ b/shopfloor/actions/search.py
@@ -65,7 +65,7 @@ class SearchAction(Component):
             "delivery_packaging": self.delivery_packaging_from_scan,
             "origin_move": self.origin_move_from_scan,
             # Extra data can be contained in barcodes
-            "expiration_date": self.dummy_from_scan,
+            "expiration_date": self.expiration_date_from_scan,
         }
 
     def _make_search_result(self, **kwargs):
@@ -208,4 +208,8 @@ class SearchAction(Component):
         return model.search(outgoing_move_domain)
 
     def dummy_from_scan(self, barcode):
+        return None
+
+    def expiration_date_from_scan(self, barcode):
+        # TODO
         return None


### PR DESCRIPTION
In some flows like GS1, a barcode representation can contain multiple content (e.g.: product, lot, expiration date, ...).

In current flows, we allow only one record return from the searches based on barcode scan.

In order to change the behavior when some extra data is found in barcodes, we add the parsed result in the search result.

e.g.: For reception flows, if we scan a GS1 and the lot is not found, we want to pre-fill expiration date for instance

