### PR TITLE
[14.0][BACKPORT] stock_available_to_promise_release : backport fixes for unrelease from 16.0

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -741,6 +741,17 @@ class StockMove(models.Model):
                 if float_is_zero(qty_to_return, precision_rounding=rounding):
                     continue
                 done_moves = origin_moves.filtered(lambda m: m.state == "done")
+                # in case of canceled origin_moves, the quantity to return must
+                # be limited to the quantity not consumed
+                done_dest_moves = done_moves.move_dest_ids.filtered(
+                    lambda m: m.state == "done"
+                )
+                returnable_qty = sum(done_moves.mapped("product_qty")) - sum(
+                    done_dest_moves.mapped("product_qty")
+                )
+                qty_to_return = min(qty_to_return, returnable_qty)
+                if float_compare(qty_to_return, 0, precision_rounding=rounding) <= 0:
+                    continue
                 if not move.rule_id.allow_unrelease_return_done_move:
                     # Without allow_unrelease_return_done_move enabled,
                     # only moves that aren't done can be unreleased.

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -622,9 +622,11 @@ class StockMove(models.Model):
         The loop into the iterator is the current moves.
         """
         moves = self
+        visited_moves = self.browse()
         while moves:
             yield moves
-            moves = moves.mapped(chain_field)
+            visited_moves += moves
+            moves = moves.mapped(chain_field) - visited_moves
 
     def _return_quantity_in_stock(self, qty_to_return_per_move):
         """Return a quantity from a list of moves.

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -12,6 +12,8 @@ from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import date_utils, float_compare, float_is_zero, float_round, groupby
 
+from odoo.addons.stock.models.stock_move import StockMove as StockMoveBase
+
 _logger = logging.getLogger(__name__)
 
 
@@ -90,24 +92,24 @@ class StockMove(models.Model):
             and self.rule_id.available_to_promise_defer_pull
         )
 
-    def _in_progress_for_unrelease(self) -> bool:
+    def _in_progress_for_unrelease(self) -> StockMoveBase:
         """
-        This method will return True if a move :
+        This method will return the moves not done or canceled that :
 
-        - is not done or canceled
-        - and if the move's picking is not printed
-        - and the move has no quantity done.
+        - have their picking printed
+        - have a quantity done != 0
 
         """
         moves = self.filtered(lambda m: m.state not in ("done", "cancel"))
         if not moves:
-            return False
-        picking_ids = moves.mapped("picking_id")
-        if picking_ids.filtered("printed"):
-            return True
-        if any(move.quantity_done for move in moves):
-            return False
-        return False
+            return moves
+        moves_printed = moves.filtered("picking_id.printed")
+        if moves_printed:
+            return moves_printed
+        moves_done = moves.filtered("quantity_done")
+        if moves_done:
+            return moves_done
+        return moves.browse()
 
     def _is_unrelease_allowed_on_origin_moves(self, origin_moves):
         """We check that the origin moves are in a state that allows the unrelease

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -66,9 +66,8 @@ class StockMove(models.Model):
                 iterator = move._get_chained_moves_iterator("move_orig_ids")
                 next(iterator)  # skip the current move
                 for origin_moves in iterator:
-                    unrelease_allowed = not origin_moves._in_progress_for_unrelease()
                     unrelease_allowed = (
-                        unrelease_allowed
+                        not origin_moves._in_progress_for_unrelease()
                         and move._is_unrelease_allowed_on_origin_moves(origin_moves)
                     )
                     if not unrelease_allowed:
@@ -148,14 +147,11 @@ class StockMove(models.Model):
             <= 0
         )
 
-    def _check_unrelease_allowed(self):
-        forbidden_moves = self.filtered(lambda m: not m.unrelease_allowed)
-        if not forbidden_moves:
-            return
+    def _unrelease_not_allowed_error(self):
         message = _("You are not allowed to unrelease those deliveries:\n")
 
         for picking, forbidden_moves_by_picking in groupby(
-            forbidden_moves, lambda m: m.picking_id
+            self, lambda m: m.picking_id
         ):
             forbidden_moves_by_picking = self.browse().concat(
                 *forbidden_moves_by_picking
@@ -716,7 +712,7 @@ class StockMove(models.Model):
         return returnable_qty
 
     def unrelease(self, safe_unrelease=False):
-        """Unrelease unreleasavbe moves
+        """Unrelease unreleasable moves
 
         If safe_unrelease is True, the unreleasaable moves for which the
         processing has already started will be ignored
@@ -724,7 +720,9 @@ class StockMove(models.Model):
         moves_to_unrelease = self.filtered(lambda m: m._is_unreleaseable())
         if safe_unrelease:
             moves_to_unrelease = self.filtered("unrelease_allowed")
-        moves_to_unrelease._check_unrelease_allowed()
+        forbidden_moves = moves_to_unrelease.filtered(lambda m: not m.unrelease_allowed)
+        if forbidden_moves:
+            forbidden_moves._unrelease_not_allowed_error()
         moves_to_unrelease.write({"need_release": True})
 
         qty_to_return_per_move = defaultdict(float)

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -56,7 +56,7 @@ class StockMove(models.Model):
     zip_code = fields.Char(related="partner_id.zip", store=True)
     city = fields.Char(related="partner_id.city", store=True)
 
-    @api.depends("rule_id", "rule_id.available_to_promise_defer_pull")
+    @api.depends("need_release", "rule_id", "rule_id.available_to_promise_defer_pull")
     def _compute_unrelease_allowed(self):
         for move in self:
             unrelease_allowed = move._is_unreleaseable()
@@ -91,35 +91,47 @@ class StockMove(models.Model):
     def _is_unrelease_allowed_on_origin_moves(self, origin_moves):
         """We check that the origin moves are in a state that allows the unrelease
         of the current move. At this stage, a move can't be unreleased if
-          * a picking is already printed. (The work on the picking is planed and
-            we don't want to change it)
-          * the processing of the origin moves is partially started.
+        the processed origin moves is not consumed by the dest moves.
         """
         self.ensure_one()
-        pickings = origin_moves.mapped("picking_id")
-        ongoing_pickings = pickings.filtered(
-            lambda p: p.printed and p.state not in ("cancel", "done")
+        open_origin_moves = origin_moves.filtered(
+            lambda m: m.state not in ("done", "cancel")
         )
-        if ongoing_pickings:
-            # The picking is either printed or done/cancelled.
-            # We can't unrelease the move because the processing of the origin moves
-            # is either started or done.
+        pickings = open_origin_moves.mapped("picking_id")
+        if pickings.filtered("printed"):
+            # The picking is printed, we can't unrelease the move
+            # because the processing of the origin moves is started.
             return False
-        # If allow_unrelease_on_cancel is not checked, only release assigned/waiting
-        # moves. If checked, also unrelease done moves.
+        if any(m.quantity_done for m in open_origin_moves):
+            # The origin move is being processed, we can't unrelease the move
+            return False
+        origin_done_moves = origin_moves.filtered(lambda m: m.state == "done")
         if self.rule_id.allow_unrelease_return_done_move:
-            unreleasable_states = ("cancel",)
-        else:
-            unreleasable_states = ("done", "cancel")
-        origin_moves = origin_moves.filtered(
-            lambda m: m.state not in unreleasable_states
+            origin_done_moves = origin_done_moves.filtered(
+                lambda m: not m.picking_type_id.return_picking_type_id
+            )
+        origin_qty_done = sum(
+            m.product_uom._compute_quantity(
+                m.quantity_done,
+                m.product_id.uom_id,
+                rounding_method="HALF-UP",
+            )
+            for m in origin_done_moves
         )
-        origin_qty_todo = sum(origin_moves.mapped("product_qty"))
+        dest_done_moves = origin_done_moves.move_dest_ids
+        dest_qty_done = sum(
+            m.product_uom._compute_quantity(
+                m.quantity_done,
+                m.product_id.uom_id,
+                rounding_method="HALF-UP",
+            )
+            for m in dest_done_moves
+        )
         return (
             float_compare(
-                self.product_qty,
-                origin_qty_todo,
-                precision_rounding=self.product_uom.rounding,
+                origin_qty_done,
+                dest_qty_done,
+                precision_rounding=self.product_id.uom_id.rounding,
             )
             <= 0
         )

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -64,8 +64,10 @@ class StockMove(models.Model):
                 iterator = move._get_chained_moves_iterator("move_orig_ids")
                 next(iterator)  # skip the current move
                 for origin_moves in iterator:
-                    unrelease_allowed = move._is_unrelease_allowed_on_origin_moves(
-                        origin_moves
+                    unrelease_allowed = not origin_moves._in_progress_for_unrelease()
+                    unrelease_allowed = (
+                        unrelease_allowed
+                        and move._is_unrelease_allowed_on_origin_moves(origin_moves)
                     )
                     if not unrelease_allowed:
                         break
@@ -88,23 +90,31 @@ class StockMove(models.Model):
             and self.rule_id.available_to_promise_defer_pull
         )
 
+    def _in_progress_for_unrelease(self) -> bool:
+        """
+        This method will return True if a move :
+
+        - is not done or canceled
+        - and if the move's picking is not printed
+        - and the move has no quantity done.
+
+        """
+        moves = self.filtered(lambda m: m.state not in ("done", "cancel"))
+        if not moves:
+            return False
+        picking_ids = moves.mapped("picking_id")
+        if picking_ids.filtered("printed"):
+            return True
+        if any(move.quantity_done for move in moves):
+            return False
+        return False
+
     def _is_unrelease_allowed_on_origin_moves(self, origin_moves):
         """We check that the origin moves are in a state that allows the unrelease
         of the current move. At this stage, a move can't be unreleased if
         the processed origin moves is not consumed by the dest moves.
         """
         self.ensure_one()
-        open_origin_moves = origin_moves.filtered(
-            lambda m: m.state not in ("done", "cancel")
-        )
-        pickings = open_origin_moves.mapped("picking_id")
-        if pickings.filtered("printed"):
-            # The picking is printed, we can't unrelease the move
-            # because the processing of the origin moves is started.
-            return False
-        if any(m.quantity_done for m in open_origin_moves):
-            # The origin move is being processed, we can't unrelease the move
-            return False
         origin_done_moves = origin_moves.filtered(lambda m: m.state == "done")
         if self.rule_id.allow_unrelease_return_done_move:
             origin_done_moves = origin_done_moves.filtered(

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -92,10 +92,10 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         with self.assertRaisesRegex(UserError, "You are not allowed to unrelease"):
             self.shipping.move_lines.unrelease()
 
-    def test_unrelease_backorder(self):
-        """Check the unrelease of a shipping backorder move"""
-        # we do a partial pick and validate the picking to create a backorder
-        # a validation
+    def test_unrelease_backorder_when_remaining_picking(self):
+        """Check the unrelease of a shipping backorder move
+
+        The picking has been partially processed and a pick backorder has beeen created"""
         line = self.picking.move_lines.move_line_ids
         line.qty_done = line.product_qty - 1
         self.picking.with_context(
@@ -130,6 +130,36 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         )
         self.assertTrue(
             all(m.procure_method == "make_to_order" for m in backorder_ship.move_lines)
+        )
+
+    def test_unrelease_backorder_when_canceled_picking(self):
+        """Check the unrelease of a shipping backorder move
+
+        The picking has been partially processed and the pick backorder has beeen canceled"""
+        line = self.picking.move_line_ids
+        line.qty_done = line.product_uom_qty - 1
+        self.picking.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        self.picking.backorder_ids.action_cancel()
+        self.shipping.action_assign()
+        line = self.shipping.move_line_ids
+        line.qty_done = line.product_uom_qty
+        self.shipping.with_context(
+            skip_immediate=True, skip_backorder=True
+        ).button_validate()
+        # at this stage, our backorder ship move is linked to the done pick move
+        backorder_ship = self.shipping.backorder_ids
+        backorder_pick = self._prev_picking(backorder_ship) - self.picking
+        self.assertEqual(len(backorder_pick), 0)
+        backorder_ship.unrelease()
+        # after the un release, our backorder ship move is not more linked to
+        # a pick move to do
+        self.assertFalse(backorder_ship.move_lines.unrelease_allowed)
+        self.assertFalse(
+            backorder_ship.move_lines.move_orig_ids.filtered(
+                lambda m: m.state not in ("cancel", "done")
+            )
         )
 
     def test_unrelease_picking_wizard(self):


### PR DESCRIPTION
Backport of:
* https://github.com/OCA/wms/pull/921
* https://github.com/OCA/wms/pull/920
* https://github.com/OCA/wms/pull/905

properly handle the unrelease in case someone canceled the backorder pick before unreleasing (for example because of an inventory loss)

cc @mt-software-de @mmequignon 