### PR TITLE
[14.0][FIX] stock_warehouse_flow: fix empty picking

### DIFF
--- a/stock_warehouse_flow/models/stock_move.py
+++ b/stock_warehouse_flow/models/stock_move.py
@@ -26,6 +26,7 @@ class StockMove(models.Model):
         # its chained moves (if any)
         FLOW = self.env["stock.warehouse.flow"]
         move_ids_to_confirm = []
+        old_pickings = self.picking_id
         for move in self:
             if not move._apply_flow_on_action_confirm():
                 move_ids_to_confirm.append(move.id)
@@ -36,6 +37,14 @@ class StockMove(models.Model):
                 move, assign_picking=False
             ).ids
         moves_to_confirm = self.browse(move_ids_to_confirm)
-        return super(StockMove, moves_to_confirm)._action_confirm(
+        res = super(StockMove, moves_to_confirm)._action_confirm(
             merge=merge, merge_into=merge_into
         )
+        # In case the move was already assigned to a picking and action_confirm
+        # was called again, with the flow it may have changed the conditions
+        # and assigned to a different picking. If the initial picking is empty,
+        # marked it as canceled.
+        for old_picking in old_pickings:
+            if not old_picking.move_lines:
+                old_picking.action_cancel()
+        return res

--- a/stock_warehouse_flow/models/stock_warehouse_flow.py
+++ b/stock_warehouse_flow/models/stock_warehouse_flow.py
@@ -555,9 +555,10 @@ class StockWarehouseFlow(models.Model):
         move.rule_id = rule
         if assign_picking:
             move._assign_picking()
-            # If all moves are moved to another picking, we can unlink the old one.
+            # If all moves are moved to another picking, the old picking will
+            # be draft. Force it to cancel.
             if not old_picking.move_lines:
-                old_picking.state = "cancel"
+                old_picking.action_cancel()
 
     def write(self, vals):
         res = super().write(vals)

--- a/stock_warehouse_flow/tests/test_warehouse_flow.py
+++ b/stock_warehouse_flow/tests/test_warehouse_flow.py
@@ -92,7 +92,6 @@ class TestWarehouseFlow(common.CommonFlow):
 
     def test_disable_flow_at_move_confirm(self):
         flow = self._get_flow("pick_ship")
-        # It is False by default
         flow.impacted_route_ids.apply_flow_on = False
         moves_before = self.env["stock.move"].search([])
         self._run_procurement(self.product, 10, flow.carrier_ids)
@@ -100,6 +99,22 @@ class TestWarehouseFlow(common.CommonFlow):
         move_ship = moves.filtered(lambda m: m.picking_type_id.code == "outgoing")
         # ensure new move doesn't have flow.to_picking_type_id as picking type
         self.assertNotEqual(move_ship.picking_type_id, flow.to_picking_type_id)
+
+    def test_change_flow_at_move_reconfirm(self):
+        """Test there is no draft empty picking when the move is reassigned"""
+        flow = self._get_flow("pick_ship")
+        flow.impacted_route_ids.apply_flow_on = False
+        moves_before = self.env["stock.move"].search([])
+        self._run_procurement(self.product, 10, flow.carrier_ids)
+        moves = self.env["stock.move"].search([("id", "not in", moves_before.ids)])
+        move_ship = moves.filtered(lambda m: m.picking_type_id.code == "outgoing")
+        self.assertNotEqual(move_ship.picking_type_id, flow.to_picking_type_id)
+        old_picking = move_ship.picking_id
+        flow.impacted_route_ids.apply_flow_on = "on_confirm"
+        move_ship._action_confirm()
+        self.assertEqual(move_ship.picking_type_id, flow.to_picking_type_id)
+        self.assertNotEqual(move_ship.picking_id, old_picking)
+        self.assertEqual(old_picking.state, "cancel")
 
     def test_no_rule_found_on_delivery_route(self):
         flow = self._get_flow("pick_ship")


### PR DESCRIPTION
If the initial picking gets emptied, mark as cancel

This was lacking on action_confirm as flow is called with no assign

cc @mmequignon @mt-software-de 