### PR TITLE
[FIX] stock_storage_type: Allow to have two rules for a storage type

### DIFF
--- a/stock_storage_type/demo/stock_storage_category.xml
+++ b/stock_storage_type/demo/stock_storage_category.xml
@@ -13,11 +13,22 @@
         <field name="storage_category_id" ref="storage_category_pallets" />
         <field
             name="condition_ids"
-            eval="[(4, ref('stock_storage_type.storage_category_allow_new_product_cond_pallets'))]"
+            eval="[(4, ref('stock_storage_type.storage_category_allow_new_product_cond_pallets')),]"
         />
         <field name="allow_new_product">empty</field>
     </record>
 
+    <record
+        id="storage_category_allow_new_product_empty_pallets_uk"
+        model="stock.storage.category.allow_new_product"
+    >
+        <field name="storage_category_id" ref="storage_category_pallets" />
+        <field
+            name="condition_ids"
+            eval="[(4, ref('stock_storage_type.storage_category_allow_new_product_cond_pallets_uk')),]"
+        />
+        <field name="allow_new_product">empty</field>
+    </record>
     <record id="storage_category_cardboxes" model="stock.storage.category">
         <field name="name">Cardboxes</field>
     </record>

--- a/stock_storage_type/demo/stock_storage_category_allow_new_product_cond.xml
+++ b/stock_storage_type/demo/stock_storage_category_allow_new_product_cond.xml
@@ -17,4 +17,19 @@ if package_type and package_type == pallets_type:
         </field>
     </record>
 
+    <record
+        id="storage_category_allow_new_product_cond_pallets_uk"
+        model="stock.storage.category.allow_new_product.cond"
+    >
+        <field name="name">Package type is 'Pallets UK'</field>
+        <field name="code_snippet">
+<![CDATA[
+result = False
+pallets_type = env.ref("stock_storage_type.package_storage_type_pallets_uk")
+if package_type and package_type == pallets_type:
+    result = True
+]]>
+        </field>
+    </record>
+
 </odoo>

--- a/stock_storage_type/models/stock_storage_category.py
+++ b/stock_storage_type/models/stock_storage_category.py
@@ -203,8 +203,8 @@ class StockStorageCategory(models.Model):
                     quants,
                 )
                 if not res:
-                    # Fallback on category option value
-                    return self.allow_new_product
+                    # Go to next rule
+                    break
             # All conditions are matching
             if res:
                 return rule.allow_new_product

--- a/stock_storage_type/tests/test_storage_category_allow_new_product.py
+++ b/stock_storage_type/tests/test_storage_category_allow_new_product.py
@@ -109,3 +109,51 @@ class TestStorageCategoryAllowNewProduct(TestStorageTypeCommon):
             int_picking.move_line_ids.mapped("location_dest_id"),
             self.pallets_bin_1_location,
         )
+
+    def test_storage_category_mixed_allow_new_product(self):
+        self.category.allow_new_product = "mixed"
+        self.assertEqual(self.category.get_allow_new_product(self.product), "mixed")
+
+        # Create a quant with a package of type Pallet to check the
+        # allow_new_product rule result
+        package_type_pallets = self.env.ref(
+            "stock_storage_type.package_storage_type_pallets"
+        )
+        package_type_pallets_uk = self.env.ref(
+            "stock_storage_type.package_storage_type_pallets_uk"
+        )
+        self.product2.package_type_id = package_type_pallets_uk
+        package = self.env["stock.quant.package"].create(
+            {
+                "name": "TEST PKG",
+                "package_type_id": package_type_pallets.id,
+            }
+        )
+        package_uk = self.env["stock.quant.package"].create(
+            {
+                "name": "TEST PKG",
+                "package_type_id": package_type_pallets_uk.id,
+            }
+        )
+        self.env["stock.quant"]._update_available_quantity(
+            self.product,
+            self.pallets_bin_2_location,
+            1.0,
+            package_id=package,
+        )
+        quant = self.env["stock.quant"].search(
+            [
+                ("location_id", "=", self.pallets_bin_2_location.id),
+                ("product_id", "=", self.product.id),
+                ("package_id", "=", package.id),
+            ]
+        )
+        self.assertEqual(
+            self.category.get_allow_new_product(
+                self.product2,
+                quants=quant,
+                package_type=package_type_pallets_uk,
+                package=package_uk,
+            ),
+            "same",
+        )


### PR DESCRIPTION
If there are several rules for a storage type (e.g.: in Pallets, you have Pallets/Pallets UK), don't bypass the next rules after the first condition evaluation.