### PR TITLE
[16.0][BACKPORT][FIX] stock_release_channel_shipment_lead_time: shipment_date dt to date conversion

### DIFF
--- a/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
+++ b/stock_release_channel_shipment_lead_time/models/stock_release_channel.py
@@ -66,9 +66,9 @@ class StockReleaseChannel(models.Model):
         for channel in self:
             shipment_date = False
             if channel.process_end_date:
-                shipment_date = channel._add_shipment_lead_time(
-                    channel.process_end_date
-                )
+                shipment_date = self._localize(
+                    channel._add_shipment_lead_time(channel.process_end_date)
+                ).date()
             channel.shipment_date = shipment_date
 
     @property


### PR DESCRIPTION
Backport of:
* https://github.com/OCA/stock-logistics-release-channel/pull/26

cc @sebalix 