### PR TITLE
[16.0][IMP] stock_release_channel_shipment_lead_time: delivery date generator

### DIFF
--- a/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
+++ b/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Camptocamp
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
-from datetime import timedelta
 
 from odoo import api, fields, models
 
@@ -9,6 +9,7 @@ class StockReleaseChannel(models.Model):
     _inherit = "stock.release.channel"
 
     shipment_lead_time = fields.Integer(help="Shipment Lead Time (days)")
+    # Migration note: rename shipment_date to delivery_date
     shipment_date = fields.Date(
         compute="_compute_shipment_date",
         store=True,
@@ -19,29 +20,72 @@ class StockReleaseChannel(models.Model):
             "number of days = lead time + 1"
         ),
     )
-
-    @api.depends(
-        "process_end_date",
-        "shipment_lead_time",
-        "warehouse_id",
-        "warehouse_id.calendar_id",
+    delivery_calendar_id = fields.Many2one(
+        comodel_name="resource.calendar",
+        compute="_compute_delivery_calendar_id",
+        store=True,
+        help=(
+            "Shipment Working Hours. Defaults tot warehouse calendar "
+            "for simplicity but another calendar can be used."
+        ),
     )
-    def _compute_shipment_date(self):
-        """
-        if no warehouse or no calendar on the warehouse:
-            process end date + lead time
+
+    @api.depends("warehouse_id.calendar_id")
+    def _compute_delivery_calendar_id(self):
+        for channel in self:
+            channel.delivery_calendar_id = channel.warehouse_id.calendar_id
+
+    def _add_shipment_lead_time(self, dt):
+        """Add lead time to given datetime.
+
+        If no calendar: dt + lead time
         else: use calendar.plan_days(days, date_from, compute_leaves=True)
             where days is amount of required open days (= lead time + 1)
         """
+        self.ensure_one()
+        if not self.shipment_lead_time:
+            return dt
+        dt_tz = self._localize(dt)
+        if not self.delivery_calendar_id:
+            shipment_tz = fields.Datetime.add(dt_tz, days=self.shipment_lead_time)
+        else:
+            days = self.shipment_lead_time + 1
+            shipment_tz = self.delivery_calendar_id.plan_days(
+                days, dt_tz, compute_leaves=True
+            )
+        shipment_dt = self._naive(shipment_tz, reset_time=True)
+        return shipment_dt
+
+    # Migration note: rename _compute_shipment_date to _compute_delivery_date
+    @api.depends(
+        "process_end_date",
+        "shipment_lead_time",
+        "delivery_calendar_id",
+    )
+    def _compute_shipment_date(self):
         for channel in self:
             shipment_date = False
             if channel.process_end_date:
-                shipment_date = channel.process_end_date + timedelta(
-                    days=channel.shipment_lead_time
+                shipment_date = channel._add_shipment_lead_time(
+                    channel.process_end_date
                 )
-                if channel.warehouse_id.calendar_id:
-                    days = channel.shipment_lead_time + 1
-                    shipment_date = channel.warehouse_id.calendar_id.plan_days(
-                        days, channel.process_end_date, compute_leaves=True
-                    )
             channel.shipment_date = shipment_date
+
+    @property
+    def _delivery_date_generators(self):
+        d = super()._delivery_date_generators
+        d["delivery"].append(self._next_delivery_date_shipment_lead_time)
+        return d
+
+    def _next_delivery_date_shipment_lead_time(self, delivery_date, partner=None):
+        """Get the next valid delivery date respecting transport lead time.
+
+        The delivery date must be postponed at least by the shipment lead time.
+
+        A delivery date generator needs to provide the earliest valid date
+        starting from the received date. It can be called multiple times with a
+        new date to validate.
+        """
+        arrival_date = self._add_shipment_lead_time(delivery_date)
+        while True:
+            delivery_date = yield max(delivery_date, arrival_date)

--- a/stock_release_channel_shipment_lead_time/readme/ROADMAP.rst
+++ b/stock_release_channel_shipment_lead_time/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+Rename "Shipment date" to "Delivery date" as it is misleading

--- a/stock_release_channel_shipment_lead_time/tests/test_release_shipment_date.py
+++ b/stock_release_channel_shipment_lead_time/tests/test_release_shipment_date.py
@@ -1,8 +1,12 @@
 # Copyright 2023 Camptocamp
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
 from odoo import fields
 
 from odoo.addons.stock_release_channel.tests.common import ChannelReleaseCase
+
+to_datetime = fields.Datetime.to_datetime
 
 
 class TestChannelReleaseShipmentLeadTime(ChannelReleaseCase):
@@ -28,3 +32,26 @@ class TestChannelReleaseShipmentLeadTime(ChannelReleaseCase):
             "2023-07-10",
             fields.Date.to_string(self.channel.shipment_date),
         )
+
+    def test_delivery_date_shipment_lead_time(self):
+        self.channel.warehouse_id = self.wh
+        self.channel.warehouse_id.calendar_id = self.env.ref(
+            "resource.resource_calendar_std"
+        )
+        self.channel.warehouse_id.partner_id.tz = "Europe/Brussels"
+        self.channel.shipment_lead_time = 1
+        dt = to_datetime("2025-01-02 08:00:00")  # Thursday
+        gen = self.channel._next_delivery_date_shipment_lead_time(dt)
+        result = next(gen)
+        next_day = to_datetime("2025-01-02 23:00:00")  # Friday
+        self.assertEqual(result, next_day)
+        result = gen.send(dt)
+        self.assertEqual(result, next_day)
+        # around week-end
+        dt = to_datetime("2025-01-03 08:00:00")  # Friday
+        gen = self.channel._next_delivery_date_shipment_lead_time(dt)
+        result = next(gen)
+        next_day = to_datetime("2025-01-05 23:00:00")  # Monday
+        self.assertEqual(result, next_day)
+        result = gen.send(dt)
+        self.assertEqual(result, next_day)


### PR DESCRIPTION
Add generator for returning next valid delivery date

Depends on:
* https://github.com/OCA/wms/pull/1022

cc @mmequignon @grindtildeath 