### PR TITLE
[FIX] shopfloor_reception: don't reset expiration date after lot scan

### DIFF
--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -6,7 +6,6 @@
 
 import {ScenarioBaseMixin} from "/shopfloor_mobile_base/static/wms/src/scenario/mixins.js";
 import {process_registry} from "/shopfloor_mobile_base/static/wms/src/services/process_registry.js";
-import event_hub from "/shopfloor_mobile_base/static/wms/src/services/event_hub.js";
 import {reception_states} from "./reception_states.js";
 
 const Reception = {

--- a/shopfloor_reception_mobile/static/src/scenario/reception_states.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception_states.js
@@ -8,6 +8,9 @@
     Define states for reception scenario.
     @param this VueJS component instance
 */
+
+import event_hub from "/shopfloor_mobile_base/static/wms/src/services/event_hub.js";
+
 export const reception_states = function () {
     return {
         init: {
@@ -129,13 +132,21 @@ export const reception_states = function () {
                 scan_placeholder: "Scan lot",
                 scan_input_placeholder_expiry: "Scan expiration date",
             },
+            enter: () => {
+                // Ensure the selected expiration date is reset
+                this.state.selected_expiration_date = null;
+            },
             on_scan: (barcode) => {
-                // Scan a lot
+                // The reception date could have been set manually and then a new
+                // lot name entered; we retrieve the expiration date from the line
+                // being handled if it exists
+                let expiration_date = this.state?.selected_expiration_date;
                 this.wait_call(
                     this.odoo.call("set_lot", {
                         picking_id: this.state.data.picking.id,
                         selected_line_id: this.line_being_handled.id,
                         lot_name: barcode.text,
+                        expiration_date: expiration_date,
                     })
                 ).then(() => {
                     // We need to wait for the call to the backend to be over
@@ -152,7 +163,9 @@ export const reception_states = function () {
                         selected_line_id: this.line_being_handled.id,
                         expiration_date: expiration_date,
                     })
-                );
+                ).then(() => {
+                    this.state.selected_expiration_date = expiration_date;
+                });
             },
             on_confirm_action: () => {
                 this.wait_call(


### PR DESCRIPTION
if the user selects an expiration date and then scans a lot, the expiration date is unintentionally reset, causing data loss
this fix preserves the manually entered expiration date when scanning a lot