### PR TITLE
[16.0][FIX] stock_storage_type: migrate `max_height` values to loc. categories

### DIFF
--- a/stock_storage_type/migrations/16.0.1.0.1/post-migrate.py
+++ b/stock_storage_type/migrations/16.0.1.0.1/post-migrate.py
@@ -61,6 +61,16 @@ def _move_location_storage_type(env):
             WHERE slst.id = sscc.old_location_storage_type_id
     """
     openupgrade.logged_query(env.cr, query)
+    query = """
+        UPDATE stock_storage_category ssc
+            SET max_height = slst.max_height
+            FROM stock_location_storage_type slst,
+                 stock_storage_category_capacity sscc
+            WHERE slst.id = sscc.old_location_storage_type_id
+            AND sscc.storage_category_id = ssc.id
+            AND slst.max_height > 0
+    """
+    openupgrade.logged_query(env.cr, query)
 
 
 def _update_location_sequence(env):


### PR DESCRIPTION
Small addition to `16.0.1.0.1` migration script to migrate the `max_height` values from old location storage types to location categories.