### PR TITLE
[16.0][IMP] stock_available_to_promise_release: remove duplicate column in move view.

### DIFF
--- a/stock_available_to_promise_release/views/stock_move_views.xml
+++ b/stock_available_to_promise_release/views/stock_move_views.xml
@@ -12,6 +12,7 @@
                 <field name="origin" optional="show" />
                 <field name="group_id" optional="show" />
                 <field name="priority" optional="show" />
+                <field name="date_priority" optional="show" />
             </field>
             <field name="product_uom_qty" position="after">
                 <field name="ordered_available_to_promise_uom_qty" />
@@ -21,8 +22,6 @@
                     groups="base.group_no_one"
                 />
                 <field name="release_ready" optional="show" />
-                <field name="date_priority" />
-                <field name="priority" />
             </field>
             <field name="location_id" position="attributes">
                 <attribute name="optional">hide</attribute>


### PR DESCRIPTION
To see the view in question, go to `Inventory / Reporting / Moves Allocations`

### Before 
<img width="1797" height="380" alt="image" src="https://github.com/user-attachments/assets/39e881e9-dc0d-47bf-affa-8015863ca50e" />

### After
<img width="1806" height="363" alt="image" src="https://github.com/user-attachments/assets/76a2f141-64b2-4b59-8b16-3075231e56ef" />
