### PR TITLE
[16.0][REF] shopfloor_reception: use generic "find" inside "scan_document"

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1036,18 +1036,30 @@ class Reception(Component):
         return self._response_for_select_document()
 
     def _scan_document__get_handlers_by_type(self):
-        return {
-            "picking": self._scan_document__by_picking,
-            # only add the handler if scan_location_or_pack_first is disabled
-            "product": (
-                self._scan_document__by_product
-                if not self.work.menu.scan_location_or_pack_first
-                else None
-            ),
-            "packaging": self._scan_document__by_packaging,
-            "lot": self._scan_document__by_lot,
-            "origin_move": self._scan_document__by_origin_move,
-        }
+        # CRITICAL ORDERING:
+        # 1. "origin_move" BEFORE "picking".
+        # -> If a partial delivery occurred, a completed move and an active
+        # backorder picking will share the same Source Document name (e.g., SO001).
+        # Because `search.find()` loops through this dictionary in order, placing
+        # "origin_move" first ensures we trigger a return for the completed delivery
+        # instead of accidentally opening the pending backorder picking.
+        #
+        # 2. "product" BEFORE "lot"
+        # -> as it restricts the lots of the found products.
+        handlers_by_type = {}
+
+        if self.work.menu.allow_return:
+            handlers_by_type["origin_move"] = self._scan_document__by_origin_move
+
+        handlers_by_type["picking"] = self._scan_document__by_picking
+
+        if not self.work.menu.scan_location_or_pack_first:
+            handlers_by_type["product"] = self._scan_document__by_product
+
+        handlers_by_type["packaging"] = self._scan_document__by_packaging
+        handlers_by_type["lot"] = self._scan_document__by_lot
+
+        return handlers_by_type
 
     def _scan_document__get_find_kw(self):
         return {

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1074,17 +1074,22 @@ class Reception(Component):
                         single correspondance. Not tracked product
         """
         handlers_by_type = self._scan_document__get_handlers_by_type()
+
+        if not handlers_by_type:
+            return self._scan_document__fallback()
+
         search = self._actions_for("search")
         find_kw = self._scan_document__get_find_kw()
-        for handler_type, handler in handlers_by_type.items():
-            record = search._find_record_by_type(
-                barcode, handler_type, handler_kw=find_kw
-            )
-            if not record:
-                continue
-            res = handler(record, barcode)
-            if res:
-                return res
+
+        result = search.find(barcode, types=handlers_by_type.keys(), handler_kw=find_kw)
+
+        if result and result.type != "none" and (recordset := result.record):
+            handler = handlers_by_type.get(result.type)
+            if handler:
+                res = handler(recordset, barcode)
+                if res:
+                    return res
+
         return self._scan_document__fallback()
 
     def list_stock_pickings(self):


### PR DESCRIPTION
The `scan_document` processing step has been refactored to utilize the `find()` method from the shopfloor search action component. Previously, the logic manually iterated over the handlers and called the internal `_find_record_by_type` method directly, bypassing the broader search pipeline.

By shifting this responsibility to the base `find` method, any standardized barcode preprocessing, custom resolution logic, or GS1-128 parsing injected into the search action component is now fully honored during reception. Furthermore, this provides downstream extending modules with a unified, singular hook point to alter or enrich barcode matching behaviors globally across the app.