### PR TITLE
[16.0][IMP] shopfloor_reception: validate product match on multi-attribute barcodes

### DIFF
--- a/shopfloor_reception/actions/message.py
+++ b/shopfloor_reception/actions/message.py
@@ -42,3 +42,11 @@ class MessageAction(Component):
                 qty=qty,
             ),
         }
+
+    def lot_product_mismatch(self):
+        return {
+            "message_type": "error",
+            "body": _(
+                "The scanned lot does not match the selected product",
+            ),
+        }

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1213,7 +1213,7 @@ class Reception(Component):
         search = self._actions_for("search")
         search_result = search.find(
             barcode=barcode,
-            types=["lot", "expiration_date"],
+            types=["lot", "expiration_date", "product"],
             handler_kw={"lot": {"products": selected_line.product_id}},
         )
 
@@ -1224,6 +1224,15 @@ class Reception(Component):
                 lot_name = result.value
             elif result.type == "expiration_date":
                 lot_expiration_date = result.value
+            elif (
+                result.type == "product"
+                and result.raw != selected_line.product_id.barcode
+            ):
+                return self._response_for_set_lot(
+                    picking,
+                    selected_line,
+                    message=self.msg_store.lot_product_mismatch(),
+                )
 
         if search_result.type == "lot":
             existing_lot = search_result.record

--- a/shopfloor_reception/tests/test_scan_lot.py
+++ b/shopfloor_reception/tests/test_scan_lot.py
@@ -151,3 +151,50 @@ class TestScanLotName(CommonCase):
 
         self.assertEqual(res["next_state"], "set_quantity")
         self.assertEqual(selected_move_line.lot_id, lot)
+
+    def test_scan_lot_wrong_product(self):
+        """
+        Test that the system detects that the scanned lot is for another product
+        than currently selected one.
+        """
+        picking = self._create_picking()
+        lot = self._create_lot()
+        expiration_date = fields.Datetime.from_string("2022-07-02")
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda l: l.product_id == self.product_a
+        )
+        selected_move_line.shopfloor_user_id = self.env.uid
+
+        other_product_barcode = "01223334444555"
+
+        gs1_barcode = f"{GTIN_AI}{other_product_barcode}"
+        gs1_barcode += f"{EXPIRATION_DATE_AI}220702{LOT_AI}{lot.name}"
+
+        with mock.patch.object(SearchAction, "find") as mock_find:
+            mock_find.return_value = SearchResult(
+                record=None,
+                type="None",
+                parse_result=[
+                    BarcodeResult(type="unknown", value=gs1_barcode),
+                    BarcodeResult(type="expiration_date", value=expiration_date),
+                    BarcodeResult(type="lot", value=lot.name),
+                    BarcodeResult(type="product", value=other_product_barcode),
+                ],
+            )
+            res = self.service.dispatch(
+                "scan_lot",
+                params={
+                    "picking_id": picking.id,
+                    "selected_line_id": selected_move_line.id,
+                    "barcode": lot.name,
+                },
+            )
+        self.assert_response(
+            res,
+            "set_lot",
+            self.msg_store.lot_product_mismatch(),
+            data={
+                "picking": self.data.picking(picking),
+                "selected_move_line": self._data_for_move_lines(selected_move_line),
+            },
+        )


### PR DESCRIPTION
Prevent users from associating a scanned lot with an incorrect product when processing multi-attribute barcodes (such as GS1-128).

Previously, if a user scanned a GS1 barcode containing both product and lot information, the system would parse the lot string without verifying if the embedded product barcode matched the currently selected line's product. This allowed mismatched lots to be assigned to the wrong products.