### PR TITLE
[16.0][FIX] stock_release_channel: Add missing multi company ir.rule

### DIFF
--- a/stock_release_channel/security/stock_release_channel.xml
+++ b/stock_release_channel/security/stock_release_channel.xml
@@ -31,4 +31,10 @@
         <field name="perm_unlink" eval="1" />
     </record>
 
+    <record model="ir.rule" id="stock_release_channel_comp_rule">
+        <field name="name">Stock Release Channel multi-company</field>
+        <field name="model_id" ref="model_stock_release_channel" />
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
+
 </odoo>

--- a/stock_release_channel_shipment_advice_deliver/models/shipment_advice.py
+++ b/stock_release_channel_shipment_advice_deliver/models/shipment_advice.py
@@ -76,8 +76,8 @@ class ShipmentAdvice(models.Model):
             )
         return True
 
-    def _postprocess_action_done(self):
-        res = super()._postprocess_action_done()
+    def _postprocess_action_done(self, backorder_policy):
+        res = super()._postprocess_action_done(backorder_policy)
         if not self.release_channel_id:
             return res
         if self.state == "error":


### PR DESCRIPTION
This is a follow up for https://github.com/OCA/wms/pull/842

Within this PR i fixed also the missing method argument for
`stock_release_channel_shipment_advice_deliver` -> `shipment_advice` -> `_postprocess_action_done` -> `backorder_policy`
which was added within https://github.com/OCA/stock-logistics-transport/pull/156

cc @i-vyshnevska @jbaudoux @sebalix 