### PR TITLE
[16.0][IMP] stock_release_channel_partner_by_date: do not archive future partner dates on action_sleep

### DIFF
--- a/stock_release_channel_partner_by_date/__manifest__.py
+++ b/stock_release_channel_partner_by_date/__manifest__.py
@@ -13,6 +13,7 @@
     "website": "https://github.com/OCA/wms",
     "depends": [
         "stock_release_channel",
+        "stock_release_channel_shipment_lead_time",
     ],
     "data": [
         "views/res_partner.xml",

--- a/stock_release_channel_partner_by_date/models/stock_release_channel.py
+++ b/stock_release_channel_partner_by_date/models/stock_release_channel.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
+from odoo.osv import expression
 
 
 class StockReleaseChannel(models.Model):
@@ -15,12 +16,20 @@ class StockReleaseChannel(models.Model):
     )
 
     def action_sleep(self):
+        shipment_date = self.shipment_date
         res = super().action_sleep()
-        channel_dates = self.env["stock.release.channel.partner.date"].search(
-            self._get_release_channel_partner_date_domain()
-        )
+        domain = self._get_release_channel_partner_date_domain(shipment_date)
+        channel_dates = self.env["stock.release.channel.partner.date"].search(domain)
         channel_dates.write({"active": False})
         return res
 
-    def _get_release_channel_partner_date_domain(self):
-        return [("release_channel_id", "in", self.ids)]
+    def _get_release_channel_partner_date_domain(self, shipment_date=None):
+        domain = [("release_channel_id", "in", self.ids)]
+        if shipment_date:
+            domain = expression.AND(
+                [
+                    domain,
+                    [("date", "<", shipment_date)],
+                ]
+            )
+        return domain

--- a/stock_release_channel_partner_by_date/tests/test_release_channel_partner_date.py
+++ b/stock_release_channel_partner_by_date/tests/test_release_channel_partner_date.py
@@ -35,6 +35,26 @@ class TestReleaseChannelPartnerDate(ReleaseChannelPartnerDateCommon):
         self.delivery_date_channel.action_sleep()
         self.assertFalse(channel_date.active)
 
+    def test_release_channel_sleep_archive_specific_date_future(self):
+        self.delivery_date_channel.process_end_date = fields.Date.today()
+        self.delivery_date_channel.action_wake_up()
+        channel_date_today = self._create_channel_partner_date(
+            self.delivery_date_channel,
+            self.partner,
+            fields.Date.today(),
+        )
+        channel_date_future = self._create_channel_partner_date(
+            self.delivery_date_channel,
+            self.partner,
+            fields.Date.add(fields.Date.today(), days=1),
+        )
+        self.assertTrue(channel_date_today.active)
+        self.assertTrue(channel_date_future.active)
+        self.delivery_date_channel.action_sleep()
+        # Keep today's specific date active to allow multiple wake/sleep cycles in the same day.
+        self.assertTrue(channel_date_today.active)
+        self.assertTrue(channel_date_future.active)
+
     def test_release_channel_on_specific_date_not_available(self):
         """Test that when no release channel is available to satisfy
         a specific partner date,no fallback release channel is


### PR DESCRIPTION

When putting a release channel to sleep, restrict the deactivation of channel partner dates to only those in the past leaving today's and future configurations active.

- Update action_sleep() in the release channel model to construct an AND domain filtering by date.
- Add test_release_channel_sleep_archive_specific_date_future to ensure future and present dates are untouched.