### PR TITLE
[16.0][FIX] stock_available_to_promise_release: improve returnable qty calculation

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -828,7 +828,7 @@ class StockMove(models.Model):
                 # in case of canceled origin_moves, the quantity to return must
                 # be limited to the quantity not consumed
                 done_dest_moves = done_moves.move_dest_ids.filtered(
-                    lambda m: m.state == "done"
+                    lambda m: m.state == "done" or m.product_uom_qty == m.quantity_done
                 )
                 returnable_qty = sum(done_moves.mapped("product_qty")) - sum(
                     done_dest_moves.mapped("product_qty")


### PR DESCRIPTION
Correct the identification of consumed moves by checking done quantities in addition to the move state.

The previous logic only considered moves in the 'done' state. However, during certain validation flows, a move might have its `quantity_done` fully set while its `state` hasn't yet been updated. This caused the returnable quantity to be over-calculated, incorrectly preventing the cancellation of moves.

By including moves where `product_uom_qty == m.quantity_done`, we accurately capture moves that are effectively finished, regardless of their transient state.