### PR TITLE
[16.0][FIX] shopfloor: fix test broken after dependent module update

### DIFF
--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -153,7 +153,10 @@ class ActionsDataCase(ActionsDataCaseBase):
             "weight": 110.0,
             "partner": {"id": self.customer.id, "name": self.customer.name},
             "carrier": {"id": carrier.id, "name": carrier.name},
-            "ship_carrier": None,
+            "ship_carrier": {
+                "id": self.picking.ship_carrier_id.id,
+                "name": self.picking.ship_carrier_id.name,
+            },
             "priority": "0",
         }
         self.assertEqual(data.pop("scheduled_date").split("T")[0], "2020-08-03")
@@ -177,7 +180,10 @@ class ActionsDataCase(ActionsDataCaseBase):
             "weight": 110.0,
             "partner": {"id": self.customer.id, "name": self.customer.name},
             "carrier": {"id": carrier.id, "name": carrier.name},
-            "ship_carrier": None,
+            "ship_carrier": {
+                "id": self.picking.ship_carrier_id.id,
+                "name": self.picking.ship_carrier_id.name,
+            },
             "progress": 0.0,
             "priority": "0",
         }

--- a/shopfloor/tests/test_actions_data_detail.py
+++ b/shopfloor/tests/test_actions_data_detail.py
@@ -122,7 +122,10 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "name": picking.name,
             "note": Markup("<p>read me</p>"),
             "origin": "created by test",
-            "ship_carrier": None,
+            "ship_carrier": {
+                "id": picking.ship_carrier_id.id,
+                "name": picking.ship_carrier_id.name,
+            },
             "weight": 110.0,
             "partner": {"id": self.customer.id, "name": self.customer.name},
             "carrier": {"id": picking.carrier_id.id, "name": picking.carrier_id.name},
@@ -159,7 +162,10 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "name": picking.name,
             "note": Markup("<p>read me</p>"),
             "origin": "created by test",
-            "ship_carrier": None,
+            "ship_carrier": {
+                "id": picking.ship_carrier_id.id,
+                "name": picking.ship_carrier_id.name,
+            },
             "weight": 110.0,
             "partner": {"id": self.customer.id, "name": self.customer.name},
             "carrier": {"id": picking.carrier_id.id, "name": picking.carrier_id.name},


### PR DESCRIPTION
Tests recently broke because of this commit in a dependent module: https://github.com/OCA/delivery-carrier/commit/9c8bd5c110e413b127eaa10dd02240ccfbadca60

See this PR: https://github.com/OCA/delivery-carrier/pull/1142

An outgoing picking is now considered its own "ship_picking_id" (which was not the case before) leading to more data than previously expected in the tests.