### PR TITLE
[16.0][IMP] shopfloor/reception_mobile: show product pictures in product details

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/detail/detail_product.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_product.js
@@ -6,6 +6,31 @@
 
 import {ItemDetailMixin} from "/shopfloor_mobile_base/static/wms/src/components/detail/detail_mixin.js";
 
+Vue.component("detail-product-image", {
+    props: ["record"],
+    template: `
+        <div v-if="record.image" class="detail-product-image-wrapper my-3 d-flex justify-center">
+            <v-img
+                :src="record.image"
+                max-height="128"
+                max-width="128"
+                aspect-ratio="1"
+                contain
+                class="rounded elevation-1"
+            >
+                <template #placeholder>
+                    <div class="d-flex align-center justify-center fill-height">
+                        <v-progress-circular
+                            color="grey-lighten-4"
+                            indeterminate
+                        />
+                    </div>
+                </template>
+            </v-img>
+        </div>
+    `,
+});
+
 // TODO: refactor according to new data from backend and maybe merge w/ `detail-lot`
 Vue.component("detail-product", {
     mixins: [ItemDetailMixin],
@@ -18,7 +43,11 @@ Vue.component("detail-product", {
         },
         full_detail_fields() {
             return [
-                // Image TODO
+                {
+                    path: "image",
+                    display_no_value: false,
+                    render_component: "detail-product-image",
+                },
                 {path: "lot.name", label: "Lot"},
                 {path: "expiration_date", label: "Expiry date"},
                 {path: "default_code", label: "Internal ref"},

--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -21,14 +21,6 @@ const Reception = {
                 v-on:found="on_scan"
                 :input_placeholder="search_input_placeholder"
             />
-            <template v-if="state_is('select_move')">
-                <item-detail-card
-                    :record="state.data.picking"
-                    :options="operation_options()"
-                    :card_color="utils.colors.color_for('screen_step_done')"
-                    :key="make_state_component_key(['reception-picking-item-detail', state.data.picking.id])"
-                />
-            </template>
             <template v-if="state_is('select_document')">
                 <manual-select
                     class="with-progress-bar"
@@ -66,6 +58,12 @@ const Reception = {
                 </div>
             </template>
             <template v-if="state_is('select_move')">
+                <item-detail-card
+                    :record="state.data.picking"
+                    :options="operation_options()"
+                    :card_color="utils.colors.color_for('screen_step_done')"
+                    :key="make_state_component_key(['reception-picking-item-detail', state.data.picking.id])"
+                />
                 <manual-select
                     :card_color="utils.colors.color_for('screen_step_done')"
                     :records="ordered_moves"

--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -113,7 +113,7 @@ const Reception = {
                 />
                 <item-detail-card
                     :record="line_being_handled"
-                    :options="picking_detail_options_for_set_lot()"
+                    :options="line_product_detail_options()"
                     :card_color="is_set_lot_possible() ? utils.colors.color_for('screen_step_done') : utils.colors.color_for('screen_step_todo')"
                     :key="make_state_component_key(['reception-product-item-detail-set-lot', state.data.picking.id])"
                 />
@@ -133,7 +133,7 @@ const Reception = {
             <template v-if="state_is('set_quantity')">
                 <item-detail-card
                     :record="line_being_handled"
-                    :options="picking_detail_options_for_set_quantity()"
+                    :options="line_product_detail_options()"
                     :card_color="utils.colors.color_for('screen_step_done')"
                     :key="make_state_component_key(['reception-product-item-detail-set-quantity', state.data.picking.id])"
                 />
@@ -175,7 +175,7 @@ const Reception = {
             <template v-if="state_is('set_destination')">
                 <item-detail-card
                     :record="line_being_handled"
-                    :options="picking_detail_options_for_set_destination()"
+                    :options="line_product_detail_options()"
                     :card_color="utils.colors.color_for('screen_step_done')"
                     :key="make_state_component_key(['reception-product-item-detail-set-destination-pack', state.data.picking.id])"
                 />
@@ -337,7 +337,7 @@ const Reception = {
             return klass;
         },
 
-        picking_detail_options_for_set_lot: function () {
+        line_product_detail_options: function () {
             return {
                 key_title: "product.display_name",
                 title_action_field: {
@@ -375,31 +375,12 @@ const Reception = {
                             );
                         },
                     },
-                ],
-            };
-        },
-        picking_detail_options_for_set_quantity: function () {
-            return {
-                key_title: "product.display_name",
-                fields: [
                     {
-                        path: "product.barcode",
-                        label: "Barcode",
-                    },
-                    {
-                        path: "product.supplier_code",
-                        label: "Vendor code",
-                    },
-                    {path: "lot.name", label: "Lot"},
-                    {
-                        path: "lot.expiration_date",
-                        label: "Expiry date",
-                        renderer: (rec, field) => {
-                            return this.utils.display.render_field_date(rec, field);
-                        },
+                        path: "package_dest.name",
+                        label: "Pack",
+                        klass: "loud",
                     },
                 ],
-                title_action_field: {action_val_path: "product.barcode"},
             };
         },
         picking_detail_options_for_select_move: function () {
@@ -444,38 +425,6 @@ const Reception = {
                         },
                     ],
                 },
-            };
-        },
-        picking_detail_options_for_set_destination: function () {
-            return {
-                key_title: "product.display_name",
-                fields: [
-                    {
-                        path: "product.supplier_code",
-                        label: "Vendor code",
-                    },
-                    {
-                        path: "product.barcode",
-                        label: "Barcode",
-                        action_val_path: "barcode",
-                    },
-                    {
-                        path: "lot.name",
-                        label: "Lot",
-                    },
-                    {
-                        path: "lot.expiration_date",
-                        label: "Expiry date",
-                        renderer: (rec, field) => {
-                            return this.utils.display.render_field_date(rec, field);
-                        },
-                    },
-                    {
-                        path: "package_dest.name",
-                        label: "Pack",
-                        klass: "loud",
-                    },
-                ],
             };
         },
         select_dest_package_display_name_values: function (rec) {


### PR DESCRIPTION

### 1. Show product image in product details

<img width="401" height="705" alt="image" src="https://github.com/user-attachments/assets/342aa712-ec09-4b59-bd8d-9dc66489d4b7" />


### 2. Centralize product detail card options

Centralize the rendering options in all these screens (avoid code duplication)

| set lot | set quantity | set detination |
|--------|--------|--------|
| <img width="398" height="700" alt="image" src="https://github.com/user-attachments/assets/ad5ec14d-45b4-4471-9e24-45a7f29476f2" /> | <img width="407" height="702" alt="image" src="https://github.com/user-attachments/assets/2ae838b9-e458-4e4c-9165-add59c1ff17f" /> | <img width="401" height="703" alt="image" src="https://github.com/user-attachments/assets/74b1f4c0-78cb-4d8a-b6f4-3173464dc605" /> | 


cc @jbaudoux 