### PR TITLE
[16.0][FIX] sale_stock_release_channel_delivery_date: Solved singletone error while shipping address not exist

### DIFF
--- a/sale_stock_release_channel_delivery_date/models/sale_order.py
+++ b/sale_stock_release_channel_delivery_date/models/sale_order.py
@@ -75,6 +75,8 @@ class SaleOrder(models.Model):
         domain_order = self._release_channel_possible_candidate_domain_base
         domain_partner = (
             self.partner_shipping_id._release_channel_possible_candidate_domain
+            if self.partner_shipping_id
+            else []
         )
         domain_channel = [("is_manual_assignment", "=", False)]
         domain = expression.AND([domain_order, domain_partner, domain_channel])


### PR DESCRIPTION
- Issue: Singleton error occurs when the shipping address is missing on a sale order.
- Steps to reproduce:
    1) Create a sale order and add a product.
    2) Remove the “Delivery Address” from the order.
    3) Observe the singleton error traceback.
    
![Error_of_shipping_address](https://github.com/user-attachments/assets/e555f434-32e0-4011-b6b3-b13af0241f9a)
