### PR TITLE
[16.0][IMP] stock_release_channel_cutoff: delivery date generator

### DIFF
--- a/stock_release_channel_cutoff/models/stock_release_channel.py
+++ b/stock_release_channel_cutoff/models/stock_release_channel.py
@@ -2,6 +2,10 @@
 # Copyright 2024 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
+from datetime import datetime
+
+import pytz
+
 from odoo import api, fields, models
 
 from odoo.addons.stock_release_channel_process_end_time.utils import (
@@ -20,18 +24,58 @@ class StockReleaseChannel(models.Model):
     # Technical field for warning on kanban view
     cutoff_warning = fields.Boolean(compute="_compute_cutoff_warning")
 
+    @property
+    def cutoff_datetime(self):
+        self.ensure_one()
+        if not self.cutoff_time:
+            return False
+        now = self.process_end_date if self.state == "open" else fields.Datetime.now()
+        return time_to_datetime(
+            float_to_time(
+                self.cutoff_time,
+            ),
+            now=now,
+            tz=self.process_end_time_tz,
+        )
+
     @api.depends("cutoff_time", "state", "process_end_date", "process_end_time_tz")
     def _compute_cutoff_warning(self):
         now = fields.Datetime.now()
         for channel in self:
             cutoff_warning = False
             if channel.state == "open" and channel.cutoff_time:
-                cutoff = time_to_datetime(
-                    float_to_time(
-                        channel.cutoff_time,
-                    ),
-                    now=channel.process_end_date,
-                    tz=channel.process_end_time_tz,
-                )
-                cutoff_warning = cutoff < now
+                cutoff_warning = channel.cutoff_datetime < now
             channel.cutoff_warning = cutoff_warning
+
+    @property
+    def _delivery_date_generators(self):
+        d = super()._delivery_date_generators
+        d["preparation"].append(self._next_delivery_date_cutoff)
+        return d
+
+    def _next_delivery_date_cutoff(self, delivery_date, partner=None):
+        """Get the next valid delivery date respecting cutoff.
+
+        The preparation date must be before the cutoff time otherwise it is
+        postponed to next day.
+
+        A delivery date generator needs to provide the earliest valid date
+        starting from the received date. It can be called multiple times with a
+        new date to validate.
+        """
+        self.ensure_one()
+        cutoff = self.cutoff_datetime
+        if not cutoff:
+            # any date is valid
+            while True:
+                delivery_date = yield delivery_date
+        wh_tz = pytz.timezone(self.process_end_time_tz)
+        next_day = time_to_datetime(
+            datetime.min.time(),
+            now=fields.Datetime.add(cutoff, days=1),
+            tz=wh_tz,
+        )
+        while True:
+            while delivery_date <= cutoff:
+                delivery_date = yield delivery_date
+            delivery_date = yield max(delivery_date, next_day)

--- a/stock_release_channel_cutoff/tests/test_compute_cutoff_time.py
+++ b/stock_release_channel_cutoff/tests/test_compute_cutoff_time.py
@@ -6,7 +6,10 @@ from datetime import datetime
 
 from freezegun import freeze_time
 
+from odoo import fields
 from odoo.tests.common import TransactionCase
+
+to_datetime = fields.Datetime.to_datetime
 
 
 class TestStockReleaseChannelCutoff(TransactionCase):
@@ -66,3 +69,38 @@ class TestStockReleaseChannelCutoff(TransactionCase):
 
         self.channel.cutoff_time = 8.0
         self.assertTrue(self.channel.cutoff_warning)
+
+    @freeze_time("2023-02-01 09:00:00")
+    def test_delivery_date_no_cutoff(self):
+        self.channel.state = "asleep"
+        self.env.company.partner_id.tz = "Europe/Brussels"
+        self.channel.cutoff_time = 0
+        dt = to_datetime("2023-02-01 08:00:00")
+        gen = self.channel._next_delivery_date_cutoff(dt)
+        result = next(gen)
+        self.assertEqual(result, dt)
+        result = gen.send(result)
+        self.assertEqual(result, dt)
+
+    @freeze_time("2023-02-01 09:00:00")
+    def test_delivery_date_cutoff(self):
+        self.channel.state = "asleep"
+        self.env.company.partner_id.tz = "Europe/Brussels"
+        self.channel.cutoff_time = 9.5  # = 8.5 in UTC
+        # before cutoff
+        dt = to_datetime("2023-02-01 08:00:00")
+        gen = self.channel._next_delivery_date_cutoff(dt)
+        result = next(gen)
+        self.assertEqual(result, dt)
+        result = gen.send(result)
+        self.assertEqual(result, dt)
+        # after cutoff
+        dt = to_datetime("2023-02-01 09:00:00")
+        result = gen.send(dt)
+        next_day = to_datetime("2023-02-01 23:00:00")
+        self.assertEqual(result, next_day)
+        result = gen.send(result)
+        self.assertEqual(result, next_day)
+        dt = to_datetime("2023-02-02 09:00:00")
+        result = gen.send(dt)
+        self.assertEqual(result, dt)


### PR DESCRIPTION
Add generator for returning next valid delivery date

Depends on:
* https://github.com/OCA/wms/pull/1022

cc @mmequignon @grindtildeath 