### PR TITLE
[16.0][IMP] stock_release_channel_partner_public_holidays: delivery date generator

### DIFF
--- a/stock_release_channel_partner_public_holidays/models/stock_release_channel.py
+++ b/stock_release_channel_partner_public_holidays/models/stock_release_channel.py
@@ -1,4 +1,8 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import timedelta
+
 from odoo import fields, models
 
 
@@ -7,3 +11,43 @@ class StockReleaseChannel(models.Model):
     _inherit = "stock.release.channel"
 
     exclude_public_holidays = fields.Boolean()
+
+    @property
+    def _delivery_date_generators(self):
+        d = super()._delivery_date_generators
+        d["customer"].append(self._next_delivery_date_partner_public_holiday)
+        return d
+
+    def _next_delivery_date_partner_public_holiday(self, delivery_date, partner):
+        """Get the next valid delivery date respecting cutoff.
+
+        The delivery date must not be a public holiday otherwise it is
+        postponed to next open day.
+
+        A delivery date generator needs to provide the earliest valid date
+        starting from the received date. It can be called multiple times with a
+        new date to validate.
+        """
+        self.ensure_one()
+        partner.ensure_one()
+
+        if not self.exclude_public_holidays:
+            while True:
+                delivery_date = yield delivery_date
+
+        batch_delta = timedelta(days=61)
+        delivery_date_tz = self._localize(delivery_date, tz=partner.tz)
+        while True:
+            end_dt_tz = delivery_date_tz + batch_delta
+            all_holidays = self.env["hr.holidays.public"].get_holidays_list(
+                start_dt=delivery_date_tz, end_dt=end_dt_tz, partner_id=partner.id
+            )
+            while delivery_date_tz <= end_dt_tz:
+                if delivery_date_tz.date() not in all_holidays.mapped("date"):
+                    delivery_date = yield self._naive(delivery_date_tz)
+                    delivery_date_tz = self._localize(delivery_date, tz=partner.tz)
+                else:
+                    delivery_date_tz += timedelta(days=1)
+                    delivery_date_tz = delivery_date_tz.replace(
+                        hour=0, minute=0, second=0, microsecond=0
+                    )

--- a/stock_release_channel_partner_public_holidays/readme/CONTRIBUTORS.rst
+++ b/stock_release_channel_partner_public_holidays/readme/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 * Nguyen Minh Chien <chien@trobz.com>

--- a/stock_release_channel_partner_public_holidays/tests/test_release_on_holiday.py
+++ b/stock_release_channel_partner_public_holidays/tests/test_release_on_holiday.py
@@ -1,3 +1,4 @@
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from datetime import timedelta
 
@@ -6,6 +7,8 @@ from freezegun import freeze_time
 from odoo import fields
 
 from odoo.addons.stock_release_channel.tests.common import ChannelReleaseCase
+
+to_datetime = fields.Datetime.to_datetime
 
 
 class ReleaseChannelEndDateCase(ChannelReleaseCase):
@@ -58,3 +61,23 @@ class ReleaseChannelEndDateCase(ChannelReleaseCase):
         self.picking.partner_id.state_id = self.env.ref("base.state_us_35")
         self._assign_picking(self.picking)
         self.assertNotEqual(self.channel, self.picking.release_channel_id)
+
+    @freeze_time("2023-09-01")
+    def test_delivery_date_public_holiday(self):
+        partner = self.picking.partner_id
+        self.channel.exclude_public_holidays = True
+        partner.tz = "Europe/Brussels"
+        dt = to_datetime("2023-09-17 08:00:00")
+        gen = self.channel._next_delivery_date_partner_public_holiday(dt, partner)
+        # not an holiday
+        result = next(gen)
+        self.assertEqual(result, dt)
+        result = gen.send(dt)
+        self.assertEqual(result, dt)
+        # an holiday
+        dt = to_datetime("2023-09-18 08:00:00")
+        result = gen.send(dt)
+        next_day = to_datetime("2023-09-18 22:00:00")
+        self.assertEqual(result, next_day)
+        result = gen.send(dt)
+        self.assertEqual(result, next_day)


### PR DESCRIPTION
Add generator for returning next valid delivery date

Depends on:
* https://github.com/OCA/wms/pull/1022

cc @mmequignon @grindtildeath 