### PR TITLE
[16.0][FIX] shopfloor_reception: ensure search result is a lot in `set_lot_confirm_action`

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1289,8 +1289,11 @@ class Reception(Component):
             )
 
         product = selected_line.product_id
-        lot = self.search_result.record or self._actions_for("search").lot_from_scan(
-            lot_name, product
+        search_result_record = self.search_result.record
+        lot = (
+            search_result_record
+            if search_result_record and search_result_record._name == "stock.lot"
+            else self._actions_for("search").lot_from_scan(lot_name, product)
         )
 
         if product.use_expiration_date and (

--- a/shopfloor_reception/tests/test_scan_lot.py
+++ b/shopfloor_reception/tests/test_scan_lot.py
@@ -4,7 +4,7 @@
 from datetime import date, datetime, timezone
 from unittest import mock
 
-from odoo.addons.shopfloor.actions.barcode_parser import BarcodeResult
+from odoo.addons.shopfloor.actions.barcode_parser import BarcodeParser, BarcodeResult
 from odoo.addons.shopfloor.actions.search import SearchAction, SearchResult
 
 from .common import CommonCase
@@ -195,5 +195,48 @@ class TestScanLotName(CommonCase):
                 "selected_move_line": self._data_for_move_lines(
                     self.selected_move_line
                 ),
+            },
+        )
+
+    def test_set_lot_from_select_move(self):
+        picking = self._create_picking()
+        lot = self._create_lot()
+        lot.expiration_date = None
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda l: l.product_id == self.product_a
+        )
+        # selected_move_line.lot_id = lot
+        with mock.patch.object(BarcodeParser, "parse") as mock_parse:
+            # Note: the order here is important, the first to match a record
+            # in DB will determine the `type` (and `record`) of the `SearchResult`
+            mock_parse.return_value = [
+                # -> Put "product" in first to test if no error in case the
+                # SearchResult type is not "lot" but "product"
+                BarcodeResult(
+                    type="product",
+                    value=selected_move_line.product_id.barcode,
+                    raw=selected_move_line.product_id.barcode,
+                ),
+                BarcodeResult(type="lot", value=lot.name, raw=lot.name),
+                BarcodeResult(
+                    type="expiration_date",
+                    value=date(2025, 4, 15),
+                    raw="250415",
+                ),
+            ]
+            response = self.service.dispatch(
+                "scan_line",
+                params={
+                    "picking_id": picking.id,
+                    "barcode": lot.name,
+                },
+            )
+        self.assert_response(
+            response,
+            next_state="set_quantity",
+            data={
+                "picking": self.data.picking(picking),
+                "selected_move_line": self._data_for_move_lines(selected_move_line),
+                "confirmation_required": None,
             },
         )


### PR DESCRIPTION
Prior to this change, if `self.search_result.record` returned a `product.product` instead of a `stock.lot`, the method would fail further down the line when expecting lot-specific attributes

### Reproduce error in UI

You can reproduce the error in shopfloor UI by first installing `shopfloor_gs1`, create a reception picking for some product with this barcode
```
3182550780926
```
And scan this GS1 inside the "select move screen": (GTIN (01)03182550780926(17)281228(10)TestPST04)
```
01031825507809261728122810TestPST04
```
<img width="392" height="680" alt="image" src="https://github.com/user-attachments/assets/9c73d45b-ac1c-4fa4-b244-2baaa1a96dda" />
