### PR TITLE
[16.0][IMP] shopfloor_reception_mobile: adjust title of manual selection ('picking' -> 'reception')

### DIFF
--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -305,8 +305,8 @@ const Reception = {
         manual_select_options_for_select_document: function (today_only = false) {
             return {
                 group_title_default: today_only
-                    ? "Pickings to process today"
-                    : "Pickings to process",
+                    ? "Receptions to process today"
+                    : "Receptions to process",
                 group_color: this.utils.colors.color_for("screen_step_todo"),
                 list_item_extra_component: "picking-list-item-progress-bar",
                 showActions: false,


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="392" height="702" alt="image" src="https://github.com/user-attachments/assets/c0e017ee-53df-4fe5-88bf-1b51c366bb58" /> | <img width="391" height="701" alt="image" src="https://github.com/user-attachments/assets/34179902-993d-4f50-b1f8-60c19d81c4e7" /> | 

cc @jbaudoux 