### PR TITLE
 [16.0][FIX] shopfloor_mobile_base: display falsy but not undefined fields in detail-card.

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/detail/detail_card.js
+++ b/shopfloor_mobile_base/static/wms/src/components/detail/detail_card.js
@@ -32,7 +32,7 @@ Vue.component("item-detail-card", {
                 <!-- TODO: this loop is the same in list-item => make it a component -->
                 <v-card-text class="details" v-if="opts.fields.length">
                     <div v-for="(field, index) in opts.fields" :class="'field-detail ' + field.path.replace('.', '-') + ' ' + (field.klass || '')">
-                        <div v-if="raw_value(record, field) || field.display_no_value">
+                        <div v-if="raw_value(record, field) !== undefined || field.display_no_value">
                             <span v-if="field.label" class="label">{{ field.label }}:</span>
                             <component
                                 v-if="field.render_component"


### PR DESCRIPTION
If the field is equal to `0` or `""` it would not get displayed in the card