### PR TITLE
[16.0][IMP] shopfloor_mobile: display absolute unit counts in packaging picker

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.js
@@ -282,7 +282,7 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
                     </v-col>
                     <v-col>
                         <div class="pkg-name"> {{ pkg[pkgNameKey] }}</div>
-                        <div v-if="contained_packaging[pkg.id]" class="pkg-qty">(x{{ contained_packaging[pkg.id].qty }} {{ contained_packaging[pkg.id].pkg.name }})</div>
+                        <div v-if="pkg.id !== unit_uom.id" class="pkg-qty">(x{{ _.round(pkg.qty / unit_uom.qty, unit_uom.rounding || 3) }} {{ unit_uom.name }})</div>
                     </v-col>
                 </v-row>
             </v-expansion-panel-content>


### PR DESCRIPTION
Updated the 'packaging-qty-picker' component to display the total number of base units contained within each packaging level. Previously, only relative quantities (e.g., x6 Level 2) were shown. This change provides the absolute unit count (e.g., x48 Units) to simplify encoding for the operator.

---

| Before | After |
| :---: | :---: |
| <img width="367" alt="before" src="https://github.com/user-attachments/assets/a16d264f-2c0e-481e-9d26-aab92f743607" /> | <img width="369" alt="after" src="https://github.com/user-attachments/assets/5a7f6d59-4f37-4b05-99f1-99dc5a43bf09" /> |