### PR TITLE
[16.0][FIX] stock_storage_type: Fixed wrong usage of create function

### DIFF
--- a/stock_storage_type/models/stock_quant_package.py
+++ b/stock_storage_type/models/stock_quant_package.py
@@ -57,8 +57,8 @@ class StockQuantPackage(models.Model):
         return res
 
     @api.model_create_multi
-    def create(self, vals):
-        records = super().create(vals)
+    def create(self, vals_list):
+        records = super().create(vals_list)
         records._sync_package_type_from_packaging()
         return records
 


### PR DESCRIPTION
Using the wrong parameter in create function leads to, that for stock.quant.package all create-functions called with parameter "vals_list" will break.

TypeError: Base.create() got an unexpected keyword argument 'vals_list'