### PR TITLE
[16.0][FIX] shopfloor_reception: incorrect increment of move line qty_done on manual selection.

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1043,7 +1043,7 @@ class Reception(Component):
     def manual_select_move(self, move_id):
         move = self.env["stock.move"].browse(move_id)
         picking = move.picking_id
-        return self._scan_line__find_or_create_line(picking, move)
+        return self._scan_line__find_or_create_line(picking, move, qty_done=0)
 
     def done_action(self, picking_id, confirmation=False):
         """Mark a picking as done

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -250,13 +250,12 @@ class TestSetDestination(CommonCase):
         # User 1 finishes his work
         move_line_data = res_u1["data"]["set_quantity"]["selected_move_line"][0]
         line_id_u1 = move_line_data["id"]
-        qty_done_u1 = move_line_data["qty_done"]
         res_u1 = service_u1.dispatch(
             "process_without_pack",
             params={
                 "picking_id": picking.id,
                 "selected_line_id": line_id_u1,
-                "quantity": qty_done_u1,
+                "quantity": 1,
             },
         )
         res_u1 = service_u1.dispatch(


### PR DESCRIPTION
Currently, selecting a move line manually automatically increments the `qty_done` by 1. This behavior creates data inconsistencies if an operator selects a line by mistake; navigating "Back" does not revert the increment, leaving an incorrect quantity on the move line.