### PR TITLE
[16.0][IMP] shopfloor: prevent exceeding qty done in location_content_transfer

### DIFF
--- a/shopfloor/data/shopfloor_scenario_data.xml
+++ b/shopfloor/data/shopfloor_scenario_data.xml
@@ -73,7 +73,8 @@
     "allow_get_work": true,
     "no_prefill_qty": true,
     "allow_move_line_search_sort_order": true,
-    "allow_move_line_search_additional_domain": true
+    "allow_move_line_search_additional_domain": true,
+    "allow_quantity_exceeding_demand": true
 
 }
         </field>

--- a/shopfloor/migrations/16.0.2.20.0/post-migrate.py
+++ b/shopfloor/migrations/16.0.2.20.0/post-migrate.py
@@ -1,0 +1,25 @@
+import json
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    location_content_transfer = env.ref("shopfloor.scenario_location_content_transfer")
+    _update_scenario_options(location_content_transfer)
+
+
+def _update_scenario_options(scenario):
+    options = scenario.options
+    options["allow_quantity_exceeding_demand"] = True
+    options_edit = json.dumps(options or {}, indent=4, sort_keys=True)
+    scenario.write({"options_edit": options_edit})
+    _logger.info(
+        "Option 'allow_quantity_exceeding_demand' added to scenario %s",
+        scenario.name,
+    )

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -758,6 +758,15 @@ class LocationContentTransfer(Component):
             return self._response_for_scan_destination(
                 location, move_line, confirmation_required=barcode
             )
+        if (
+            quantity > move_line.qty_done
+            and not self.work.menu.allow_quantity_exceeding_demand
+        ):
+            return self._response_for_scan_destination(
+                location,
+                move_line,
+                message=self.msg_store.unable_to_pick_more(move_line.qty_done),
+            )
 
         self._lock_lines(move_line)
 

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -648,6 +648,25 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         # no remaining move should exist
         self.assertEqual(picking.backorder_ids, first_done_picking)
 
+    def test_set_destination_line_exceeding_quantity(self):
+        move_line = self.picking2.move_line_ids[0]
+        self._simulate_selected_move_line(move_line)
+        # Process more than expected
+        response = self.service.dispatch(
+            "set_destination_line",
+            params={
+                "location_id": self.content_loc.id,
+                "move_line_id": move_line.id,
+                "quantity": move_line.reserved_uom_qty + 2,
+                "barcode": self.dest_location.barcode,
+            },
+        )
+        self.assert_response_scan_destination(
+            response,
+            move_line,
+            message=self.service.msg_store.unable_to_pick_more(move_line.qty_done),
+        )
+
 
 class LocationContentTransferSetDestinationXSpecialCase(
     LocationContentTransferCommonCase


### PR DESCRIPTION
When clicking on the "Process By Line" button, we get to a screen where this is possible to enter a quantity manually. 

<img width="396" height="680" alt="image" src="https://github.com/user-attachments/assets/47b85480-eb29-471a-af2c-bca35c439359" />


Nothing prevented from entering an exceeding quantity.

Prevent exceeding qty done in location content transfer scenario in case the menu option "allow_quantity_exceeding_demand" is False

<img width="1683" height="753" alt="image" src="https://github.com/user-attachments/assets/2975419a-3af2-4267-b620-699d2c35b1b2" />


Following what has been done in https://github.com/OCA/wms/pull/1169