### PR TITLE
[16.0][FIX] shopfloor_mobile_base: prevent virtual keyboard from disappearing after each keystroke

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
+++ b/shopfloor_mobile_base/static/wms/src/components/searchbar/searchbar.js
@@ -116,13 +116,7 @@ export var Searchbar = Vue.component("searchbar", {
     methods: {
         capture_focus: function () {
             if (this.autofocus && this.$refs.searchbar) {
-                // We need to use both "focus" and "click" in combination
-                // to make sure that the searchbar is fully focused and ready for scanning
-                // without having to manually tap on it.
-                // Using simply one or the other is not enough
-                // to always be able to input any scanned text.
                 this.$refs.searchbar.focus();
-                this.$refs.searchbar.click();
             }
         },
         show_virtual_keyboard: function (elem) {


### PR DESCRIPTION
#### Problem
In the current implementation, manual text entry in the search bar is nearly impossible on mobile devices. After every keystroke, the virtual keyboard hides, requiring the user to tap the input field again for every single character.

#### Root Cause
Following the changes in #767, a click event is triggered whenever the UI focuses on the search bar. Because the component calls `this.capture_focus()` within the `updated` lifecycle hook:
1. User types a character.
2. The state updates, triggering the `updated` hook.
3. `capture_focus()` is called.
4. A click is triggered
5. The virtual keyboard gets hidden

---

I do not have a scanner device to test that the focus still works as expected right now, I'll be testing that soon and come back in here 