### PR TITLE
[16.0][FIX] shopfloor_reception: fix "TypeError: fromisoformat: argument must be str" when scanning GS1 barcode

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -888,7 +888,8 @@ class Reception(Component):
                     result.type == "expiration_date"
                     and line.product_id.use_expiration_date
                 ):
-                    expiration_date = datetime.fromisoformat(result.value)
+                    date = result.value
+                    expiration_date = datetime(date.year, date.month, date.day)
 
             if found:
                 return self.set_lot_confirm_action(

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -878,8 +878,7 @@ class Reception(Component):
             for result in self.search_result.parse_result:
                 if result.type == "lot":
                     if self.search_result.type == "lot" and self.search_result.record:
-                        lot_id = self.search_result.record
-                        lot_name = lot_id.name
+                        lot_name = self.search_result.record.name
                         found = True
                     else:
                         lot_name = result.value

--- a/shopfloor_reception/tests/test_multi_barcode.py
+++ b/shopfloor_reception/tests/test_multi_barcode.py
@@ -1,5 +1,7 @@
 # Copyright 2025 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+from datetime import date
+
 import mock
 
 from odoo import fields
@@ -34,7 +36,7 @@ class TestStructuredBarcode(CommonCase):
                 BarcodeResult(type="lot", value=lot.name, raw=lot.name),
                 BarcodeResult(
                     type="expiration_date",
-                    value="2025-04-15",
+                    value=date(2025, 4, 15),
                     raw="250415",
                 ),
             ]


### PR DESCRIPTION
**Reson of the error:** The shopfloor_gs1 module returns date as `datetime.date` but the code inside `shopfloor_reception` expected `str`