### PR TITLE
[FIX] shopfloor: location_content_transfer – restrict lot search by product

### DIFF
--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -611,7 +611,11 @@ class LocationContentTransfer(Component):
             "lot": self._scan_line__by_lot,
             "none": self._scan_line__fallback,
         }
-        search_result = search.find(barcode, types=handlers.keys())
+        search_result = search.find(
+            barcode,
+            types=handlers.keys(),
+            handler_kw=dict(lot=dict(products=move_line.product_id)),
+        )
         handler = handlers.get(search_result.type, self._scan_line__fallback)
         # handler might've been called but returned no response.
         # I.E. package is scanned but doesn't matches move_line's package.

--- a/shopfloor/tests/test_cluster_picking_scan_line.py
+++ b/shopfloor/tests/test_cluster_picking_scan_line.py
@@ -78,6 +78,12 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self.product_a.tracking = "serial"
         self._simulate_batch_selected(self.batch, in_lot=True)
         line = self.batch.picking_ids.move_line_ids
+        lot = line.lot_id
+        self.assertTrue(lot)
+        lot_with_same_name = line.lot_id.copy(
+            {"product_id": self.product_b.id, "name": line.lot_id.name}
+        )
+        self.assertEqual(lot_with_same_name.name, lot.name)
         self._scan_line_ok(line, line.lot_id.name)
 
     def test_scan_line_error_product_tracked(self):


### PR DESCRIPTION
when scanning a lot barcode, if multiple products share the same lot name, the system could match the wrong lot
this fix ensures that the search is restricted to the current product to avoid incorrect lot selection and related errors