### PR TITLE
[16.0][FIX] shopfloor_mobile: remove duplicate supplier info in product/lot details

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/detail/detail_lot.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_lot.js
@@ -39,10 +39,18 @@ Vue.component("detail-lot", {
         },
         supplier_detail_fields() {
             return [
-                {path: "name", klass: "loud"},
-                {path: "product_code", label: "Code"},
-                {path: "product_name", label: "Name"},
+                {path: "partner", klass: "loud"},
+                {path: "product_code", label: "Vendor Code"},
+                {path: "product_name", label: "Vendor Name"},
             ];
+        },
+        unique_suppliers(suppliers) {
+            if (!suppliers) {
+                return [];
+            }
+            return _.uniqBy(suppliers, (supp) =>
+                [supp.partner, supp.product_name, supp.product_code].join("|")
+            );
         },
         render_packaging(record, field) {
             return [record.name, "(" + record.code + ")", "= " + record.qty].join(" ");
@@ -73,7 +81,7 @@ Vue.component("detail-lot", {
         <div class="suppliers mb-4" v-if="record.product.suppliers.length">
             <separator-title>Suppliers</separator-title>
             <item-detail-card
-                v-for="supp in record.product.suppliers"
+                v-for="supp in unique_suppliers(record.product.suppliers)"
                 :key="'supp' + supp.id"
                 :record="supp"
                 :options="{no_title: true, fields: supplier_detail_fields()}" />

--- a/shopfloor_mobile/static/wms/src/components/detail/detail_product.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_product.js
@@ -31,10 +31,18 @@ Vue.component("detail-product", {
         },
         supplier_detail_fields() {
             return [
-                {path: "name", klass: "loud"},
-                {path: "product_code", label: "Code"},
-                {path: "product_name", label: "Name"},
+                {path: "partner", klass: "loud"},
+                {path: "product_code", label: "Vendor Code"},
+                {path: "product_name", label: "Vendor Name"},
             ];
+        },
+        unique_suppliers(suppliers) {
+            if (!suppliers) {
+                return [];
+            }
+            return _.uniqBy(suppliers, (supp) =>
+                [supp.partner, supp.product_name, supp.product_code].join("|")
+            );
         },
         render_packaging(record, field) {
             return [record.name, "(" + record.code + ")", "= " + record.qty].join(" ");
@@ -104,7 +112,7 @@ Vue.component("detail-product", {
     <div class="suppliers mb-4" v-if="_.result(record, 'suppliers', []).length">
         <separator-title>Suppliers</separator-title>
         <item-detail-card
-            v-for="supp in record.suppliers"
+            v-for="supp in unique_suppliers(record.suppliers)"
             :key="'supp' + supp.id"
             :record="supp"
             :options="{no_title: true, fields: supplier_detail_fields()}"


### PR DESCRIPTION
<img width="1451" height="768" alt="image" src="https://github.com/user-attachments/assets/dc2d7455-3640-4789-beca-08880af8b97c" />

### Product details

| Before | After |
|--------|--------|
| <img width="396" height="700" alt="image" src="https://github.com/user-attachments/assets/ff3f891a-5df0-4ea7-b3f6-e2aa4867e2a6" /> | <img width="396" height="700" alt="image" src="https://github.com/user-attachments/assets/1fc69233-1aa2-4268-a62b-439e90aa77ef" /> | 

### Lot details

| Before | After |
|--------|--------|
| <img width="396" height="700" alt="image" src="https://github.com/user-attachments/assets/6af41cf7-76f0-4b06-86f2-f6a61e70b902" /> | <img width="396" height="700" alt="image" src="https://github.com/user-attachments/assets/1d3d4929-c3dd-4778-a70a-431a7089cad1" /> | 

cc @jbaudoux 