### PR TITLE
[16.0][FIX] stock_release_channel_shipment_advice_deliver job function process_shipments

### DIFF
--- a/stock_release_channel_shipment_advice_deliver/data/queue_job_function.xml
+++ b/stock_release_channel_shipment_advice_deliver/data/queue_job_function.xml
@@ -2,14 +2,14 @@
 <odoo noupdate="1">
 
     <record
-        id="job_function_stock_release_channel_action_deliver"
+        id="job_function_stock_release_channel_process_shipments"
         model="queue.job.function"
     >
         <field
             name="model_id"
             ref="stock_release_channel.model_stock_release_channel"
         />
-        <field name="method">_action_deliver</field>
+        <field name="method">_process_shipments</field>
         <field name="channel_id" ref="channel_root_background_stock_picking_deliver" />
     </record>
 


### PR DESCRIPTION
Missing job_function to `_action_deliver`

Actually there is a job function to `_action_deliver` but this one is never used as the method that is called with delay is `_action_deliver`.

https://github.com/OCA/wms/blob/da5e224621c6f128e84031f77f3a910673022f87/stock_release_channel_shipment_advice_deliver/models/stock_release_channel.py#L201

