### PR TITLE
[16.0] shopfloor: fix unmark

### DIFF
--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -159,7 +159,6 @@ class StockAction(Component):
                 "shopfloor_user_id": False,
                 "qty_done": 0,
                 "result_package_id": False,
-                "lot_id": False,
             }
         )
         pickings = move_lines.picking_id

--- a/shopfloor/tests/test_actions_stock.py
+++ b/shopfloor/tests/test_actions_stock.py
@@ -14,12 +14,13 @@ class TestActionsStock(CommonCase):
         super().setUpClass()
         with cls.work_on_actions(cls) as work:
             cls.stock = work.component(usage="stock")
+        cls.product_a.tracking = "lot"
         cls.picking = cls._create_picking(
             lines=[(cls.product_a, 10), (cls.product_b, 10)], confirm=True
         )
         cls.move0 = cls.picking.move_ids[0]
         cls.move1 = cls.picking.move_ids[1]
-        cls._fill_stock_for_moves(cls.move0)
+        cls._fill_stock_for_moves(cls.move0, in_lot=True)
         cls._fill_stock_for_moves(cls.move1)
         cls.picking.action_assign()
 

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1475,6 +1475,7 @@ class Reception(Component):
         if selected_line.exists():
             if selected_line.reserved_uom_qty:
                 stock = self._actions_for("stock")
+                selected_line.lot_id = False
                 stock.unmark_move_line_as_picked(selected_line, split=False)
             else:
                 selected_line.unlink()


### PR DESCRIPTION
don't reset lot on unmark_move_line_as_picked
    
We don't want to reset the lot when unmarking a move line as picked, as it
can lead to loss of information especially it will reset the reservation
if the product is tracked by lot.
