### PR TITLE
[16.0][IMP] stock_available_to_promise_release no search available to promise qty on done / canceled moves

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -471,7 +471,17 @@ class StockMove(models.Model):
         }
         if operator not in operator_mapping:
             raise UserError(_("Unsupported operator %s") % (operator,))
-        moves = self.search([("need_release", "=", True)])
+
+        moves = self.search(
+            [
+                (
+                    "state",
+                    "in",
+                    ["waiting", "confirmed", "partially_available", "assigned"],
+                ),
+                ("need_release", "=", True),
+            ]
+        )
         operator_func = operator_mapping[operator]
         # computed field has no depends set, invalidate cache before reading
         moves.invalidate_recordset(["ordered_available_to_promise_uom_qty"])


### PR DESCRIPTION
### Context 
I am trying to improve the processing time of [`product.pickings_auto_release`](https://github.com/OCA/stock-logistics-warehouse/blob/0639912c240d7693a86253abcc79b6be6a736248/stock_move_auto_assign_auto_release/models/product_product.py#L18)
With a large number of moves, this operation is slow and becomes slower as the number of moves increases. 
I wonder why we should look for available quantities to promise in moves that are already done or cancelled?
Perhaps there is a reason for this, but IMO we should exclude them from the search.

1. When stock move is done [_prepare_auto_assign](https://github.com/OCA/stock-logistics-warehouse/blob/0639912c240d7693a86253abcc79b6be6a736248/stock_move_auto_assign/models/stock_move.py#L15) is called.
2. Product moves with [is_auto_release_allowed](https://github.com/OCA/stock-logistics-warehouse/blob/0639912c240d7693a86253abcc79b6be6a736248/stock_move_auto_assign_auto_release/models/stock_picking.py#L38) are searched. `release_ready` is part of the search domain
3. `_search_release_ready` scan ALL moves with `ordered_available_to_promise_uom_qty > 0` no matter the state. 
https://github.com/OCA/wms/blob/da5e224621c6f128e84031f77f3a910673022f87/stock_available_to_promise_release/models/stock_move.py#L387 => This is very slow

**Speedscope before this change** (~1min)

<img width="2556" height="1326" alt="image" src="https://github.com/user-attachments/assets/b8e222f1-0b3c-41fa-9299-55fb4a1e74d2" />

**Speedscope after this change** (~12s)
<img width="2547" height="1340" alt="image" src="https://github.com/user-attachments/assets/14e427cd-740d-415f-b81b-79c19a6ccbce" />



