### PR TITLE
[14.0][FIX] stock_storage_type: cond evaluation context

### DIFF
--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -356,7 +356,7 @@ class StockLocation(models.Model):
             return dest_location
 
         for package_sequence in package_locations:
-            if not package_sequence.can_be_applied(putaway_location, quant, product):
+            if not package_sequence.can_be_applied(dest_location, quant, product):
                 continue
             pref_loc = package_sequence.location_id
             storage_locations = pref_loc.get_storage_locations(products=product)
@@ -372,7 +372,7 @@ class StockLocation(models.Model):
                 return allowed_location
         _logger.debug(
             "Could not find a valid putaway location, fallback to %s"
-            % putaway_location.complete_name
+            % dest_location.complete_name
         )
         return putaway_location
 


### PR DESCRIPTION
When the putaway_location is not set, fallback on the current destination location.

No need to fwd port, as this is now the standard odoo behavior: https://github.com/odoo/odoo/blob/16.0/addons/stock/models/stock_location.py#L336

cc @mmequignon @sebalix 