### PR TITLE
[14.0][FIX] shopfloor_delivery_shipment: Search only docks of warehouse

### DIFF
--- a/shopfloor_delivery_shipment/actions/search.py
+++ b/shopfloor_delivery_shipment/actions/search.py
@@ -1,15 +1,19 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2026 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo.osv import expression
+
 from odoo.addons.component.core import Component
 
 
 class SearchAction(Component):
     _inherit = "shopfloor.search.action"
 
-    def dock_from_scan(self, barcode):
+    def dock_from_scan(self, barcode, warehouses=None):
         model = self.env["stock.dock"]
         if not barcode:
             return model.browse()
-        return model.search(
-            ["|", ("barcode", "=", barcode), ("name", "=", barcode)], limit=1
-        )
+        domain = ["|", ("barcode", "=", barcode), ("name", "=", barcode)]
+        if warehouses:
+            domain = expression.AND([domain, [("warehouse_id", "in", warehouses.ids)]])
+        return model.search(domain, limit=1)

--- a/shopfloor_delivery_shipment/services/delivery_shipment.py
+++ b/shopfloor_delivery_shipment/services/delivery_shipment.py
@@ -60,7 +60,7 @@ class DeliveryShipment(Component):
             # End point called with the back button
             return self._response_for_scan_dock()
         search = self._actions_for("search")
-        dock = search.dock_from_scan(barcode)
+        dock = search.dock_from_scan(barcode, self.picking_types.warehouse_id)
         if dock:
             shipment_advice = self._find_shipment_advice_from_dock(dock)
             if not shipment_advice:

--- a/shopfloor_delivery_shipment/tests/test_delivery_shipment_scan_dock.py
+++ b/shopfloor_delivery_shipment/tests/test_delivery_shipment_scan_dock.py
@@ -106,3 +106,21 @@ class DeliveryShipmentScanDockCase(DeliveryShipmentCommonCase):
         self.assert_response_scan_document(
             response, self.shipment, lines_to_load=lines_to_load
         )
+
+    def test_scan_dock_same_barcode_different_warehouses(self):
+        self.shipment.dock_id = self.dock2.id
+        self.shipment.action_confirm()
+        self.shipment.action_in_progress()
+        wh2 = self.wh.sudo().create({"name": "WH2", "code": "wh2"})
+        barcode = "test-dock"
+        self.dock.sudo().write(
+            {
+                "barcode": barcode,
+                "warehouse_id": wh2.id,
+            }
+        )
+        self.dock2.sudo().barcode = barcode
+        response = self.service.dispatch(
+            "scan_dock", params={"barcode": self.dock.barcode}
+        )
+        self.assert_response_scan_document(response, self.shipment)


### PR DESCRIPTION
If there are docks with same barcodes in different warehouses.
It depends on the ordering of docks, if dock for the right warehouse is found. 
By adding the warehouse to the domain when searching a dock it is fixed. 

@jbaudoux 
