### PR TITLE
[16.0] [REF] shopfloor_reception: use shopfloor.search.move.line component in scan_document

### DIFF
--- a/shopfloor/actions/move_line_search.py
+++ b/shopfloor/actions/move_line_search.py
@@ -61,10 +61,11 @@ class MoveLineSearch(Component):
     def _search_move_lines_domain(
         self,
         locations=None,
-        picking_type=None,
-        package=None,
-        product=None,
-        lot=None,
+        pickings=None,
+        picking_types=None,
+        packages=None,
+        products=None,
+        lots=None,
         match_user=False,
         picking_ready=True,
         # When True, adds the package in the domain even if the package is False
@@ -84,18 +85,26 @@ class MoveLineSearch(Component):
             ("qty_done", "=", 0),
             ("state", "in", ("assigned", "partially_available")),
         ]
-        picking_types = picking_type if picking_type is not None else self.picking_types
+        if pickings:
+            domain += [("picking_id", "in", pickings.ids)]
+        picking_types = (
+            picking_types if picking_types is not None else self.picking_types
+        )
         if picking_types:
             domain += [("picking_id.picking_type_id", "in", picking_types.ids)]
         locations = locations or picking_types.default_location_src_id
         if locations:
             domain += [("location_id", "child_of", locations.ids)]
-        if package or package is not None and enforce_empty_package:
-            domain += [("package_id", "=", package.id if package else False)]
-        if product:
-            domain += [("product_id", "=", product.id)]
-        if lot:
-            domain += [("lot_id", "=", lot.id)]
+        if packages or packages is not None and enforce_empty_package:
+            domain += (
+                [("package_id", "in", packages.ids)]
+                if packages
+                else [("package_id", "=", False)]
+            )
+        if products:
+            domain += [("product_id", "in", products.ids)]
+        if lots:
+            domain += [("lot_id", "in", lots.ids)]
         if match_user:
             # we only want to see the lines assigned to the current user
             domain += [
@@ -112,10 +121,11 @@ class MoveLineSearch(Component):
     def search_move_lines(
         self,
         locations=None,
-        picking_type=None,
-        package=None,
-        product=None,
-        lot=None,
+        pickings=None,
+        picking_types=None,
+        packages=None,
+        products=None,
+        lots=None,
         order=None,
         match_user=False,
         sort_keys_func=None,
@@ -126,10 +136,11 @@ class MoveLineSearch(Component):
         move_lines = self.env["stock.move.line"].search(
             self._search_move_lines_domain(
                 locations,
-                picking_type,
-                package,
-                product,
-                lot,
+                pickings,
+                picking_types,
+                packages,
+                products,
+                lots,
                 match_user=match_user,
                 picking_ready=picking_ready,
                 enforce_empty_package=enforce_empty_package,

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -331,7 +331,7 @@ class LocationContentTransfer(Component):
         move_lines = self.search_move_line.search_move_lines(
             locations=location,
             match_user=True,
-            picking_type=self.env[
+            picking_types=self.env[
                 "stock.picking.type"
             ],  # disable filtering on picking types
         )

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -321,7 +321,7 @@ class ZonePicking(Component):
 
     def _picking_type_zone_lines(self, zone_location, picking_type):
         return self.search_move_line.search_move_lines(
-            zone_location, picking_type=picking_type
+            locations=zone_location, picking_types=picking_type
         )
 
     def _data_for_move_line(
@@ -437,12 +437,12 @@ class ZonePicking(Component):
     ):
         """Find lines that potentially need work in given locations."""
         return self.search_move_line.search_move_lines(
-            locations or self.zone_location,
-            picking_type=picking_type or self.picking_type,
+            locations=locations or self.zone_location,
+            picking_types=picking_type or self.picking_type,
             order=self.lines_order,
-            package=package,
-            product=product,
-            lot=lot,
+            packages=package,
+            products=product,
+            lots=lot,
             match_user=match_user,
             enforce_empty_package=enforce_empty_package,
         )

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -80,19 +80,6 @@ class Reception(Component):
             move_line.product_id.tracking in ("lot", "serial") and not move_line.lot_id
         )
 
-    def _move_line_by_product(self, product):
-        return self.env["stock.move.line"].search(
-            self._domain_move_line_by_product(product)
-        )
-
-    def _move_line_by_packaging(self, packaging):
-        return self.env["stock.move.line"].search(
-            self._domain_move_line_by_packaging(packaging)
-        )
-
-    def _move_line_by_lot(self, lot):
-        return self.env["stock.move.line"].search(self._domain_move_line_by_lot(lot))
-
     def _scheduled_date_today_domain(self):
         domain = []
         today_start, today_end = self._get_today_start_end_datetime_utc()
@@ -135,32 +122,6 @@ class Reception(Component):
         return self.work.menu.filter_today_scheduled_pickings
 
     # DOMAIN METHODS
-
-    def _domain_move_line_by_packaging(self, packaging):
-        return [
-            ("move_id.picking_id.picking_type_id", "in", self.picking_types.ids),
-            ("move_id.picking_id.state", "=", "assigned"),
-            ("move_id.picking_id.user_id", "in", [False, self.env.uid]),
-            ("package_id.product_packaging_id", "=", packaging.id),
-        ]
-
-    def _domain_move_line_by_product(self, product):
-        return [
-            ("move_id.picking_id.picking_type_id", "in", self.picking_types.ids),
-            ("move_id.picking_id.state", "=", "assigned"),
-            ("move_id.picking_id.user_id", "in", [False, self.env.uid]),
-            ("product_id", "=", product.id),
-        ]
-
-    def _domain_move_line_by_lot(self, lot):
-        return [
-            ("move_id.picking_id.picking_type_id", "in", self.picking_types.ids),
-            ("move_id.picking_id.state", "=", "assigned"),
-            ("move_id.picking_id.user_id", "=", False),
-            "|",
-            ("lot_id.name", "=", lot),
-            ("lot_name", "=", lot),
-        ]
 
     def _domain_stock_picking(self, today_only=False):
         domain = [
@@ -215,8 +176,8 @@ class Reception(Component):
             - set_lot: a single picking has been found for this packaging
             - select_document: A single or no pickings has been found for this packaging
         """
-        move_lines = self._move_line_by_product(product).filtered(
-            lambda l: l.picking_id.picking_type_id.id in self.picking_types.ids
+        move_lines = self.search_move_line.search_move_lines(
+            products=product, picking_types=self.picking_types, match_user=True
         )
         pickings = move_lines.move_id.picking_id
         if pickings:
@@ -240,10 +201,11 @@ class Reception(Component):
             - set_lot: a single picking has been found for this packaging
             - select_document: A single or no pickings has been found for this packaging
         """
-        move_lines = self._move_line_by_packaging(packaging).filtered(
-            lambda l: l.picking_id.picking_type_id.id in self.picking_types.ids
+        move_lines = self.env["stock.move.line"].search(
+            self.search_move_line._search_move_lines_domain()
+            + [("package_id.product_packaging_id", "=", packaging.id)]
         )
-        pickings = move_lines.move_id.picking_id
+        pickings = move_lines.picking_id
         if pickings:
             return self._response_for_select_document(
                 pickings=pickings,
@@ -261,7 +223,9 @@ class Reception(Component):
             - set_lot: a single picking has been found for this packaging
             - select_document: A single or no pickings has been found for this packaging
         """
-        move_lines = self._move_line_by_lot(lot)
+        move_lines = self.search_move_line.search_move_lines(
+            lots=lot, picking_types=self.picking_types, match_user=True
+        )
         if not move_lines:
             return
         pickings = move_lines.move_id.picking_id
@@ -364,7 +328,13 @@ class Reception(Component):
         return "scheduled_date ASC, id ASC"
 
     def _scan_document__by_picking(self, pickings, barcode):
-        picking_filter_result = pickings
+        picking_filter_result = self.search_move_line.search_move_lines(
+            pickings=pickings,
+            picking_types=self.env[
+                "stock.picking.type"
+            ],  # disable filtering on picking types
+        ).picking_id
+
         reception_pickings = picking_filter_result.filtered(
             lambda p: p.picking_type_id.id in self.picking_types.ids
         )

--- a/shopfloor_reception/tests/test_return_scan_document.py
+++ b/shopfloor_reception/tests/test_return_scan_document.py
@@ -113,3 +113,17 @@ class TestScanDocumentReturn(CommonCaseReturn):
             next_state="select_move",
             data={"picking": self._data_for_picking_with_moves(return_picking)},
         )
+
+    def test_scan_picking_respects_move_line_search_additional_domain(self):
+        pick = self._create_picking()
+
+        self.menu.sudo().move_line_search_additional_domain = (
+            f'[("picking_id.id", "!=", {pick.id})]'
+        )
+        response = self.service.dispatch("scan_document", params={"barcode": pick.name})
+        self.assert_response(
+            response,
+            next_state="select_document",
+            data={"pickings": []},
+            message=self.msg_store.barcode_not_found(),
+        )


### PR DESCRIPTION
### Rationale
The "additional_domain" on the menu was respected when displaying the list of pickings but when scanning a picking by name, you could bypass the filter

---

- Reduces code duplication
- Fix scan_document bypassing the "additional_domain" set on the shopfloor menu