### PR TITLE
[14.0][IMP] stock_available_to_promise_release: Do not copy picking responsible to cancel picking

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Camptocamp (https://www.camptocamp.com)
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# Copyright 2025 Raumschmiede GmbH
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 import itertools
 import logging
@@ -657,7 +658,12 @@ class StockMove(models.Model):
             if product_return_moves:
                 wiz_values["product_return_moves"] = product_return_moves
                 return_wiz = self.env["stock.return.picking"].create(wiz_values)
-                return_wiz.create_returns()
+                action = return_wiz.create_returns()
+
+                cancel_picking = self.picking_id.browse(action["res_id"])
+                # Do not copy the responsible user from the source picking as somebody
+                # else could scan the new cancel picking
+                cancel_picking.user_id = False
         return True
 
     def _unrelease_set_returnable_qty_per_move(

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel.py
@@ -1,4 +1,5 @@
 # Copyright 2025 Camptocamp SA
+# Copyright 2025 Raumschmiede GmbH
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from datetime import datetime
 
@@ -36,6 +37,11 @@ class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
         cls.pack_picking = cls._prev_picking(cls.ship_picking)
         cls.pick_picking = cls._prev_picking(cls.pack_picking)
 
+        cls.demo_user = cls.env.ref("base.user_demo")
+        cls.ship_picking.user_id = cls.demo_user
+        cls.pack_picking.user_id = cls.demo_user
+        cls.pick_picking.user_id = cls.demo_user
+
         # Why is this not working when creating picking after enabling this setting?
         delivery_route.write(
             {
@@ -70,6 +76,8 @@ class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
         self.assertEqual(self.pack_picking.state, "cancel")
         self.assertEqual(self.pick_picking.state, "done")
         cancel_picking = self._get_cleanup_picking()
+        self.assertEqual(self.pick_picking.user_id, self.demo_user)
+        self.assertFalse(cancel_picking.user_id)
         self.assertEqual(len(cancel_picking), 1)
         self.assertEqual(cancel_picking.location_id, self.loc_pack)
         self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
@@ -84,6 +92,8 @@ class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
         self.assertEqual(self.pack_picking.state, "done")
         self.assertEqual(self.pick_picking.state, "done")
         cancel_picking = self._get_cleanup_picking()
+        self.assertEqual(self.pack_picking.user_id, self.demo_user)
+        self.assertFalse(cancel_picking.user_id)
         self.assertEqual(len(cancel_picking), 1)
         self.assertEqual(cancel_picking.location_id, self.loc_output)
         self.assertEqual(cancel_picking.location_dest_id, self.loc_stock)
@@ -98,6 +108,7 @@ class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
         self.assertEqual(self.pack_picking.state, "cancel")
         self.assertEqual(self.pick_picking.state, "done")
         cancel_picking = self._get_cleanup_picking()
+        self.assertFalse(cancel_picking.user_id)
         # In the end, we cancelled 5 units for the pick backorder, and returned
         # 5 units from pack -> stock
         self.assertEqual(pick_backorder.state, "cancel")
@@ -116,6 +127,7 @@ class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
         self.assertEqual(self.pack_picking.state, "done")
         self.assertEqual(self.pick_picking.state, "done")
         cancel_pickings = self._get_cleanup_picking()
+        self.assertFalse(cancel_pickings.user_id)
         self.assertEqual(len(cancel_pickings), 2)
         # In the end, we cancelled 5 units for the pack backorder, returned
         # 5 units from pack -> stock, and 5 units from output -> stock


### PR DESCRIPTION
When the cancel picking is scanned by someone who isn't the responsible, an error occurs. The responsible needs to be removed manually to make it scanable. Remove the responsible after creating the picking so that anyone can scan it without error.


I'm not sure about the test changes and the commit message. If you know a better one, please suggest it.

@mt-software-de 
@jbaudoux 