### PR TITLE
[16.0] [IMP] stock_storage_type: Speed up potential mix exception columns initialization

### DIFF
--- a/stock_storage_type/__manifest__.py
+++ b/stock_storage_type/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Storage Type",
     "summary": "Manage packages and locations storage types",
-    "version": "16.0.2.1.0",
+    "version": "16.0.2.1.1",
     "development_status": "Beta",
     "category": "Warehouse Management",
     "website": "https://github.com/OCA/wms",

--- a/stock_storage_type/migrations/16.0.2.1.1/post-migrate.py
+++ b/stock_storage_type/migrations/16.0.2.1.1/post-migrate.py
@@ -1,0 +1,39 @@
+# Copyright 2026 ACSONE SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+
+    _logger.info("Initializing potential mix exception columns on stock_location")
+    cr.execute(
+        """
+        UPDATE stock_location
+        SET
+            has_potential_lot_mix_exception     = (
+                fill_state NOT IN ('empty', 'being_emptied') IS TRUE
+                AND COALESCE(counts.lot_cnt, 0) > 1
+            ),
+            has_potential_product_mix_exception = (
+                fill_state NOT IN ('empty', 'being_emptied') IS TRUE
+                AND COALESCE(counts.product_cnt, 0) > 1
+            )
+        FROM (
+            SELECT
+                sl.id,
+                COUNT(DISTINCT lrel.stock_lot_id)         AS lot_cnt,
+                COUNT(DISTINCT prel.product_product_id)   AS product_cnt
+            FROM stock_location sl
+            LEFT JOIN stock_location_stock_lot_rel lrel
+                ON lrel.stock_location_id = sl.id
+            LEFT JOIN product_product_stock_location_rel prel
+                ON prel.stock_location_id = sl.id
+            GROUP BY sl.id
+        ) AS counts
+        WHERE stock_location.id = counts.id;
+            """
+    )
+    _logger.info("Potential mix exception columns on stock_location initialized")
+    _logger.info("%d stock_location records updated", cr.rowcount)

--- a/stock_storage_type/migrations/16.0.2.1.1/pre-migrate.py
+++ b/stock_storage_type/migrations/16.0.2.1.1/pre-migrate.py
@@ -1,0 +1,20 @@
+# Copyright 2026 ACSONE SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+import logging
+
+from odoo.tools import sql
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if sql.column_exists(cr, "stock_location", "has_potential_product_mix_exception"):
+        return
+
+    _logger.info("Adding potential mix exception columns on stock_location")
+    sql.create_column(
+        cr, "stock_location", "has_potential_product_mix_exception", "boolean"
+    )
+    sql.create_column(
+        cr, "stock_location", "has_potential_lot_mix_exception", "boolean"
+    )

--- a/stock_storage_type/models/stock_location.py
+++ b/stock_storage_type/models/stock_location.py
@@ -171,7 +171,6 @@ class StockLocation(models.Model):
         for location in self:
             if (
                 location.fill_state not in ("empty", "being_emptied")
-                and location._should_compute_will_contain_lot_ids()
                 and len(location.location_will_contain_lot_ids) > 1
             ):
                 locations_with_exception |= location
@@ -187,7 +186,6 @@ class StockLocation(models.Model):
         for location in self:
             if (
                 location.fill_state not in ("empty", "being_emptied")
-                and location._should_compute_will_contain_product_ids()
                 and len(location.location_will_contain_product_ids) > 1
             ):
                 locations_with_exception |= location
@@ -312,53 +310,64 @@ class StockLocation(models.Model):
         "do_not_mix_products",
     )
     def _compute_location_will_contain_product_ids(self):
+        rec_computed = self.browse()
+        rec_not_computed = self.browse()
         for rec in self:
-            if not rec._should_compute_will_contain_product_ids():
-                no_product = self.env["product.product"].browse()
-                rec.location_will_contain_product_ids = no_product
+            if rec._should_compute_will_contain_product_ids():
+                rec_computed |= rec
             else:
-                non_fully_reserved_quants = rec.quant_ids.filtered(
-                    lambda q: float_compare(
-                        q.quantity, 0, precision_rounding=q.product_uom_id.rounding
+                rec_not_computed |= rec
+
+        no_product = self.env["product.product"].browse()
+        rec_not_computed.location_will_contain_product_ids = no_product
+
+        # To avoid to fetch all move lines and quants for all records,
+        # we prefetch them for the records that should be computed
+        # This way we avoid to fetch quant_ids for locaitions like 'Customers'
+        # for example
+        for rec in rec_computed.with_prefetch(rec_computed.ids):
+            non_fully_reserved_quants = rec.quant_ids.filtered(
+                lambda q: float_compare(
+                    q.quantity, 0, precision_rounding=q.product_uom_id.rounding
+                )
+                > 0
+                and float_compare(
+                    q.reserved_quantity,
+                    q.quantity,
+                    precision_rounding=q.product_uom_id.rounding,
+                )
+                < 0
+            )
+            # Products that are obviously in the location
+            products = (
+                non_fully_reserved_quants.product_id
+                | rec.mapped("in_move_line_ids.product_id")
+                | rec.mapped("in_move_ids.product_id")
+            )
+            # For fully reserved quants, ensure the product is not being emptied
+            remaining_quants = rec.quant_ids.filtered(
+                lambda q, products=products: q.product_id not in products
+            )
+            if remaining_quants:
+                for product, quants_by_product in groupby(
+                    remaining_quants, lambda q: q.product_id
+                ):
+                    quantity = sum(map(lambda q: q.quantity, quants_by_product))
+                    picked_quantity = sum(
+                        ml.qty_done
+                        for ml in rec.out_move_line_ids
+                        if ml.product_id == product
                     )
-                    > 0
-                    and float_compare(
-                        q.reserved_quantity,
-                        q.quantity,
-                        precision_rounding=q.product_uom_id.rounding,
-                    )
-                    < 0
-                )
-                # Products that are obviously in the location
-                products = (
-                    non_fully_reserved_quants.product_id
-                    | rec.mapped("in_move_line_ids.product_id")
-                    | rec.mapped("in_move_ids.product_id")
-                )
-                # For fully reserved quants, ensure the product is not being emptied
-                remaining_quants = rec.quant_ids.filtered(
-                    lambda q, products=products: q.product_id not in products
-                )
-                if remaining_quants:
-                    for product, quants_by_product in groupby(
-                        remaining_quants, lambda q: q.product_id
-                    ):
-                        quantity = sum(map(lambda q: q.quantity, quants_by_product))
-                        picked_quantity = sum(
-                            ml.qty_done
-                            for ml in rec.out_move_line_ids
-                            if ml.product_id == product
+                    if (
+                        float_compare(
+                            quantity,
+                            picked_quantity,
+                            precision_rounding=product.uom_id.rounding,
                         )
-                        if (
-                            float_compare(
-                                quantity,
-                                picked_quantity,
-                                precision_rounding=product.uom_id.rounding,
-                            )
-                            > 0
-                        ):
-                            products |= product
-                rec.location_will_contain_product_ids = products
+                        > 0
+                    ):
+                        products |= product
+            rec.location_will_contain_product_ids = products
 
     @api.depends(
         "quant_ids.quantity",


### PR DESCRIPTION
Before this commit, the initialization of the potential mix exception columns
on stock_location was done using the ORM, which was very slow on large databases.
This commit add an SQL query to initialize those columns in a more efficient way.

* [ ] includes #1166 