### PR TITLE
[16.0][FIX] shopfloor_reception: correct _set_quantity__by_lot signature

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -754,8 +754,8 @@ class Reception(Component):
         selected_line.location_dest_id = location
         return self._response_for_select_move(picking)
 
-    def _set_quantity__by_lot(self, picking, selected_line, barcode):
-        if selected_line.lot_id.name == barcode or selected_line.lot_name == barcode:
+    def _set_quantity__by_lot(self, picking, selected_line, lot):
+        if selected_line.lot_id.name == lot.name or selected_line.lot_name == lot.name:
             selected_line.qty_done += 1
             return self._response_for_set_quantity(picking, selected_line)
 

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -53,6 +53,28 @@ class TestSetQuantity(CommonCase):
             },
         )
 
+    def test_set_quantity_scan_lot(self):
+        picking = self._create_picking()
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda l: l.product_id == self.product_a
+        )
+        lot = self._create_lot(
+            product_id=selected_move_line.product_id.id, name="Test Lot"
+        )
+        selected_move_line.write({"shopfloor_user_id": self.env.uid, "lot_id": lot.id})
+        self.service.dispatch(
+            "set_quantity",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+                # ↓ UI calls with 0 by default
+                "quantity": 0.0,
+                "barcode": "Test Lot",
+            },
+        )
+
+        self.assertEqual(selected_move_line.qty_done, 1)
+
     def test_set_quantity_scan_wrong_lot(self):
         # create lot "4" for product b
         self.env["stock.lot"].create(


### PR DESCRIPTION
### The problem
When a user is in the `set_quantity` state of a Reception and scans a Lot/Serial barcode, the system would raise a 500 error due to an invalid method signature in the reception component.

### Technical Reason
The dispatcher method `_set_quantity__by_barcode` uses the Shopfloor search service to identify the scanned barcode. Once identified as a lot, it calls the corresponding handler:
`handler(picking, selected_line, search_result.record)`

The `search_result.record` provides an Odoo recordset (`stock.lot`). However, the implementation of `_set_quantity__by_lot` was incorrectly expecting a raw string (`barcode` as a string) instead of a recordset. 

This mismatch caused:
1. Failure when accessing attributes like `lot.name`.
2. Inconsistency with other `_set_quantity__by_*` handlers (like product or packaging) which all receive recordsets.

### Changes
Updated `_set_quantity__by_lot(self, picking, selected_line, lot)` to correctly handle the `lot` argument as a `stock.lot` recordset.