### PR TITLE
[16.0][FW] stock_available_to_promise_release: multiple ports from 14.0

### DIFF
--- a/.oca/oca-port/blacklist/stock_available_to_promise_release.json
+++ b/.oca/oca-port/blacklist/stock_available_to_promise_release.json
@@ -1,0 +1,9 @@
+{
+  "pull_requests": {
+    "OCA/wms#556": "Already ported",
+    "OCA/wms#604": "v14 migration update, not relevant",
+    "OCA/wms#686": "Already ported",
+    "OCA/wms#810": "Already ported + not relevant",
+    "OCA/wms#1015": "14.0 backport from 16.0 (already there, false positive)"
+  }
+}

--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -872,6 +872,7 @@ class StockMove(models.Model):
                 move_names=move_names,
             )
             picking.message_post(body=body)
+            picking.last_release_date = False
 
     def _split_origins(self, origins, qty=None):
         """Split the origins of the move according to the quantity into the

--- a/stock_available_to_promise_release/tests/test_unrelease.py
+++ b/stock_available_to_promise_release/tests/test_unrelease.py
@@ -55,13 +55,14 @@ class TestAvailableToPromiseRelease(PromiseReleaseCommonCase):
         )
         self.assertEqual(self.picking.move_ids.state, "cancel")
         self.assertEqual(self.picking.state, "cancel")
+        self.assertFalse(self.picking.last_release_date)
 
     def test_unrelease_full(self):
         """Unrelease all moves of a released ship. The pick should be deleted and
         the moves should be mark as to release"""
         with self._assert_full_unreleased():
             self.shipping.move_ids.unrelease()
-
+        self.assertFalse(self.shipping.last_release_date)
         # I can release again the move and a new pick is created
         self.shipping.release_available_to_promise()
         new_picking = self._prev_picking(self.shipping) - self.picking

--- a/stock_available_to_promise_release/tests/test_unrelease_cancel.py
+++ b/stock_available_to_promise_release/tests/test_unrelease_cancel.py
@@ -1,5 +1,6 @@
 # Copyright 2025 Camptocamp SA
 # Copyright 2025 Raumschmiede GmbH
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from datetime import datetime
 
@@ -155,7 +156,11 @@ class TestAvailableToPromiseReleaseCancel(PromiseReleaseCommonCase):
         ship_picking = self._out_picking(picking_chain)
         ship_picking.release_available_to_promise()
         # Creating a second move. Both moves thave the same origin (pack.move_line)
-        self.env["stock.move"].create(ship_picking.move_ids._split(4))
+        split_move_vals = ship_picking.move_ids._split(4)
+        split_move_vals[0]["date_deadline"] = datetime.now()
+        split_move = self.env["stock.move"].create(split_move_vals)
+        split_move._action_confirm()
+        split_move._action_assign()
         pack_picking = self._prev_picking(ship_picking)
         pick_picking = self._prev_picking(pack_picking)
         self._deliver(pick_picking)


### PR DESCRIPTION
Each missing commit reported by `oca-port` have been checked.

Port from 14.0 to 16.0:
- #873
- #1053

The following PRs have been blacklisted:
- #556: Already ported
- #604: v14 migration update, not relevant
- #686: Already ported
- #810: Already ported + not relevant
- #1015: 14.0 backport from 16.0 (already there, false positive)