### PR TITLE
[16.0][FIX] stock_release_channel_partner_delivery_window: Fix channel assignment computation

### DIFF
--- a/stock_release_channel_partner_delivery_window/__manifest__.py
+++ b/stock_release_channel_partner_delivery_window/__manifest__.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 {
@@ -11,6 +12,7 @@
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",
     "depends": [
+        "sale",
         "stock_partner_delivery_window",
         "stock_release_channel_shipment_lead_time",
     ],

--- a/stock_release_channel_partner_delivery_window/models/stock_release_channel.py
+++ b/stock_release_channel_partner_delivery_window/models/stock_release_channel.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields, models
 
@@ -17,26 +18,13 @@ class StockReleaseChannel(models.Model):
     )
 
     def filter_release_channel_partner_window(self, picking, partner):
-        channels = self
-        if (
-            not partner.delivery_time_preference
-            or partner.delivery_time_preference == "anytime"
-        ):
-            return channels
-
-        for channel in self:
-            if not channel.shipment_date:
-                continue
-            shipment_datetime = fields.Datetime.to_datetime(channel.shipment_date)
-            if channel.process_end_date:
-                shipment_datetime = shipment_datetime.replace(
-                    hour=channel.process_end_date.hour,
-                    minute=channel.process_end_date.minute,
-                )
-            if (
-                channel.respect_partner_delivery_time_windows
-                and not picking.sale_id.commitment_date
-                and not partner.is_in_delivery_window(shipment_datetime)
-            ):
-                channels -= channel
-        return channels
+        if picking.sale_id.commitment_date:
+            # Date is forced on SO, don't filter
+            return self
+        return self.filtered(
+            lambda channel: not channel.respect_partner_delivery_time_windows
+            or (
+                channel.shipment_date
+                and channel.shipment_date.weekday() in partner.delivery_time_weekdays
+            )
+        )

--- a/stock_release_channel_partner_delivery_window/tests/test_release_window.py
+++ b/stock_release_channel_partner_delivery_window/tests/test_release_window.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import timedelta
 
@@ -28,8 +29,8 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
                         0,
                         0,
                         {
-                            "time_window_start": 0.00,
-                            "time_window_end": 23.99,
+                            "time_window_start": 8.00,
+                            "time_window_end": 18.50,
                             "time_window_weekday_ids": [
                                 (
                                     6,


### PR DESCRIPTION
Consider only the weekday when checking if the picking can be delivered on the channel shipment date

Depends on:
* https://github.com/OCA/stock-logistics-workflow/pull/1940

@mmequignon @santostelmo 