### PR TITLE
[16.0][IMP] shopfloor_reception: clearer error messages in case of lot product mismatch

### DIFF
--- a/shopfloor_reception/actions/message.py
+++ b/shopfloor_reception/actions/message.py
@@ -43,10 +43,24 @@ class MessageAction(Component):
             ),
         }
 
-    def lot_product_mismatch(self):
+    def lot_product_mismatch(self, line, lot_product):
         return {
             "message_type": "error",
             "body": _(
-                "The scanned lot does not match the selected product",
+                "The scanned lot does not match the selected product. "
+                "Current product is '%(current_product)s' but the scanned lot "
+                "is for '%(lot_product)s'.",
+                current_product=line.product_id.display_name,
+                lot_product=lot_product.display_name,
+            ),
+        }
+
+    def lot_product_not_found(self, product_barcode):
+        return {
+            "message_type": "error",
+            "body": _(
+                "The scanned lot contains the product barcode '%(product_barcode)s' "
+                "but you have no product with this barcode in Odoo.",
+                product_barcode=product_barcode,
             ),
         }

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1184,15 +1184,27 @@ class Reception(Component):
                 barcode=barcode,
                 types=["lot"],
             )
-        except SearchInvalidProduct:
+        except SearchInvalidProduct as e:
+            lot_product = e.recordset
             return self._response_for_set_lot(
                 picking,
                 selected_line,
-                message=self.msg_store.lot_product_mismatch(),
+                message=self.msg_store.lot_product_mismatch(selected_line, lot_product),
             )
 
-        # Look for more info in the barcode
         existing_lot = search_result.record or self.env["stock.lot"]
+        if not existing_lot and (
+            product_barcode := search_result.parse_result.get("product")
+        ):
+            product = search.product_from_scan(product_barcode.value)
+            if not product:
+                return self._response_for_set_lot(
+                    picking,
+                    selected_line,
+                    message=self.msg_store.lot_product_not_found(product_barcode.value),
+                )
+
+        # Look for more info in the barcode
         lot_name = barcode
         if lot_result := search_result.parse_result.get("lot"):
             lot_name = lot_result.value

--- a/shopfloor_reception/tests/test_scan_lot.py
+++ b/shopfloor_reception/tests/test_scan_lot.py
@@ -182,7 +182,39 @@ class TestScanLotName(CommonCase):
         self.assert_response(
             res,
             "set_lot",
-            self.msg_store.lot_product_mismatch(),
+            self.msg_store.lot_product_mismatch(
+                self.selected_move_line, lot_other_product.product_id
+            ),
+            data={
+                "picking": self.data.picking(self.picking),
+                "selected_move_line": self._data_for_move_lines(
+                    self.selected_move_line
+                ),
+            },
+        )
+
+    def test_scan_lot_product_not_found(self):
+        lot = self._create_lot(
+            product_id=self.product_b.id, expiration_date=datetime(2022, 7, 2)
+        )
+        unkown_barcode = lot.product_id.barcode
+        with mock.patch.object(BarcodeParser, "parse") as mock_parse:
+            mock_parse.return_value = self._get_gs1_parsing_results(lot)
+            # ↓ Delete the barcode on the product to simulate that we do not have it
+            lot.product_id.sudo().barcode = False
+            res = self.service.dispatch(
+                "scan_lot",
+                params={
+                    "picking_id": self.picking.id,
+                    "selected_line_id": self.selected_move_line.id,
+                    "barcode": mock_parse.return_value["unknown"].raw,
+                },
+            )
+
+        self.assert_response(
+            res,
+            "set_lot",
+            self.msg_store.lot_product_not_found(unkown_barcode),
             data={
                 "picking": self.data.picking(self.picking),
                 "selected_move_line": self._data_for_move_lines(


### PR DESCRIPTION
When scanning a GS1, we parse the GS1 data to ensure the product on the GS1 matches the barcode we have in odoo.

However, when we do not have a barcode for the given product in odoo, the error message was confusing.

| Before | After (barcode not found) | After (barcode mismatch) |
|--------|--------|--------|
| <img width="396" height="683" alt="image" src="https://github.com/user-attachments/assets/f8b37994-b03e-45ba-9cb9-5cff75c35899" /> | <img width="398" height="683" alt="image" src="https://github.com/user-attachments/assets/5de86df5-0da1-4424-9784-5c667290a1a6" /> | <img width="398" height="683" alt="image" src="https://github.com/user-attachments/assets/0c7c0c42-e0c6-43ab-91c8-12d677362669" /> |


cc @jbaudoux 