### PR TITLE
[16.0][FIX] sale_stock_release_channel_partner_by_date: fix computation of release channel

### DIFF
--- a/sale_stock_release_channel_partner_by_date/__manifest__.py
+++ b/sale_stock_release_channel_partner_by_date/__manifest__.py
@@ -14,6 +14,7 @@
         "sales_team",
         "sale_stock",
         # OCA/wms
+        "sale_stock_release_channel",
         "stock_release_channel_partner_by_date",
     ],
     "data": [

--- a/sale_stock_release_channel_partner_by_date/models/sale_order.py
+++ b/sale_stock_release_channel_partner_by_date/models/sale_order.py
@@ -29,14 +29,15 @@ class SaleOrder(models.Model):
         return f"[{parts}]"
 
     def _release_channel_id_domain_parts(self):
-        return [
-            "'|', ('warehouse_id', '=', False), ('warehouse_id', '=', warehouse_id)",
-        ]
+        return ["('warehouse_id', 'in', (False, warehouse_id))"]
 
     def _get_release_channel_id_depends(self):
         return ["partner_shipping_id", "warehouse_id", "commitment_date"]
 
-    @api.depends(lambda o: o._get_release_channel_id_depends())
+    @api.depends(
+        lambda o: ["release_channel_partner_date_id"]
+        + o._get_release_channel_id_depends()
+    )
     def _compute_release_channel_id(self):
         for rec in self:
             if not rec._check_release_channel_partner_date_requirements():
@@ -44,32 +45,40 @@ class SaleOrder(models.Model):
             channel_date = rec.release_channel_partner_date_id
             if channel_date:
                 rec.release_channel_id = channel_date.release_channel_id
+            elif rec.release_channel_id not in rec.release_channel_id.filtered_domain(
+                self._release_channel_possible_candidate_domain_base
+            ):
+                # empty release channel when value is not compatible anymore
+                # with new depends values
+                rec.release_channel_id = False
 
     @api.depends(
-        "state",
-        "partner_shipping_id",
-        "commitment_date",
-        "expected_date",
-        "warehouse_id",
+        lambda o: ["state", "expected_date"] + o._get_release_channel_id_depends()
     )
     def _compute_release_channel_partner_date_id(self):
         for rec in self:
-            channel_partner_date = rec._get_release_channel_partner_date()
+            channel_partner_date = rec._get_release_channel_partner_date()[:1]
             rec.release_channel_partner_date_id = channel_partner_date
 
     def _get_release_channel_partner_date(self):
         self.ensure_one()
-        model = self.env["stock.release.channel.partner.date"]
-        domain = self._get_release_channel_partner_date_domain()
-        return domain and model.search(domain, limit=1) or model
-
-    def _get_release_channel_partner_date_domain(self):
-        self.ensure_one()
         if not self._check_release_channel_partner_date_requirements():
-            return
+            return self.env["stock.release.channel.partner.date"]
+        return (
+            self.env["stock.release.channel.partner.date"]
+            .with_context(active_test=False)
+            .search(self._release_channel_partner_date_domain)
+            .filtered(
+                lambda o: o.release_channel_id.filtered_domain(
+                    self._release_channel_possible_candidate_domain_base
+                )
+            )
+        )
+
+    @property
+    def _release_channel_partner_date_domain(self):
         delivery_date = self._get_delivery_date()
         return [
-            ("release_channel_id.warehouse_id", "in", [False, self.warehouse_id.id]),
             ("partner_id", "=", self.partner_shipping_id.id),
             ("date", "=", delivery_date),
         ]
@@ -103,10 +112,11 @@ class SaleOrder(models.Model):
         model = self.env["stock.release.channel.partner.date"]
         if self.state not in ("sale", "done") or not self.release_channel_id:
             return model
-        channel = self.release_channel_id.with_context(active_test=False)
-        channel_dates = channel.release_channel_partner_date_ids.filtered_domain(
-            self._get_release_channel_partner_date_domain()
-        )
+        channel_dates = (
+            self._get_release_channel_partner_date().filtered(
+                lambda rcd: rcd.release_channel_id == self.release_channel_id
+            )
+        )[:1]
         if channel_dates:
             channel_dates.write({"active": True})
         else:

--- a/sale_stock_release_channel_partner_by_date/models/sale_order.py
+++ b/sale_stock_release_channel_partner_by_date/models/sale_order.py
@@ -42,7 +42,8 @@ class SaleOrder(models.Model):
             if not rec._check_release_channel_partner_date_requirements():
                 continue
             channel_date = rec.release_channel_partner_date_id
-            rec.release_channel_id = channel_date.release_channel_id
+            if channel_date:
+                rec.release_channel_id = channel_date.release_channel_id
 
     @api.depends(
         "state",

--- a/sale_stock_release_channel_partner_by_date/tests/common.py
+++ b/sale_stock_release_channel_partner_by_date/tests/common.py
@@ -20,8 +20,7 @@ class SaleReleaseChannelCase(ReleaseChannelCase):
     def _create_sale_order(cls, channel=False, date=False, warehouse=False):
         sale_form = Form(cls.env["sale.order"])
         sale_form.partner_id = cls.customer
-        if warehouse:
-            sale_form.warehouse_id = warehouse
+        sale_form.warehouse_id = warehouse or cls.wh
         with sale_form.order_line.new() as line_form:
             line_form.product_id = cls.product
             line_form.product_uom_qty = 1

--- a/sale_stock_release_channel_partner_by_date_delivery/__manifest__.py
+++ b/sale_stock_release_channel_partner_by_date_delivery/__manifest__.py
@@ -11,8 +11,8 @@
     "website": "https://github.com/OCA/wms",
     "depends": [
         # OCA/wms
+        "sale_stock_release_channel_delivery",
         "sale_stock_release_channel_partner_by_date",
-        "stock_release_channel_delivery",
     ],
     "data": [
         "views/sale_order.xml",

--- a/sale_stock_release_channel_partner_by_date_delivery/models/sale_order.py
+++ b/sale_stock_release_channel_partner_by_date_delivery/models/sale_order.py
@@ -22,11 +22,23 @@ class SaleOrder(models.Model):
 
     def _get_release_channel_partner_date_domain(self):
         domain = super()._get_release_channel_partner_date_domain()
-        if domain and self.carrier_id:
-            carrier_domain = [
-                "|",
-                ("release_channel_id.carrier_ids", "in", self.carrier_id.ids),
-                ("release_channel_id.carrier_ids", "=", False),
-            ]
+        if domain:
+            if self.carrier_id:
+                carrier_domain = [
+                    ("release_channel_id.carrier_ids", "in", self.carrier_id.ids),
+                ]
+            else:
+                carrier_domain = [
+                    ("release_channel_id.carrier_ids", "=", False),
+                ]
             domain = expression.AND([domain, carrier_domain])
         return domain
+
+    def _compute_release_channel_id(self):
+        # pylint: disable=missing-return
+        super()._compute_release_channel_id()
+        for rec in self:
+            # Selected release channel and carrier have to be compatible
+            if rec.release_channel_id.carrier_ids and rec.carrier_id:
+                if rec.carrier_id not in rec.release_channel_id.carrier_ids:
+                    rec.release_channel_id = False

--- a/sale_stock_release_channel_partner_by_date_delivery/models/sale_order.py
+++ b/sale_stock_release_channel_partner_by_date_delivery/models/sale_order.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import models
-from odoo.osv import expression
 
 
 class SaleOrder(models.Model):
@@ -19,26 +18,3 @@ class SaleOrder(models.Model):
         depends = super()._get_release_channel_id_depends()
         depends.append("carrier_id")
         return depends
-
-    def _get_release_channel_partner_date_domain(self):
-        domain = super()._get_release_channel_partner_date_domain()
-        if domain:
-            if self.carrier_id:
-                carrier_domain = [
-                    ("release_channel_id.carrier_ids", "in", self.carrier_id.ids),
-                ]
-            else:
-                carrier_domain = [
-                    ("release_channel_id.carrier_ids", "=", False),
-                ]
-            domain = expression.AND([domain, carrier_domain])
-        return domain
-
-    def _compute_release_channel_id(self):
-        # pylint: disable=missing-return
-        super()._compute_release_channel_id()
-        for rec in self:
-            # Selected release channel and carrier have to be compatible
-            if rec.release_channel_id.carrier_ids and rec.carrier_id:
-                if rec.carrier_id not in rec.release_channel_id.carrier_ids:
-                    rec.release_channel_id = False

--- a/sale_stock_release_channel_partner_by_date_delivery/tests/test_sale_release_channel.py
+++ b/sale_stock_release_channel_partner_by_date_delivery/tests/test_sale_release_channel.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields
+from odoo.tests.common import Form
 
 from odoo.addons.sale_stock_release_channel_partner_by_date.tests.common import (
     SaleReleaseChannelCase,
@@ -24,9 +25,18 @@ class TestSaleReleaseChannel(SaleReleaseChannelCase):
             }
         )
         cls.carrier_channel.action_wake_up()
+        cls.carrier2_channel = cls.default_channel.copy(
+            {
+                "name": "Test with carrier2",
+                "sequence": 10,
+                "carrier_ids": [(6, 0, cls.carrier2.ids)],
+            }
+        )
+        cls.carrier2_channel.action_wake_up()
 
-    def test_sale_order_with_wrong_carrier(self):
+    def test_sale_order_without_carrier_with_channel_date(self):
         delivery_date = fields.Datetime.now()
+        # Create one specific channel not matching the SO regarding the carrier
         channel_date_model = self.env["stock.release.channel.partner.date"]
         channel_date_model.create(
             {
@@ -35,9 +45,8 @@ class TestSaleReleaseChannel(SaleReleaseChannelCase):
                 "date": delivery_date.date(),
             }
         )
-        # With wrong carrier set: order doesn't detect the specific channel for carrier
         order = self._create_sale_order(date=delivery_date)
-        order.carrier_id = self.carrier2
+        self.assertFalse(order.carrier_id)
         self.assertFalse(order.release_channel_id)
         order.action_confirm()
         self.assertFalse(order.release_channel_id)
@@ -48,7 +57,7 @@ class TestSaleReleaseChannel(SaleReleaseChannelCase):
         self.env["stock.release.channel"].assign_release_channel(picking_out)
         self.assertEqual(picking_out.release_channel_id, self.default_channel)
 
-    def test_sale_order_with_carrier(self):
+    def test_sale_order_with_carrier_with_channel_date(self):
         delivery_date = fields.Datetime.now()
         channel_date_model = self.env["stock.release.channel.partner.date"]
         channel_date = channel_date_model.create(
@@ -71,3 +80,93 @@ class TestSaleReleaseChannel(SaleReleaseChannelCase):
         # Then delivery gets the default channel
         self.env["stock.release.channel"].assign_release_channel(picking_out)
         self.assertEqual(picking_out.release_channel_id, self.carrier_channel)
+
+    def test_sale_order_with_carrier_without_channel_date(self):
+        delivery_date = fields.Datetime.now()
+        # With carrier set: order doesn't detect any specific channel
+        order = self._create_sale_order(date=delivery_date)
+        order.carrier_id = self.carrier
+        self.assertFalse(order.release_channel_id)
+        self.assertFalse(order._get_release_channel_partner_date())
+        # The user is able to set a release channel on the form
+        with Form(order) as form:
+            form.release_channel_id = self.carrier_channel
+        order.action_confirm()
+        self.assertEqual(order.release_channel_id, self.carrier_channel)
+        # A specific channel has been created at order confirmation
+        self.assertTrue(order._get_release_channel_partner_date())
+        picking_out = order.picking_ids
+        self.assertFalse(picking_out.release_channel_id)
+        # Then delivery then gets the channel defined on the SO
+        self.env["stock.release.channel"].assign_release_channel(picking_out)
+        self.assertEqual(picking_out.release_channel_id, self.carrier_channel)
+
+    def test_sale_order_with_incompatible_channel_and_carrier_1(self):
+        # Case 1: a release channel having a specific channel configured
+        # is detected, but incompatible with the selected carrier afterwards.
+        #   => unset the detected release channel
+        delivery_date = fields.Datetime.now()
+        channel_date_model = self.env["stock.release.channel.partner.date"]
+        channel_date_model.create(
+            {
+                "partner_id": self.customer.id,
+                "release_channel_id": self.carrier_channel.id,
+                "date": delivery_date.date(),
+            }
+        )
+        order = self._create_sale_order(
+            date=delivery_date, channel=self.carrier_channel
+        )
+        self.assertEqual(order.release_channel_id, self.carrier_channel)
+        #   => select a carrier
+        order.carrier_id = self.carrier2
+        self.assertFalse(order.release_channel_id)
+        # Confirm the order and check release channel on delivery
+        order.action_confirm()
+        self.assertFalse(order.release_channel_id)
+        self.assertFalse(order._get_release_channel_partner_date())
+        picking_out = order.picking_ids
+        self.assertFalse(picking_out.release_channel_id)
+        # Then delivery gets the default channel
+        self.env["stock.release.channel"].assign_release_channel(picking_out)
+        self.assertEqual(picking_out.release_channel_id, self.default_channel)
+
+    def test_sale_order_with_incompatible_channel_and_carrier_2(self):
+        # Case 2: a release channel having a specific channel configured
+        # is detected, but incompatible with the selected carrier afterwards.
+        # However another specific channel is compatible with the selected carrier.
+        #   => update the selected release channel to be compatible with the
+        #   selected carrier
+        delivery_date = fields.Datetime.now()
+        channel_date_model = self.env["stock.release.channel.partner.date"]
+        channel_date_model.create(
+            {
+                "partner_id": self.customer.id,
+                "release_channel_id": self.carrier_channel.id,
+                "date": delivery_date.date(),
+            }
+        )
+        order = self._create_sale_order(
+            date=delivery_date, channel=self.carrier_channel
+        )
+        self.assertEqual(order.release_channel_id, self.carrier_channel)
+        channel_date_model = self.env["stock.release.channel.partner.date"]
+        channel_date = channel_date_model.create(
+            {
+                "partner_id": self.customer.id,
+                "release_channel_id": self.carrier2_channel.id,
+                "date": delivery_date.date(),
+            }
+        )
+        #   => select a carrier
+        order.carrier_id = self.carrier2
+        self.assertEqual(order.release_channel_id, self.carrier2_channel)
+        # Confirm the order and check release channel on delivery
+        order.action_confirm()
+        self.assertEqual(order.release_channel_id, self.carrier2_channel)
+        self.assertEqual(order._get_release_channel_partner_date(), channel_date)
+        picking_out = order.picking_ids
+        self.assertFalse(picking_out.release_channel_id)
+        # Then delivery gets the selected channel
+        self.env["stock.release.channel"].assign_release_channel(picking_out)
+        self.assertEqual(picking_out.release_channel_id, self.carrier2_channel)


### PR DESCRIPTION
Aims to supersede https://github.com/OCA/wms/pull/955

Depends on:
* https://github.com/OCA/wms/pull/1035
* https://github.com/OCA/wms/pull/1036

cc @sebalix @santostelmo 