### PR TITLE
[16.0][FIX] shopfloor_base: fix _registered_endpoint_rule_keys

### DIFF
--- a/shopfloor_base/models/shopfloor_app.py
+++ b/shopfloor_base/models/shopfloor_app.py
@@ -163,7 +163,8 @@ class ShopfloorApp(models.Model):
 
     def _registered_endpoint_rule_keys(self):
         # `endpoint.route.sync.mixin` api
-        return [x[0] for x in self._registered_routes()]
+        # TODO: add tests
+        return [x.key for x in self._registered_routes()]
 
     def _register_hook(self):
         super()._register_hook()

--- a/shopfloor_base/tests/test_shopfloor_app.py
+++ b/shopfloor_base/tests/test_shopfloor_app.py
@@ -65,7 +65,12 @@ class TestShopfloorApp(CommonCase):
                 ),
                 "method_name": "_process_endpoint",
             }
-            self.assertEqual(rule.handler_options, expected_handler_opts)
+            for k, v in expected_handler_opts.items():
+                self.assertEqual(
+                    rule.handler_options[k],
+                    v,
+                    f"{k} differs: {rule.handler_options[k]} != {v}",
+                )
             _check[rule.route] = set(rule.routing["methods"])
         expected = {
             # TODO: review methods
@@ -145,7 +150,10 @@ class TestShopfloorApp(CommonCase):
         )
 
     def test_make_app_manifest(self):
-        param = "http://localhost:8069"
+        self.env["ir.config_parameter"].sudo().set_param(
+            "web.base.url", "http://foo.com"
+        )
+        param = "http://foo.com"
         manifest = self.shopfloor_app._make_app_manifest()
         expected = {
             "name": self.shopfloor_app.name,


### PR DESCRIPTION
This PR is a partial backport of OCA/shopfloor-app#19, following up on the discussion in OCA/wms#1104.

### Improvements & Fixes

shopfloor_base: fix `_registered_endpoint_rule_keys`

Corrects a TypeError where EndpointRule objects were being accessed as tuples (non-subscriptable).
This ensures that archiving an app and syncing the registry no longer triggers a crash.

### Exclusions & Technical Notes
 Routing Registration Fix

I have intentionally excluded the ["routing registration" fix](https://github.com/OCA/wms/commit/7001f8c8ba18981895fdc5b59ac5d67fd9176e17) from this backport for the following reasons:

1. **Compatibility Issue**: Implementing the change in Odoo 16.0 resulted in a ValueError:
`Wrong value for endpoint.route.handler.tool.route_type: 'restapi'`
2. **Non-Reproducible**: I was unable to reproduce the bug (unwrapped server-side exceptions leading to "undefined undefined" alerts).