### PR TITLE
[16.0] shopfloor_base: critical fixes

### DIFF
--- a/shopfloor_base/models/shopfloor_app.py
+++ b/shopfloor_base/models/shopfloor_app.py
@@ -163,7 +163,8 @@ class ShopfloorApp(models.Model):
 
     def _registered_endpoint_rule_keys(self):
         # `endpoint.route.sync.mixin` api
-        return [x[0] for x in self._registered_routes()]
+        # TODO: add tests
+        return [x.key for x in self._registered_routes()]
 
     def _register_hook(self):
         super()._register_hook()

--- a/shopfloor_base/models/shopfloor_app.py
+++ b/shopfloor_base/models/shopfloor_app.py
@@ -253,6 +253,12 @@ class ShopfloorApp(models.Model):
         method_name = vals.pop("_method_name")
         route_handler = self.env["endpoint.route.handler.tool"]
         new_route = route_handler.new(vals)
+        # SF endpoints must use the ``restapi`` dispatcher provided by base_rest.
+        # NOTE: this ``route_type`` value
+        # is not declared on `endpoint.route.handler.route_type` field selection,
+        # but is not relevant in this case
+        # because the value is set only on a in memory recordset.
+        new_route.route_type = "restapi"
         new_route._refresh_endpoint_data()
         options = {
             "handler": {

--- a/shopfloor_base/tests/test_shopfloor_app.py
+++ b/shopfloor_base/tests/test_shopfloor_app.py
@@ -65,7 +65,12 @@ class TestShopfloorApp(CommonCase):
                 ),
                 "method_name": "_process_endpoint",
             }
-            self.assertEqual(rule.handler_options, expected_handler_opts)
+            for k, v in expected_handler_opts.items():
+                self.assertEqual(
+                    rule.handler_options[k],
+                    v,
+                    f"{k} differs: {rule.handler_options[k]} != {v}",
+                )
             _check[rule.route] = set(rule.routing["methods"])
         expected = {
             # TODO: review methods
@@ -145,7 +150,10 @@ class TestShopfloorApp(CommonCase):
         )
 
     def test_make_app_manifest(self):
-        param = "http://localhost:8069"
+        self.env["ir.config_parameter"].sudo().set_param(
+            "web.base.url", "http://foo.com"
+        )
+        param = "http://foo.com"
         manifest = self.shopfloor_app._make_app_manifest()
         expected = {
             "name": self.shopfloor_app.name,

--- a/shopfloor_base/tests/test_shopfloor_app.py
+++ b/shopfloor_base/tests/test_shopfloor_app.py
@@ -55,6 +55,7 @@ class TestShopfloorApp(CommonCase):
         routes = rec._registered_routes()
         _check = {}
         for rule in routes:
+            self.assertEqual(rule.routing["type"], "restapi")
             self.assertEqual(rule.route_group, rec._route_group())
             self.assertTrue(rule.endpoint_hash)
             service, endpoint = rule.route.split("/")[-2:]


### PR DESCRIPTION
Backport of https://github.com/OCA/shopfloor-app/pull/19


### [shopfloor_base: fix _registered_endpoint_rule_keys ](https://github.com/OCA/wms/commit/43b9b2b2097cd5df7ecfb1244672863f2929747a)

This was breaking _unregister_controllers since we don't get tuples
but EndpointRule objects.

Prior to this change the call failed like
```
  File /odoo/external-src/shopfloor-app/shopfloor_base/models/shopfloor_app.py, line 166, in _registered_endpoint_rule_keys
    return [x[0] for x in self._registered_routes()]
            ~^^^
TypeError: 'EndpointRule' object is not subscriptable
```

**How to reproduce:** archive an app and sync registry (or directly call the method on an existing active app).

### [shopfloor_base: fix routing registration](https://github.com/OCA/wms/commit/7001f8c8ba18981895fdc5b59ac5d67fd9176e17)  (the most important fix)

This prevented the usage of the `fastapi` dispatcher leading - among other things - to broken handling of server side errors as exceptions are not wrapped.

**How to reproduce:** raise an exception server side (eg: override the 1st method of a scenario to raise an exception in any case) and see on the screen an alert w/ "undefined undefined" instead of a nice error message.


### TODO

@lmignon I have no time to test this on 16 so I simply backported the fixes. Could you have a look?
Migrations scripts should be also ported (w/o the "readonly" flag) iif the issue is confirmed as all the existing routes should be updated.