### PR TITLE
[16.0][FIX] shopfloor_reception: fix expiration dates time zone handling

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -887,8 +887,9 @@ class Reception(Component):
                     result.type == "expiration_date"
                     and line.product_id.use_expiration_date
                 ):
-                    date = result.value
-                    expiration_date = datetime(date.year, date.month, date.day)
+                    expiration_date = datetime.combine(
+                        result.value, datetime.min.time()
+                    )
 
             if found:
                 return self.set_lot_confirm_action(

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -898,9 +898,7 @@ class Reception(Component):
         # We could have found a lot, but with result type "unknow"
         # Put this afterwards to favor multi-attribute barcode parsing
         # logic first
-        if self.search_result.record and isinstance(
-            self.search_result.record, self.env["stock.lot"].__class__
-        ):
+        if self.search_result.record and self.search_result.record._name == "stock.lot":
             return self.set_lot_confirm_action(
                 picking.id, line.id, lot_name=self.search_result.record.name
             )

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 
-from datetime import datetime, time, timezone
+from datetime import date, datetime, time, timezone
 
 import pytz
 from decorator import contextmanager
@@ -100,12 +100,8 @@ class Reception(Component):
         domain.append(("scheduled_date", "<=", today_end))
         return domain
 
-    def _get_today_start_end_datetime_utc(self):
-        """
-        Returns the start and end of the current day for the warehouse/company
-        timezone, converted to UTC naive datetimes.
-        """
-        # TODO: Put warehouse tz retrieval in shopfloor module?
+    # TODO: Put warehouse tz retrieval in shopfloor module?
+    def _get_current_timezone(self) -> str:
         company = self.env.company
         warehouse = self.picking_types.warehouse_id
 
@@ -114,8 +110,31 @@ class Reception(Component):
             if (len(warehouse) == 1 and warehouse.partner_id.tz)
             else company.partner_id.tz or "UTC"
         )
-        tz = pytz.timezone(tz_name)
+        return pytz.timezone(tz_name)
 
+    def _locale_date_to_datetime_utc(self, _date: date) -> datetime:
+        """
+        Convert an expiration date (interpreted in local time) to a UTC datetime at midnight.
+
+        Context:
+        In GS1 logistics standards, an expiration date is often represented simply
+        as a date without a time or timezone context. For inventory, tracking, or
+        reservation evaluation, this function assumes that the expiration takes
+        effect at midnight (00:00:00) **in the user's or system's local timezone**,
+        and shifts that timestamp to UTC for consistent database comparison.
+        """
+        tz = self._get_current_timezone()
+        _datetime = datetime.combine(_date, datetime.min.time())
+        localized_datetime = tz.localize(_datetime)
+        datetime_utc = localized_datetime.astimezone(UTC)
+        return datetime_utc
+
+    def _get_today_start_end_datetime_utc(self):
+        """
+        Returns the start and end of the current day for the warehouse/company
+        timezone, converted to UTC naive datetimes.
+        """
+        tz = self._get_current_timezone()
         now_local = pytz.utc.localize(datetime.now()).astimezone(tz)
 
         local_start = datetime.combine(
@@ -887,9 +906,7 @@ class Reception(Component):
                     result.type == "expiration_date"
                     and line.product_id.use_expiration_date
                 ):
-                    expiration_date = datetime.combine(
-                        result.value, datetime.min.time()
-                    )
+                    expiration_date = self._locale_date_to_datetime_utc(result.value)
 
             if found:
                 return self.set_lot_confirm_action(
@@ -1222,11 +1239,7 @@ class Reception(Component):
             if result.type == "lot":
                 lot_name = result.value
             elif result.type == "expiration_date":
-                # We need to ensure we have a `datetime` object (and not a
-                # `date` one) for valid comparison with stock.lot.expiration_date
-                lot_expiration_date = datetime.combine(
-                    result.value, datetime.min.time()
-                )
+                lot_expiration_date = self._locale_date_to_datetime_utc(result.value)
             elif (
                 result.type == "product"
                 and result.raw != selected_line.product_id.barcode
@@ -1246,7 +1259,7 @@ class Reception(Component):
         if (
             lot_expiration_date
             and existing_lot
-            and existing_lot.expiration_date != lot_expiration_date
+            and existing_lot.expiration_date != lot_expiration_date.replace(tzinfo=None)
         ):
             message = self.msg_store.lot_already_exists_different_expiration_date(
                 existing_lot
@@ -1266,11 +1279,11 @@ class Reception(Component):
     def set_lot_confirm_action(
         self, picking_id, selected_line_id, lot_name, expiration_date: datetime = None
     ):
-        """Set lot and its expiration date
+        r"""Set lot and its expiration date (/!\ expected to be passed in UTC)
 
         Input:
             barcode: The barcode of a lot
-            expiration_date: The expiration_date
+            expiration_date: The expiration_date (in UTC)
 
         transitions:
           - set_lot: Error: expiration_date is required
@@ -1278,6 +1291,10 @@ class Reception(Component):
         """
         picking = self.env["stock.picking"].browse(picking_id)
         selected_line = self.env["stock.move.line"].browse(selected_line_id)
+
+        # The UI sends tz aware dates but for comparisons we need everything to be tz unaware
+        if expiration_date:
+            expiration_date = expiration_date.replace(tzinfo=None)
 
         message = self._check_picking_processible(picking)
         if message:
@@ -1345,13 +1362,16 @@ class Reception(Component):
         self.env.context = {**self.env.context} | {"lot": lot}
 
     def _set_lot_confirm_action__handle_existing_lot(
-        self, picking, line, lot, expiration_date
+        self, picking, line, lot, expiration_date: datetime
     ):
+        r"""
+        /!\ expiration_date is expected to be in UTC !
+        """
         if not expiration_date:
             return
         elif not lot.expiration_date:
-            lot.expiration_date = expiration_date.astimezone(UTC).replace(tzinfo=None)
-        elif lot.expiration_date.astimezone(UTC) != expiration_date.astimezone(UTC):
+            lot.expiration_date = expiration_date
+        elif lot.expiration_date != expiration_date.replace(tzinfo=None):
             # Prevent user from overwritting an existing expiration date on an existing lot
             return self._response_for_set_lot(
                 picking,

--- a/shopfloor_reception/tests/test_scan_lot.py
+++ b/shopfloor_reception/tests/test_scan_lot.py
@@ -92,8 +92,8 @@ class TestScanLotName(CommonCase):
 
         self.assertEqual(
             res["data"]["set_lot"]["selected_move_line"][0]["lot"]["expiration_date"],
-            datetime(
-                expiration_date.year, expiration_date.month, expiration_date.day
+            datetime.combine(
+                expiration_date, datetime.min.time(), tzinfo=timezone.utc
             ).isoformat(),
         )
         self.assertEqual(
@@ -133,8 +133,8 @@ class TestScanLotName(CommonCase):
 
         self.assertEqual(
             res["data"]["set_lot"]["selected_move_line"][0]["lot"]["expiration_date"],
-            datetime(
-                expiration_date.year, expiration_date.month, expiration_date.day
+            datetime.combine(
+                expiration_date, datetime.min.time(), tzinfo=timezone.utc
             ).isoformat(),
         )
         self.assertEqual(
@@ -199,12 +199,16 @@ class TestScanLotName(CommonCase):
         )
 
     def test_set_lot_from_select_move(self):
+        # Test that time zones are handled correctly
+        self.wh.partner_id.sudo().tz = "Europe/Brussels"
+
         picking = self._create_picking()
         lot = self._create_lot()
         lot.expiration_date = None
         selected_move_line = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_a
         )
+        selected_move_line.product_id.sudo().use_expiration_date = True
         # selected_move_line.lot_id = lot
         with mock.patch.object(BarcodeParser, "parse") as mock_parse:
             # Note: the order here is important, the first to match a record
@@ -240,3 +244,8 @@ class TestScanLotName(CommonCase):
                 "confirmation_required": None,
             },
         )
+
+        # Verify the expiration datetime on the lot is correct in UTC
+        # 2025-04-15 00:00:00 Brussels time is 2025-04-14 22:00:00 UTC
+        expected_utc = datetime(2025, 4, 14, 22, 0, 0)
+        self.assertEqual(selected_move_line.lot_id.expiration_date, expected_utc)

--- a/shopfloor_reception/tests/test_set_lot_confirm.py
+++ b/shopfloor_reception/tests/test_set_lot_confirm.py
@@ -13,8 +13,12 @@ class TestSetLotConfirm(CommonCase):
         cls.product_a.tracking = "lot"
 
     def test_set_existing_lot(self):
+        self.wh.partner_id.sudo().tz = "Europe/Brussels"
+        # 2025-04-15 00:00:00 Brussels time is 2025-04-14 22:00:00 UTC
+        expiration_date_utc = "2025-04-14 22:00:00"
+
         picking = self._create_picking()
-        lot = self._create_lot()
+        lot = self._create_lot(expiration_date=expiration_date_utc)
         selected_move_line = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_a
         )
@@ -25,10 +29,12 @@ class TestSetLotConfirm(CommonCase):
                 "picking_id": picking.id,
                 "selected_line_id": selected_move_line.id,
                 "lot_name": lot.name,
+                # Test locale aware timezones are handled correctly
+                "expiration_date": "2025-04-14T22:00:00+00:00",
             },
         )
         self.assertEqual(selected_move_line.lot_id, lot)
-        self.assertFalse(selected_move_line.expiration_date)
+        self.assertTrue(selected_move_line.expiration_date)
         self.assert_response(
             response,
             next_state="set_quantity",


### PR DESCRIPTION
Following a first fix from: https://github.com/OCA/wms/pull/1191

### Reproduce the errors

- Create a db with shopfloor_reception and shopfloor_gs1 installed
- Make the tz of the warehouse's partner to something else than UTC

#### Error 1

Creating a lot from a GS1 scan does shift the time (e.g. you see "2026-12-31 01:00:00" in odoo instead of "2026-12-31 00:00:00")

#### Error 2

- Create a lot by hand for 2026-12-31 00:00:00" through odoo UI
- Scan the corresponding GS1 in the screen 'set_lot'
- You get the "Lot already exists, different expiration date" error tough you should not since the date do match