### PR TITLE
[16.0] stock_available_to_promise_release: bump version (patch)

### DIFF
--- a/stock_available_to_promise_release/__manifest__.py
+++ b/stock_available_to_promise_release/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Stock Available to Promise Release",
-    "version": "16.0.3.8.1",
+    "version": "16.0.3.8.2",
     "summary": "Release Operations based on available to promise",
     "author": "Camptocamp, BCIM, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/wms",


### PR DESCRIPTION
Following the merge of f41c665b4f64b15b4006020d28624518c09328b4 and 795af363f85c85b0597d477c8fc65d8ab69df1cb.