### PR TITLE
[16.0][FIX] shopfloor_mobile: fix duplicate title in "detail-product" component.

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/detail/detail_product.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_product.js
@@ -136,9 +136,10 @@ Vue.component("detail-product", {
                         </template>
                     </item-detail-card>
               </v-expansion-panel-header>
-              <v-expansion-panel-content v-for="(lot, i) in location.lots">
+              <v-expansion-panel-content>
                 <separator-title v-if="location.lots.length > 0">Lots</separator-title>
                 <item-detail-card
+                v-for="(lot, i) in location.lots"
                 :record="lot"
                 v-bind="$props"
                 :key="make_component_key(['lot', lot.id])"


### PR DESCRIPTION
The "Lots" title was incorrectly placed inside the for loop, making it appear at every iteration

<img width="832" height="721" alt="image" src="https://github.com/user-attachments/assets/2a9a5d6d-2ce2-4078-8298-340acc14a8e0" />
