### PR TITLE
[16.0][IMP] shopfloor/shopfloor_reception: prevent unexpected backorders when unmarking moves

### DIFF
--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -152,32 +152,33 @@ class StockAction(Component):
                 lines.write(values_assigned)
         move_lines.picking_id.filtered(lambda p: p.user_id != user).user_id = user.id
 
-    def unmark_move_line_as_picked(self, move_lines):
+    def unmark_move_line_as_picked(self, move_lines, split=True):
         """Reverse the change from `mark_move_line_as_picked`."""
         move_lines.write(
             {
                 "shopfloor_user_id": False,
                 "qty_done": 0,
                 "result_package_id": False,
+                "lot_id": False,
             }
         )
         pickings = move_lines.picking_id
         for picking in pickings:
-            lines_still_assigned = picking.move_line_ids.filtered(
-                lambda x: x.shopfloor_user_id
-            )
-            if lines_still_assigned:
-                # Because there is other lines in the picking still assigned
-                # The picking has to be split
-                unmark_lines = picking.move_line_ids & move_lines
-                unmark_lines._extract_in_split_order(default={"user_id": False})
-            else:
-                pickings.write(
+            still_assigned_users = picking.move_line_ids.shopfloor_user_id
+            if not still_assigned_users:
+                picking.write(
                     {
                         "user_id": False,
                         "printed": False,
                     }
                 )
+            else:
+                # Decide what to do if there are other lines in the picking still assigned
+                if split:
+                    unmarked_lines = picking.move_line_ids & move_lines
+                    unmarked_lines._extract_in_split_order(default={"user_id": False})
+                else:
+                    picking.user_id = still_assigned_users[0]
 
     def validate_moves(self, moves):
         """Validate moves in different ways depending on several criterias:

--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -176,7 +176,9 @@ class StockAction(Component):
                 # Decide what to do if there are other lines in the picking still assigned
                 if split:
                     unmarked_lines = picking.move_line_ids & move_lines
-                    unmarked_lines._extract_in_split_order(default={"user_id": False})
+                    unmarked_lines._extract_in_split_order(
+                        default={"user_id": False, "printed": False}
+                    )
                 else:
                     picking.user_id = still_assigned_users[0]
 

--- a/shopfloor/tests/test_actions_stock.py
+++ b/shopfloor/tests/test_actions_stock.py
@@ -23,6 +23,17 @@ class TestActionsStock(CommonCase):
         cls._fill_stock_for_moves(cls.move1)
         cls.picking.action_assign()
 
+        cls.other_user = (
+            cls.env["res.users"]
+            .sudo()
+            .create(
+                {
+                    "name": "Other user",
+                    "login": "other_user",
+                }
+            )
+        )
+
     @classmethod
     def setUpClassVars(cls):
         super().setUpClassVars()
@@ -46,3 +57,43 @@ class TestActionsStock(CommonCase):
         self.assertTrue(self.picking.move_line_ids.shopfloor_user_id)
         self.assertFalse(picking_not_assigned.move_line_ids.shopfloor_user_id)
         self.assertFalse(picking_not_assigned.user_id)
+
+    def test_unmark_move_line_as_picked_nosplit_full_picking(self):
+        lines = self.picking.move_line_ids
+        self.stock.mark_move_line_as_picked(lines)
+        self.assertEqual(self.picking.user_id, self.env.user)
+
+        self.stock.unmark_move_line_as_picked(lines, split=False)
+        self.assertFalse(lines.shopfloor_user_id)
+        self.assertEqual(lines.picking_id, self.picking)
+        self.assertFalse(self.picking.user_id)
+
+    def test_unmark_move_line_as_picked_nosplit_partial_picking_same_user(self):
+        lines = self.picking.move_line_ids
+        self.stock.mark_move_line_as_picked(lines)
+        self.assertEqual(self.picking.user_id, self.env.user)
+
+        line_unpicked = lines[0]
+        self.stock.unmark_move_line_as_picked(line_unpicked, split=False)
+        self.assertFalse(line_unpicked.shopfloor_user_id)
+        self.assertEqual(line_unpicked.picking_id, self.picking)
+        self.assertEqual(self.picking.user_id, self.env.user)
+
+    def test_unmark_move_line_as_picked_nosplit_partial_picking_different_user(self):
+        lines = self.picking.move_line_ids
+        self.stock.mark_move_line_as_picked(lines[0], user=self.env.user, split=False)
+        self.stock.mark_move_line_as_picked(lines[1], user=self.other_user, split=False)
+
+        user_line = lines.filtered(lambda line: line.shopfloor_user_id == self.env.user)
+        other_line = lines.filtered(
+            lambda line: line.shopfloor_user_id == self.other_user
+        )
+        self.assertEqual(self.picking.user_id, self.other_user)
+        self.assertEqual(len(user_line), 1)
+        self.assertEqual(len(other_line), 1)
+
+        self.stock.unmark_move_line_as_picked(other_line, split=False)
+        self.assertFalse(other_line.shopfloor_user_id)
+        self.assertEqual(user_line.shopfloor_user_id, self.env.user)
+        self.assertEqual(lines.picking_id, self.picking)
+        self.assertEqual(self.picking.user_id, self.env.user)

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1324,7 +1324,7 @@ class Reception(Component):
         if selected_line.exists():
             if selected_line.reserved_uom_qty:
                 stock = self._actions_for("stock")
-                stock.unmark_move_line_as_picked(selected_line)
+                stock.unmark_move_line_as_picked(selected_line, split=False)
             else:
                 selected_line.unlink()
         return self._response_for_select_move(picking)

--- a/shopfloor_reception/tests/test_set_quantity_action.py
+++ b/shopfloor_reception/tests/test_set_quantity_action.py
@@ -80,10 +80,10 @@ class TestSetQuantityAction(CommonCase):
         )
         self.assertFalse(self.selected_move_line.result_package_id)
 
-    def test_cancel_action(self):
-        picking = self._create_picking()
+    def test_cancel_action_concurrent(self):
+        picking = self.picking
         move_product_a = picking.move_ids.filtered(
-            lambda l: l.product_id == self.product_a
+            lambda m: m.product_id == self.product_a
         )
         # User 1 and 2 selects the same picking
         service_user_1 = self.service
@@ -169,3 +169,52 @@ class TestSetQuantityAction(CommonCase):
         )
         # This line has been created by shopfloor, therefore, we unlinked it
         self.assertFalse(move_line_user_2.exists())
+
+    def test_cancel_action_no_backorder(self):
+        picking = self.picking
+        move_line = self.selected_move_line
+        move = self.selected_move_line.move_id
+
+        self.service.dispatch(
+            "process_without_pack",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": move_line.id,
+                "quantity": 2,
+            },
+        )
+        self.assertEqual(move.quantity_done, 2)
+        self.assertEqual(len(move.move_line_ids), 2)
+
+        new_move_line = move.move_line_ids - move_line
+        self.assertEqual(new_move_line.reserved_qty, 8)
+
+        # Make some modifications on the new move line
+        self.service.dispatch(
+            "set_quantity",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": new_move_line.id,
+                "quantity": 3,
+            },
+        )
+        new_move_line.lot_id = self._create_lot()
+        self.assertTrue(new_move_line.lot_id)
+        self.assertTrue(new_move_line.qty_done)
+
+        # cancel modifications on new move line
+        self.service.dispatch(
+            "set_quantity__cancel_action",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": new_move_line.id,
+            },
+        )
+        self.assertTrue(new_move_line.exists())
+        self.assertEqual(new_move_line.reserved_qty, 8)
+        self.assertFalse(new_move_line.lot_id)
+        self.assertEqual(
+            new_move_line.picking_id,
+            move_line.picking_id,
+            "Cancelling the move line should not move it into a backorder",
+        )

--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -155,7 +155,7 @@ const Reception = {
                                 <btn-back/>
                             </v-col>
                             <v-col class="text-center" cols="12">
-                                <cancel-button/>
+                                <cancel-button @cancel="state.on_cancel"/>
                             </v-col>
                         </v-row>
                     </div>


### PR DESCRIPTION
Previously, unmarking a move line as picked would trigger backorder logic (see https://github.com/OCA/wms/pull/543),
moving assigned moves into a new picking. This was functionally confusing
for UI users in the reception scenario, as canceling an action on a move line would cause items to
"disappear" from the current picking.

There is now an option on the unmarking function to choose to not trigger this split.