### PR TITLE
[14.0][FIX] stock_available_to_promise_release: Assign transfers after unrelease return

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -686,6 +686,14 @@ class StockMove(models.Model):
                 # Do not copy the responsible user from the source picking as somebody
                 # else could scan the new cancel picking
                 cancel_picking.user_id = False
+
+                returned_moves = return_wiz.product_return_moves.move_id
+                pickings_to_assign = returned_moves.move_dest_ids.picking_id.filtered(
+                    lambda picking: picking.id != cancel_picking.id
+                    and picking.state == "confirmed"
+                )
+                if pickings_to_assign:
+                    pickings_to_assign.action_assign()
         return True
 
     def _unrelease_set_returnable_qty_per_move(

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_unrelease_2steps
 from . import test_unrelease_3steps
 from . import test_unrelease_merged_moves
 from . import test_unrelease_cancel
+from . import test_unrelease_cancel_fixed_pick

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Camptocamp SA
 # Copyright 2025 Raumschmiede GmbH
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from datetime import datetime
 
@@ -155,7 +156,11 @@ class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
         ship_picking = self._out_picking(picking_chain)
         ship_picking.release_available_to_promise()
         # Creating a second move. Both moves thave the same origin (pack.move_line)
-        self.env["stock.move"].create(ship_picking.move_lines._split(4))
+        split_move_vals = ship_picking.move_lines._split(4)
+        split_move_vals[0]["date_deadline"] = datetime.now()
+        split_move = self.env["stock.move"].create(split_move_vals)
+        split_move._action_confirm()
+        split_move._action_assign()
         pack_picking = self._prev_picking(ship_picking)
         pick_picking = self._prev_picking(pack_picking)
         self._deliver(pick_picking)

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel_fixed_pick.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel_fixed_pick.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from datetime import datetime
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseReleaseCancelFixedPick(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 50.0)
+        cls._update_qty_in_location(cls.loc_bin1, cls.product2, 50.0)
+        pick_rule = cls.wh.delivery_route_id.rule_ids.filtered(
+            lambda r: r.location_src_id == cls.loc_stock
+        )
+        pick_rule.group_propagation_option = "fixed"
+        pick_rule.group_id = cls.env["procurement.group"].create({"name": "Fixed"})
+        delivery_route = cls.wh.delivery_route_id
+        delivery_route.write(
+            {
+                "available_to_promise_defer_pull": True,
+                "allow_unrelease_return_done_move": True,
+            }
+        )
+        cls.cleanup_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Cancel Cleanup",
+                "default_location_dest_id": cls.loc_stock.id,
+                "sequence_code": "CCP",
+                "code": "internal",
+            }
+        )
+        cls.pick_type = pick_rule.picking_type_id
+        cls.pick_type.return_picking_type_id = cls.cleanup_type
+
+    def test_full_cancel(self):
+        picking_chain1 = self._create_picking_chain(
+            self.wh, [(self.product1, 10)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        picking_chain2 = self._create_picking_chain(
+            self.wh, [(self.product1, 10)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        ship_picking1 = self._out_picking(picking_chain1)
+        ship_picking1.release_available_to_promise()
+        ship_picking2 = self._out_picking(picking_chain2)
+        ship_picking2.release_available_to_promise()
+        self.assertNotEqual(ship_picking1, ship_picking2)
+        pick1 = self._prev_picking(ship_picking1)
+        pick2 = self._prev_picking(ship_picking2)
+        self.assertEqual(pick1, pick2)
+        self._deliver(pick1)
+        self.assertEqual(ship_picking1.state, "assigned")
+        self.assertEqual(ship_picking2.state, "assigned")
+        ship_picking2.action_cancel()
+        self.assertEqual(ship_picking2.state, "cancel")
+        self.assertEqual(ship_picking1.state, "assigned")
+
+    def test_partial_cancel(self):
+        picking_chain1 = self._create_picking_chain(
+            self.wh,
+            [(self.product1, 10), (self.product2, 10)],
+            date=datetime(2019, 9, 2, 16, 0),
+        )
+        picking_chain2 = self._create_picking_chain(
+            self.wh,
+            [(self.product1, 10), (self.product2, 10)],
+            date=datetime(2019, 9, 2, 16, 0),
+        )
+        ship_picking1 = self._out_picking(picking_chain1)
+        ship_picking1.release_available_to_promise()
+        ship_picking2 = self._out_picking(picking_chain2)
+        ship_picking2.release_available_to_promise()
+        self.assertNotEqual(ship_picking1, ship_picking2)
+        pick1 = self._prev_picking(ship_picking1)
+        pick2 = self._prev_picking(ship_picking2)
+        self.assertEqual(pick1, pick2)
+        self._deliver(pick1)
+        self.assertEqual(ship_picking1.state, "assigned")
+        self.assertEqual(ship_picking2.state, "assigned")
+        ship2_product2_move = ship_picking2.move_lines.filtered(
+            lambda m: m.product_id == self.product2
+        )
+        ship2_product2_move._action_cancel()
+        self.assertEqual(ship_picking2.state, "assigned")
+        self.assertEqual(ship_picking1.state, "assigned")


### PR DESCRIPTION
On a environment with a fixed procurement pick rule.

If two delivery having the same pick move as origin and one of the deliveries were canceled,
then also the none cancel delivery changed the state from assigned to confirmed.
This is because of https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/addons/stock/wizard/stock_picking_return.py#L116. 

Now after returning the already done moves it calls action_assign on the destination pickings. 
This ensures the the pickings keeping the state `assigned`. 
