### PR TITLE
[16.0][IMP] stock_release_channel_partner_delivery_window: delivery date generator

### DIFF
--- a/stock_release_channel_partner_delivery_window/models/stock_release_channel.py
+++ b/stock_release_channel_partner_delivery_window/models/stock_release_channel.py
@@ -1,6 +1,8 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import datetime
+
 from odoo import api, fields, models
 
 
@@ -33,3 +35,80 @@ class StockReleaseChannel(models.Model):
                 channel.delivery_date_weekday = channel.shipment_date.weekday()
             else:
                 channel.delivery_date_weekday = -1
+
+    @property
+    def _delivery_date_generators(self):
+        d = super()._delivery_date_generators
+        d["customer"].append(self._next_delivery_date_partner_delivery_window)
+        return d
+
+    def _next_delivery_date_partner_delivery_window(self, delivery_date, partner):
+        """Get the next valid delivery date respecting customer delivery window.
+
+        The delivery date must be when the customer is open.
+        From the initial delivery_date, if the customer is not open on that
+        date and time, postpone to the start of the next open window.
+
+        A delivery date generator needs to provide the earliest valid date
+        starting from the received date. It can be called multiple times with a
+        new date to validate.
+        """
+        self.ensure_one()
+        partner.ensure_one()
+        if not self.respect_partner_delivery_time_windows:
+            while True:
+                delivery_date = yield delivery_date
+
+        if partner.delivery_time_preference == "anytime":
+            # no constrain, any date is valid
+            while True:
+                delivery_date = yield delivery_date
+
+        tz = partner.tz
+        if partner.delivery_time_preference == "workdays":
+            # postpone to Monday when date is on a week-end
+            while True:
+                delivery_date_tz = self._localize(delivery_date, tz=tz)
+                # postpone on Monday if Sat or Sun
+                if delivery_date_tz.weekday() < 5:  # Mon-Fri
+                    delivery_date = yield delivery_date
+                    continue
+                days = 0
+                if delivery_date_tz.weekday() == 5:  # Sat
+                    days = 1
+                elif delivery_date_tz.weekday() == 6:  # Sun
+                    days = 2
+                delivery_date_tz = fields.Datetime.add(delivery_date_tz, days=days)
+                delivery_date = self._naive(delivery_date_tz, reset_time=days)
+                delivery_date = yield delivery_date
+
+        while True:
+            # yield first delivery window
+            delivery_date_tz = self._localize(delivery_date, tz=tz)
+            weekday = delivery_date_tz.weekday()
+            for inc in range(8):
+                # Each weekday is tested to find a window.
+                # On the first day, we need a window that ends after current
+                # delivery time. Afterwards, we just need a window.
+                windows = partner.delivery_time_window_ids.filtered(
+                    lambda w: str(weekday + inc)
+                    in w.time_window_weekday_ids.mapped("name")
+                    and (inc or w.get_time_window_end_time() >= delivery_date_tz.time())
+                )
+                if windows:
+                    w = windows[0]
+                    break
+            else:
+                # There is no time window, we consider any date valid
+                while True:
+                    delivery_date = yield delivery_date
+            # Postpone the delivery date to that found window
+            delivery_date_tz = datetime.combine(
+                (fields.Datetime.add(delivery_date_tz, days=inc)).date(),
+                max(w.get_time_window_start_time(), delivery_date_tz.time())
+                if not inc
+                else w.get_time_window_start_time(),
+                tzinfo=delivery_date_tz.tzinfo,
+            )
+            delivery_date = self._naive(delivery_date_tz)
+            delivery_date = yield delivery_date

--- a/stock_release_channel_partner_delivery_window/tests/test_release_window.py
+++ b/stock_release_channel_partner_delivery_window/tests/test_release_window.py
@@ -8,6 +8,8 @@ from odoo import fields
 
 from odoo.addons.stock_release_channel.tests.common import ChannelReleaseCase
 
+to_datetime = fields.Datetime.to_datetime
+
 
 class ReleaseChannelEndDateCase(ChannelReleaseCase):
     @classmethod
@@ -104,3 +106,28 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.picking.partner_id = self.customer_time_window
         self._assign_picking(self.picking)
         self.assertEqual(self.channel, self.picking.release_channel_id)
+
+    def test_delivery_date_partner_time_window_workdays(self):
+        # before opening
+        dt = to_datetime("2025-01-01 05:00:00")  # Wed
+        gen = self.channel._next_delivery_date_partner_delivery_window(
+            dt, self.customer_time_window
+        )
+        result = next(gen)
+        opening = to_datetime("2025-01-02 08:00:00")  # Thu
+        self.assertEqual(result, opening)
+        result = gen.send(result)
+        self.assertEqual(result, opening)
+        # during opening
+        dt = to_datetime("2025-01-02 09:00:00")
+        result = gen.send(dt)
+        self.assertEqual(result, dt)
+        result = gen.send(result)
+        self.assertEqual(result, dt)
+        # after opening
+        dt = to_datetime("2025-01-02 19:00:00")
+        result = gen.send(dt)
+        next_opening = to_datetime("2025-01-04 08:00:00")  # Sat
+        self.assertEqual(result, next_opening)
+        result = gen.send(result)
+        self.assertEqual(result, next_opening)


### PR DESCRIPTION
Add generator for returning next valid delivery date

Depends on:
* https://github.com/OCA/wms/pull/1022
* https://github.com/OCA/wms/pull/1025

cc @mmequignon @grindtildeath 