### PR TITLE
[16.0][BWP][FIX]shopfloor_reception: Make lot_id mandatory at set_lot step

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1149,10 +1149,22 @@ class Reception(Component):
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
         if message:
             return self._response_for_set_lot(picking, selected_line, message=message)
-        message = self._check_expiry_date(selected_line)
-        if message:
-            return self._response_for_set_lot(picking, selected_line, message=message)
+        checks = [
+            self._check_expiry_date,
+            self._check_lot,
+        ]
+        for check in checks:
+            message = check(selected_line)
+            if message:
+                return self._response_for_set_lot(
+                    picking, selected_line, message=message
+                )
         return self._before_state__set_quantity(picking, selected_line)
+
+    def _check_lot(self, line):
+        need_lot = line.product_id.tracking == "lot"
+        if need_lot and not line.lot_id:
+            return self.msg_store.scan_lot_on_product_tracked_by_lot()
 
     def _check_expiry_date(self, line):
         use_expiration_date = (

--- a/shopfloor_reception/tests/test_set_lot_confirm.py
+++ b/shopfloor_reception/tests/test_set_lot_confirm.py
@@ -8,7 +8,30 @@ class TestSetLotConfirm(CommonCase):
     @classmethod
     def setUpClassBaseData(cls):
         super().setUpClassBaseData()
-        cls.product_a.tracking = "lot"
+
+    def test_ensure_lot(self):
+        picking = self._create_picking()
+        self.product_a.tracking = "lot"
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda li: li.product_id == self.product_a
+        )
+        response = self.service.dispatch(
+            "set_lot_confirm_action",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+            },
+        )
+        message = self.msg_store.scan_lot_on_product_tracked_by_lot()
+        self.assert_response(
+            response,
+            next_state="set_lot",
+            data={
+                "picking": self.data.picking(picking),
+                "selected_move_line": self.data.move_lines(selected_move_line),
+            },
+            message=message,
+        )
 
     def test_ensure_expiry_date(self):
         picking = self._create_picking()


### PR DESCRIPTION
backward port of: https://github.com/OCA/stock-logistics-shopfloor/pull/52