### PR TITLE
[16.0][FIX] stock_available_to_promise_release: fix Kanban counter layout

### DIFF
--- a/stock_available_to_promise_release/views/stock_picking_type_views.xml
+++ b/stock_available_to_promise_release/views/stock_picking_type_views.xml
@@ -13,13 +13,11 @@
                 position="before"
             >
                 <div t-if="record.count_picking_need_release.raw_value > 0" class="row">
-                    <div class="col-9">
+                    <div class="col-12">
                         <a name="get_action_picking_tree_need_release" type="object">
-                            Need Release
-                        </a>
-                    </div>
-                    <div class="col-3">
-                        <field name="count_picking_need_release" />
+                            <field
+                                name="count_picking_need_release"
+                            /> Need Release </a>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
The "Need Release" counter on the Picking Type Kanban view was inconsistent with standard Odoo counters. Additionally, the layout broke when the count reached 1,000 or more, causing the number to overflow the card boundaries.

| Before | <img width="1587" height="649" alt="image" src="https://github.com/user-attachments/assets/fdfd1a05-3329-478c-9a3c-ad3ce1d5c8f2" /> |
|--------|--------|
| After | <img width="1598" height="667" alt="image" src="https://github.com/user-attachments/assets/2811e018-2950-47ce-ba30-7b84e7a91e14" /> | 