### PR TITLE
[16.0][FWP][FIX] stock_available_to_promise_release: Assign transfers after unrelease return

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -730,6 +730,14 @@ class StockMove(models.Model):
                 # Do not copy the responsible user from the source picking as somebody
                 # else could scan the new cancel picking
                 cancel_picking.user_id = False
+
+                returned_moves = return_wiz.product_return_moves.move_id
+                pickings_to_assign = returned_moves.move_dest_ids.picking_id.filtered(
+                    lambda picking: picking.id != cancel_picking.id
+                    and picking.state == "confirmed"
+                )
+                if pickings_to_assign:
+                    pickings_to_assign.action_assign()
         return True
 
     def _unrelease_set_returnable_qty_per_move(

--- a/stock_available_to_promise_release/tests/__init__.py
+++ b/stock_available_to_promise_release/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_unrelease_2steps
 from . import test_unrelease_3steps
 from . import test_unrelease_merged_moves
 from . import test_unrelease_cancel
+from . import test_unrelease_cancel_fixed_pick

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel_fixed_pick.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel_fixed_pick.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from datetime import datetime
+
+from .common import PromiseReleaseCommonCase
+
+
+class TestAvailableToPromiseReleaseCancelFixedPick(PromiseReleaseCommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls._update_qty_in_location(cls.loc_bin1, cls.product1, 50.0)
+        cls._update_qty_in_location(cls.loc_bin1, cls.product2, 50.0)
+        pick_rule = cls.wh.delivery_route_id.rule_ids.filtered(
+            lambda r: r.location_src_id == cls.loc_stock
+        )
+        pick_rule.group_propagation_option = "fixed"
+        pick_rule.group_id = cls.env["procurement.group"].create({"name": "Fixed"})
+        delivery_route = cls.wh.delivery_route_id
+        delivery_route.write(
+            {
+                "available_to_promise_defer_pull": True,
+                "allow_unrelease_return_done_move": True,
+            }
+        )
+        cls.cleanup_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Cancel Cleanup",
+                "default_location_dest_id": cls.loc_stock.id,
+                "sequence_code": "CCP",
+                "code": "internal",
+            }
+        )
+        cls.pick_type = pick_rule.picking_type_id
+        cls.pick_type.return_picking_type_id = cls.cleanup_type
+
+    def test_full_cancel(self):
+        picking_chain1 = self._create_picking_chain(
+            self.wh, [(self.product1, 10)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        picking_chain2 = self._create_picking_chain(
+            self.wh, [(self.product1, 10)], date=datetime(2019, 9, 2, 16, 0)
+        )
+        ship_picking1 = self._out_picking(picking_chain1)
+        ship_picking1.release_available_to_promise()
+        ship_picking2 = self._out_picking(picking_chain2)
+        ship_picking2.release_available_to_promise()
+        self.assertNotEqual(ship_picking1, ship_picking2)
+        pick1 = self._prev_picking(ship_picking1)
+        pick2 = self._prev_picking(ship_picking2)
+        self.assertEqual(pick1, pick2)
+        self._deliver(pick1)
+        self.assertEqual(ship_picking1.state, "assigned")
+        self.assertEqual(ship_picking2.state, "assigned")
+        ship_picking2.action_cancel()
+        self.assertEqual(ship_picking2.state, "cancel")
+        self.assertEqual(ship_picking1.state, "assigned")
+
+    def test_partial_cancel(self):
+        picking_chain1 = self._create_picking_chain(
+            self.wh,
+            [(self.product1, 10), (self.product2, 10)],
+            date=datetime(2019, 9, 2, 16, 0),
+        )
+        picking_chain2 = self._create_picking_chain(
+            self.wh,
+            [(self.product1, 10), (self.product2, 10)],
+            date=datetime(2019, 9, 2, 16, 0),
+        )
+        ship_picking1 = self._out_picking(picking_chain1)
+        ship_picking1.release_available_to_promise()
+        ship_picking2 = self._out_picking(picking_chain2)
+        ship_picking2.release_available_to_promise()
+        self.assertNotEqual(ship_picking1, ship_picking2)
+        pick1 = self._prev_picking(ship_picking1)
+        pick2 = self._prev_picking(ship_picking2)
+        self.assertEqual(pick1, pick2)
+        self._deliver(pick1)
+        self.assertEqual(ship_picking1.state, "assigned")
+        self.assertEqual(ship_picking2.state, "assigned")
+        ship2_product2_move = ship_picking2.move_lines.filtered(
+            lambda m: m.product_id == self.product2
+        )
+        ship2_product2_move._action_cancel()
+        self.assertEqual(ship_picking2.state, "assigned")
+        self.assertEqual(ship_picking1.state, "assigned")

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel_fixed_pick.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel_fixed_pick.py
@@ -79,7 +79,7 @@ class TestAvailableToPromiseReleaseCancelFixedPick(PromiseReleaseCommonCase):
         self._deliver(pick1)
         self.assertEqual(ship_picking1.state, "assigned")
         self.assertEqual(ship_picking2.state, "assigned")
-        ship2_product2_move = ship_picking2.move_lines.filtered(
+        ship2_product2_move = ship_picking2.move_ids.filtered(
             lambda m: m.product_id == self.product2
         )
         ship2_product2_move._action_cancel()


### PR DESCRIPTION
FWP of #1053

This PR needs to be merged at first otherwise the tests of `sale_stock_available_to_promise_release_block` will fail. https://github.com/OCA/wms/pull/1058

cc @jbaudoux @i-vyshnevska @Ricardoalso 