### PR TITLE
[16][IMP] shopfloor_mobile_base: persist profile

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/main.js
+++ b/shopfloor_mobile_base/static/wms/src/main.js
@@ -51,7 +51,13 @@ const register_app_components = function (components) {
 register_app_components(process_registry.all());
 register_app_components(page_registry.all());
 
-config_registry.add("profile", {default: {}, reset_on_clear: true});
+config_registry.add("profile", {
+    default: {},
+    reset_on_clear: true,
+    storage: {
+        driver: "local",
+    },
+});
 config_registry.add("appmenu", {default: [], reset_on_clear: true});
 config_registry.add("authenticated", {default: false, reset_on_clear: true});
 config_registry.add("current_language", {


### PR DESCRIPTION
Align with language managment: profile selection is persisted.

Without this, on each login user is asked to choose a profile.
