### PR TITLE
[IMP] shopfloor: Add context key to control package total quantity computation

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -131,7 +131,9 @@ class DataAction(Component):
             ("package_type_id:storage_type", ["id", "name"]),
             (
                 "quant_ids:total_quantity",
-                lambda rec, fname: sum(rec.quant_ids.mapped("quantity")),
+                lambda rec, fname: 0
+                if rec.env.context.get("no_quantity", False)
+                else sum(rec.quant_ids.mapped("quantity")),
             ),
         ]
 

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -115,7 +115,7 @@ class ClusterPicking(Component):
             # suggest pack to be used for the next line
             data["package_dest"] = self.data.package(
                 last_picked_line.result_package_id.with_context(
-                    picking_id=move_line.picking_id.id
+                    picking_id=move_line.picking_id.id, no_quantity=True
                 ),
                 picking=move_line.picking_id,
             )


### PR DESCRIPTION
the total quantity per package is not relevant or displayed in all scenarios where the parser is used. currently, it's only used in the zone_picking scenario

this PR introduces a context key to conditionally disable the total quantity computation based on the use case. this avoids unnecessary access to stock.quant when the information isn't required, improving performance and preventing potential concurrency issues

example of usage: https://github.com/OCA/wms/pull/718/commits/e55352111d71ead8f00139f84218719609f844dc