### PR TITLE
[FIX] shopfloor_reception_mobile: Use correct dependency

### DIFF
--- a/shopfloor_reception_mobile/__manifest__.py
+++ b/shopfloor_reception_mobile/__manifest__.py
@@ -5,7 +5,7 @@
     "summary": "Scenario for receiving products",
     "version": "16.0.1.1.0",
     "development_status": "Beta",
-    "depends": ["shopfloor_mobile_base", "shopfloor_reception"],
+    "depends": ["shopfloor_mobile_base", "shopfloor_mobile", "shopfloor_reception"],
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["JuMiSanAr"],
     "website": "https://github.com/OCA/wms",


### PR DESCRIPTION
As we use wms utils javascript defined in shopfloor_mobile, depend on it.