### PR TITLE
[16.0][IMP] shopfloor_reception_mobile: add product info button in 'set_quantity' screen

### DIFF
--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -401,6 +401,7 @@ const Reception = {
                         },
                     },
                 ],
+                title_action_field: {action_val_path: "product.barcode"},
             };
         },
         picking_detail_options_for_select_move: function () {


### PR DESCRIPTION
<img width="398" height="678" alt="image" src="https://github.com/user-attachments/assets/2a31da5b-0daa-4b53-aea4-22a6e21e761c" />

cc @jbaudoux 