### PR TITLE
[16.0][REF] shopfloor_reception: block lot creation with a different expiration date

### DIFF
--- a/shopfloor_reception/actions/message.py
+++ b/shopfloor_reception/actions/message.py
@@ -12,22 +12,16 @@ _logger = logging.getLogger(__name__)
 class MessageAction(Component):
     _inherit = "shopfloor.message.action"
 
-    def lot_already_exists_different_expiration_date(self, lot, expiration_date):
+    def lot_already_exists_different_expiration_date(self, lot):
         formatted_lot_expiration_date = self.work.env[
             "ir.qweb.field.date"
         ].value_to_html(lot.expiration_date, {})
-        formatted_provided_expiration_date = self.work.env[
-            "ir.qweb.field.date"
-        ].value_to_html(expiration_date, {})
         return {
-            "message_type": "warning",
+            "message_type": "error",
             "body": _(
-                "This lot already exists with a different expiration date.\n\n"
-                "Lot: '%(lot_name)s'\nStored expiration date: %(current)s"
-                "\nProvided expiration date: %(provided)s",
-                lot_name=lot.name,
-                current=formatted_lot_expiration_date,
-                provided=formatted_provided_expiration_date,
+                "This lot already exists with expiration date "
+                "'%(lot_expiration_date)s'. You cannot change its date.",
+                lot_expiration_date=formatted_lot_expiration_date,
             ),
         }
 

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1237,7 +1237,7 @@ class Reception(Component):
             and existing_lot.expiration_date != lot_expiration_date
         ):
             message = self.msg_store.lot_already_exists_different_expiration_date(
-                existing_lot, lot_expiration_date
+                existing_lot
             )
 
         res = self._response_for_set_lot(
@@ -1342,7 +1342,7 @@ class Reception(Component):
                 picking,
                 line,
                 message=self.msg_store.lot_already_exists_different_expiration_date(
-                    lot, expiration_date
+                    lot
                 ),
                 lot_name=lot.name,
                 lot_expiration_date=expiration_date,

--- a/shopfloor_reception/tests/test_scan_lot.py
+++ b/shopfloor_reception/tests/test_scan_lot.py
@@ -126,9 +126,7 @@ class TestScanLotName(CommonCase):
         )
         self.assertEqual(
             res["message"],
-            self.msg_store.lot_already_exists_different_expiration_date(
-                lot, lot.expiration_date + timedelta(days=2)
-            ),
+            self.msg_store.lot_already_exists_different_expiration_date(lot),
         )
 
     def test_scan_lot_name_auto_set_lot_on_move_line(self):

--- a/shopfloor_reception/tests/test_set_lot_confirm.py
+++ b/shopfloor_reception/tests/test_set_lot_confirm.py
@@ -164,9 +164,7 @@ class TestSetLotConfirm(CommonCase):
                 "picking": self.data.picking(picking),
                 "selected_move_line": move_line_response_data,
             },
-            message=self.msg_store.lot_already_exists_different_expiration_date(
-                lot, new_expiration_date
-            ),
+            message=self.msg_store.lot_already_exists_different_expiration_date(lot),
         )
 
     @freeze_time("2020-01-01 11:00:00")


### PR DESCRIPTION
Change the notification semantic when trying to scan or assign an existing lot with a different expiration date. Previously, this scenario raised a "warning" message type, which was misleading since the system blocks the operation as an error.

Update the message type from "warning" to "error" and simplify the message body.

| Before | After |
|--------|--------|
| <img width="402" height="684" alt="image" src="https://github.com/user-attachments/assets/a05f2f79-a040-4979-9af8-a802b26e6771" /> | <img width="399" height="683" alt="image" src="https://github.com/user-attachments/assets/6c882799-21c5-4dbb-82c5-55b5788ab59c" /> | 