### PR TITLE
[16.0][FIX] stock_release_channel_partner_by_date: show archived

### DIFF
--- a/stock_release_channel_partner_by_date/models/res_partner.py
+++ b/stock_release_channel_partner_by_date/models/res_partner.py
@@ -13,4 +13,5 @@ class ResPartner(models.Model):
         inverse_name="partner_id",
         string="Additional Release Channels",
         help="Additional release channels for a specific delivery date.",
+        context={"active_test": False},
     )

--- a/stock_release_channel_partner_by_date/views/res_partner.xml
+++ b/stock_release_channel_partner_by_date/views/res_partner.xml
@@ -15,7 +15,8 @@
                     colspan="2"
                 />
                 <field name="stock_release_channel_by_date_ids" nolabel="1" colspan="2">
-                  <tree editable="top">
+                  <tree editable="top" decoration-muted="active == False">
+                    <field name="active" invisible="1" />
                     <field name="partner_id" invisible="1" force_save="1" />
                     <field name="release_channel_id" options="{'no_create': True}" />
                     <field name="date" />


### PR DESCRIPTION
Commits extracted from:
* https://github.com/OCA/wms/pull/955

as they are not related to computation
and in order to already merge those fixes

cc @sebalix 