### PR TITLE
[16.0][REF] shopfloor/shopfloor_reception: global boolean "allow_quantity_exceeding_demand" on all scenarios

### DIFF
--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -103,6 +103,15 @@ class ShopfloorMenu(models.Model):
             "triggering a backorder creation with the remaining lines."
         ),
     )
+    allow_quantity_exceeding_demand = fields.Boolean(
+        help="If True, prevents shopfloor error in case you process more qty than "
+        "planned."
+    )
+
+    allow_quantity_exceeding_demand_is_possible = fields.Boolean(
+        compute="_compute_allow_quantity_exceeding_demand_is_possible"
+    )
+
     # TODO: refactor handling of these options.
     # Possible solution:
     # * field should stay on the scenario and get stored in options
@@ -157,8 +166,7 @@ class ShopfloorMenu(models.Model):
         string="Show Get Work on start",
         default=False,
         help=(
-            "When enabled the user will have the option to ask "
-            "for a task to work on."
+            "When enabled the user will have the option to ask for a task to work on."
         ),
     )
     allow_get_work_is_possible = fields.Boolean(
@@ -428,7 +436,7 @@ class ShopfloorMenu(models.Model):
             ):
                 raise exceptions.ValidationError(
                     _(
-                        "Processing reserved quantities is" " not allowed for menu {}."
+                        "Processing reserved quantities is not allowed for menu {}."
                     ).format(menu.name)
                 )
 
@@ -536,6 +544,13 @@ class ShopfloorMenu(models.Model):
         for menu in self:
             menu.require_destination_package_is_possible = menu.scenario_id.has_option(
                 "require_destination_package"
+            )
+
+    @api.depends("scenario_id")
+    def _compute_allow_quantity_exceeding_demand_is_possible(self):
+        for menu in self:
+            menu.allow_quantity_exceeding_demand_is_possible = (
+                menu.scenario_id.has_option("allow_quantity_exceeding_demand")
             )
 
     @api.constrains(

--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -13,6 +13,16 @@
             </field>
             <group name="options" position="inside">
                 <group
+                    name="quantity_exceeding_demand"
+                    attrs="{'invisible': [('allow_quantity_exceeding_demand_is_possible', '=', False)]}"
+                >
+                    <field
+                        name="allow_quantity_exceeding_demand_is_possible"
+                        invisible="1"
+                    />
+                    <field name="allow_quantity_exceeding_demand" />
+                </group>
+                <group
                     name="move_create"
                     attrs="{'invisible': [('move_create_is_possible', '=', False)]}"
                 >

--- a/shopfloor_reception/data/shopfloor_scenario_data.xml
+++ b/shopfloor_reception/data/shopfloor_scenario_data.xml
@@ -11,7 +11,8 @@
       "auto_post_line": true,
       "allow_return": true,
       "scan_location_or_pack_first": true,
-      "allow_filter_today_scheduled_pickings": true
+      "allow_filter_today_scheduled_pickings": true,
+      "allow_quantity_exceeding_demand": true
 }
       </field>
   </record>

--- a/shopfloor_reception/migrations/16.0.1.11.0/post-migrate.py
+++ b/shopfloor_reception/migrations/16.0.1.11.0/post-migrate.py
@@ -1,0 +1,25 @@
+import json
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    reception = env.ref("shopfloor_reception.scenario_reception")
+    _update_scenario_options(reception)
+
+
+def _update_scenario_options(scenario):
+    options = scenario.options
+    options["allow_quantity_exceeding_demand"] = True
+    options_edit = json.dumps(options or {}, indent=4, sort_keys=True)
+    scenario.write({"options_edit": options_edit})
+    _logger.info(
+        "Option 'allow_quantity_exceeding_demand' added to scenario %s",
+        scenario.name,
+    )

--- a/shopfloor_reception/models/shopfloor_menu.py
+++ b/shopfloor_reception/models/shopfloor_menu.py
@@ -18,10 +18,6 @@ class ShopfloorMenu(models.Model):
         default=False,
         help=FILTER_TODAY_SCHEDULED_PICKINGS_HELP,
     )
-    allow_over_reception = fields.Boolean(
-        help="Allows operators to receive more goods than originally "
-        "planned on the incoming pickings (displays a confirmation prompt)."
-    )
 
     @api.depends("scenario_id")
     def _compute_filter_today_scheduled_pickings_is_possible(self):

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1480,7 +1480,7 @@ class Reception(Component):
     ):
         compare = self._set_quantity__check_quantity_done(line, quantity)
         if compare == 1:
-            if not self.work.menu.allow_over_reception:
+            if not self.work.menu.allow_quantity_exceeding_demand:
                 return self._response_for_set_quantity(
                     picking, line, message=self.msg_store.unable_to_pick_qty()
                 )

--- a/shopfloor_reception/tests/test_over_reception.py
+++ b/shopfloor_reception/tests/test_over_reception.py
@@ -17,7 +17,7 @@ class TestOverReception(CommonCase):
         )
         cls.reception_picking = picking
         cls.reception_line = picking.move_line_ids[0]
-        cls.menu.sudo().allow_over_reception = True
+        cls.menu.sudo().allow_quantity_exceeding_demand = True
 
     def test_over_reception_confirmation_flow(self):
         """

--- a/shopfloor_reception/views/shopfloor_menu.xml
+++ b/shopfloor_reception/views/shopfloor_menu.xml
@@ -8,8 +8,15 @@
         <field name="inherit_id" ref="shopfloor_base.shopfloor_menu_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//group[@name='options']" position="inside">
-                <group name="over_reception">
-                    <field name="allow_over_reception" />
+                <group
+                    name="filter_today_scheduled_pickings"
+                    attrs="{'invisible': [('filter_today_scheduled_pickings_is_possible', '=', False)]}"
+                >
+                    <field
+                        name="filter_today_scheduled_pickings_is_possible"
+                        invisible="1"
+                    />
+                    <field name="filter_today_scheduled_pickings" />
                 </group>
             </xpath>
         </field>


### PR DESCRIPTION
Make the `allow_over_reception` field from reception scenario available to all scenarios and rename it to `allow_quantity_exceeding_demand`

Also includes : fix accidentally deleted code (from this PR: https://github.com/OCA/wms/pull/1090)