### PR TITLE
[16.0][BPORT] shopfloor: cluster picking: close batch on unload

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -104,10 +104,9 @@ class StockMove(models.Model):
             "move_ids": [],
             "move_line_ids": [],
             "backorder_id": picking.id,
-            "batch_id": picking.batch_id.id,
         }
         data.update(dict(default or []))
-        new_picking = picking.with_context(disable_batch_sanity_check=True).copy(data)
+        new_picking = picking.copy(data)
         link = '<a href="#" data-oe-model="stock.picking" data-oe-id="%d">%s</a>' % (
             new_picking.id,
             new_picking.name,
@@ -131,6 +130,10 @@ class StockMove(models.Model):
                 if line.package_id == line.result_package_id:
                     line.result_package_id = False
 
+        # The batch cannot be set during copy as the moves have to be first
+        # extracted to the new picking in order to have a non draft state that
+        # will succeed the batch sanity check
+        new_picking.batch_id = picking.batch_id
         return new_picking
 
     def extract_and_action_done(self):

--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -2,11 +2,31 @@
 # Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, models
-from odoo.tools.float_utils import float_compare
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class StockMove(models.Model):
     _inherit = "stock.move"
+
+    @property
+    def picked(self):
+        """:return: True if there is a quantity picked."""
+        self.ensure_one()
+        return (
+            float_compare(
+                self.quantity_done,
+                0,
+                precision_rounding=self.product_uom.rounding,
+            )
+            > 0
+        )
+
+    @property
+    def has_quantity_reserved(self):
+        self.ensure_one()
+        return not float_is_zero(
+            self.reserved_availability, precision_rounding=self.product_uom.rounding
+        )
 
     def _qty_is_satisfied(self):
         compare = float_compare(

--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -104,9 +104,10 @@ class StockMove(models.Model):
             "move_ids": [],
             "move_line_ids": [],
             "backorder_id": picking.id,
+            "batch_id": picking.batch_id.id,
         }
         data.update(dict(default or []))
-        new_picking = picking.copy(data)
+        new_picking = picking.with_context(disable_batch_sanity_check=True).copy(data)
         link = '<a href="#" data-oe-model="stock.picking" data-oe-id="%d">%s</a>' % (
             new_picking.id,
             new_picking.name,

--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -31,6 +31,39 @@ class StockMoveLine(models.Model):
     # allow domain on picking_id.xxx without too much perf penalty
     picking_id = fields.Many2one(auto_join=True)
 
+    @property
+    def picked(self):
+        """:return: True if there is a quantity picked."""
+        self.ensure_one()
+        return (
+            float_compare(
+                self.qty_done,
+                0,
+                precision_rounding=self.product_uom_id.rounding,
+            )
+            > 0
+        )
+
+    @property
+    def is_fully_picked(self):
+        """:return: True if the quantity picked >= quantity reserved."""
+        self.ensure_one()
+        return (
+            float_compare(
+                self.qty_done,
+                self.reserved_uom_qty,
+                precision_rounding=self.product_uom_id.rounding,
+            )
+            >= 0
+        )
+
+    @property
+    def has_quantity_reserved(self):
+        self.ensure_one()
+        return not float_is_zero(
+            self.reserved_uom_qty, precision_rounding=self.product_uom_id.rounding
+        )
+
     def _split_partial_quantity(self):
         """Create new move line for the quantity remaining to do
 

--- a/shopfloor/models/stock_picking_batch.py
+++ b/shopfloor/models/stock_picking_batch.py
@@ -39,8 +39,3 @@ class StockPickingBatch(models.Model):
 
     def _calc_weight(self, pickings):
         return sum(pickings.mapped("total_weight"))
-
-    def _sanity_check(self):
-        if self.env.context.get("disable_batch_sanity_check"):
-            return
-        return super()._sanity_check()

--- a/shopfloor/models/stock_picking_batch.py
+++ b/shopfloor/models/stock_picking_batch.py
@@ -39,3 +39,8 @@ class StockPickingBatch(models.Model):
 
     def _calc_weight(self, pickings):
         return sum(pickings.mapped("total_weight"))
+
+    def _sanity_check(self):
+        if self.env.context.get("disable_batch_sanity_check"):
+            return
+        return super()._sanity_check()

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1,8 +1,12 @@
 # Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
-# Copyright 2020-2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from markupsafe import Markup
+
 from odoo import _, fields
+from odoo.exceptions import UserError
 from odoo.osv import expression
 
 from odoo.addons.base_rest.components.service import to_bool, to_int
@@ -1154,47 +1158,80 @@ class ClusterPicking(Component):
     def _unload_write_destination_on_lines(self, lines, location):
         stock = self._actions_for("stock")
         stock.set_destination_on_lines(lines, location)
+        if self.work.menu.unload_package_at_destination:
+            stock.unload_package(lines)
         lines.write({"shopfloor_unloaded": True})
-        for picking in lines.batch_id.picking_ids:
-            picking_lines = lines.filtered(lambda x, p=picking: x.picking_id == p)
-            self._unload_set_picking_to_done(picking, picking_lines)
+        for picking in lines.picking_id:
+            self._unload_set_picking_to_done(picking)
 
-    def _unload_set_picking_to_done(self, picking, picking_lines):
+    def _unload_set_picking_to_done(self, picking):
+        """Set picking to done when all picked move lines have been unloaded"""
         if picking.state == "done":
             return
-        # We set the picking to done only when the last line is
-        # unloaded to avoid backorders.
-        all_lines_unloaded = all(
-            line.shopfloor_unloaded for line in picking.move_line_ids
+        for ml in picking.move_line_ids:
+            if not ml.picked or not ml.has_quantity_reserved:
+                continue
+            # Ensure the quantity picked >= quantity reserved.
+            # At this stage, the move line should have already been split
+            # when setting the destination package.
+            if not ml.is_fully_picked:
+                raise UserError(
+                    _(
+                        "Internal Error: The move line %s is not fully picked",
+                        ml.display_name,
+                    )
+                )
+            if not ml.shopfloor_unloaded:
+                # A move line is not unloaded, exit
+                return
+        stock = self._actions_for("stock")
+        for move in picking.move_ids:
+            move.split_other_move_lines(
+                move.move_line_ids.filtered(lambda ml: ml.picked)
+            )
+        # remove assigned non picked moves
+        moves_to_validate = picking.move_ids.filtered(
+            lambda m: not (m.state == "assigned" and not m.picked)
         )
-        if self.work.menu.unload_package_at_destination and all_lines_unloaded:
-            picking_lines.result_package_id = False
-        if all_lines_unloaded:
-            picking._action_done()
+        stock.validate_moves(moves_to_validate)
+        if picking.state not in ("cancel", "done"):
+            # A split order has been created, remove picking from batch
+            picking.batch_id = False
 
     def _unload_end(self, batch, completion_info_popup=None):
-        """After unloading close the batch transfer.
+        """Remove unprocessed pickings from batch to close it.
 
-        Always close the batch transfer after unloading. The remaining work to do will
-        be assigned to a new one.
         Returns to `start` transition.
         """
-        all_pickings = batch.picking_ids
-        if all(picking.state == "done" for picking in all_pickings):
-            # do not use the 'done()' method because it does many things we
-            # don't care about
-            batch.state = "done"
-            return self._response_for_start(
-                message=self.msg_store.batch_transfer_complete(),
-                popup=completion_info_popup,
+
+        empty_pickings = batch.picking_ids.filtered(
+            lambda picking: picking.state in ("waiting", "confirmed", "assigned")
+            and all(
+                not m.picked or not m.has_quantity_reserved
+                for m in picking.move_ids
+                if m.state not in ("done", "cancel")
             )
-        all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
-        batch.state = "done"
-        # Unassign not validated pickings from the batch, they will be
-        # processed in another batch automatically later on
-        all_pickings.invalidate_recordset(["state"])
-        pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
-        pickings_not_done.batch_id = False
+        )
+        if empty_pickings:
+            batch.message_post(
+                body=Markup("<b>%s:</b> %s")
+                % (
+                    _("Unprocessed transfer removed from batch"),
+                    ", ".join(
+                        Markup(
+                            "<a href=#id=%s&view_type=form&model=stock.picking>%s</a>"
+                        )
+                        % (p.id, p.name)
+                        for p in empty_pickings
+                    ),
+                )
+            )
+            empty_pickings.batch_id = False
+
+        if batch.state != "done":
+            # As processed pickings are already done, the batch should now be done
+            raise UserError(self.env._("Internal Error: Batch not properly done."))
+
         return self._response_for_start(
             message=self.msg_store.batch_transfer_complete(),
             popup=completion_info_popup,

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -62,9 +62,9 @@ class ClusterPicking(Component):
     * Declare stock out: if a good is in fact not in stock or only partially. Note
       the move lines will become unavailable or partially unavailable and will
       generate a back-order.
-    * Full bin: declaring a full bin allows to move directly to the first phase
-      (picking) to the second one (unload). The scenario will go
-      back to the first phase if some lines remain in the queue of lines to pick.
+    * Full bin: declaring a full bin allows to move directly from the first phase
+      (picking) to the second one (unload). Then the batch will be closed and
+      the scenario will go the start for the user to work on a new batch.
 
     You will find a sequence diagram describing states and endpoints
     relationships [here](../docs/cluster_picking_diag_seq.png).
@@ -1173,10 +1173,11 @@ class ClusterPicking(Component):
             picking._action_done()
 
     def _unload_end(self, batch, completion_info_popup=None):
-        """Try to close the batch if all transfers are done.
+        """After unloading close the batch transfer.
 
-        Returns to `start_line` transition if some lines could still be processed,
-        otherwise try to validate all the transfers of the batch.
+        Always close the batch transfer after unloading. The remaining work to do will
+        be assigned to a new one.
+        Returns to `start` transition.
         """
         all_pickings = batch.picking_ids
         if all(picking.state == "done" for picking in all_pickings):
@@ -1187,29 +1188,17 @@ class ClusterPicking(Component):
                 message=self.msg_store.batch_transfer_complete(),
                 popup=completion_info_popup,
             )
-
-        next_line = self._next_line_for_pick(batch)
-        if next_line:
-            return self._response_for_start_line(
-                next_line,
-                message=self.msg_store.batch_transfer_line_done(),
-                popup=completion_info_popup,
-            )
-        else:
-            # TODO add tests for this (for instance a picking is not 'done'
-            # because a move was unassigned, we want to validate the batch to
-            # produce backorders)
-            all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
-            batch.state = "done"
-            # Unassign not validated pickings from the batch, they will be
-            # processed in another batch automatically later on
-            all_pickings.invalidate_recordset(["state"])
-            pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
-            pickings_not_done.batch_id = False
-            return self._response_for_start(
-                message=self.msg_store.batch_transfer_complete(),
-                popup=completion_info_popup,
-            )
+        all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
+        batch.state = "done"
+        # Unassign not validated pickings from the batch, they will be
+        # processed in another batch automatically later on
+        all_pickings.invalidate_recordset(["state"])
+        pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
+        pickings_not_done.batch_id = False
+        return self._response_for_start(
+            message=self.msg_store.batch_transfer_complete(),
+            popup=completion_info_popup,
+        )
 
     def unload_split(self, picking_batch_id):
         """Indicates that now the batch must be treated line per line

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -186,9 +186,9 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         # destination (when /set_destination_all is called, all the lines to
         # unload must have the same destination).
         # However, we keep a line without qty_done and destination package,
-        # so when the dest location is set, the endpoint should route back
-        # to the 'start_line' state to work on the remaining line.
+        # it will be moved in a new transfer and the batch closed.
         lines_to_unload = self.move_lines[:2]
+        line_not_processed = self.move_lines[2:]
         self._set_dest_package_and_done(lines_to_unload, self.bin1)
         lines_to_unload.write({"location_dest_id": self.packing_location.id})
 
@@ -199,11 +199,14 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                 "barcode": self.packing_location.barcode,
             },
         )
-        # Since the whole batch is not complete, state should not be done.
+        # The batch is closed
+        self.assertRecordValues(self.batch, [{"state": "done"}])
         # The picking with one line should be "done" because we unloaded its line.
-        # The second one still has a line to pick.
         self.assertRecordValues(self.one_line_picking, [{"state": "done"}])
-        self.assertRecordValues(self.two_lines_picking, [{"state": "assigned"}])
+        # The other picking has one line being unloaded and one put in a back order
+        self.assertEqual(len(self.two_lines_picking.move_line_ids), 1)
+        self.assertRecordValues(self.two_lines_picking, [{"state": "done"}])
+        self.new_picking = line_not_processed.picking_id
         self.assertRecordValues(
             self.move_lines,
             [
@@ -217,8 +220,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                 {
                     "shopfloor_unloaded": True,
                     "qty_done": 10,
-                    # will be done when the second line of the picking is unloaded
-                    "state": "assigned",
+                    "state": "done",
                     "picking_id": self.two_lines_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
@@ -226,19 +228,16 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                     "shopfloor_unloaded": False,
                     "qty_done": 0,
                     "state": "assigned",
-                    "picking_id": self.two_lines_picking.id,
+                    "picking_id": self.new_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
             ],
         )
-        self.assertRecordValues(self.batch, [{"state": "in_progress"}])
-
         self.assert_response(
-            # the remaining move line still needs to be picked
             response,
-            next_state="start_line",
-            data=self._line_data(self.move_lines[2]),
-            message={"body": "Batch Transfer line done", "message_type": "success"},
+            next_state="start",
+            message={"body": "Batch Transfer complete", "message_type": "success"},
+            popup=self.ANY,
         )
 
     def test_set_destination_all_picking_unassigned(self):

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -188,7 +188,6 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         # However, we keep a line without qty_done and destination package,
         # it will be moved in a new transfer and the batch closed.
         lines_to_unload = self.move_lines[:2]
-        line_not_processed = self.move_lines[2:]
         self._set_dest_package_and_done(lines_to_unload, self.bin1)
         lines_to_unload.write({"location_dest_id": self.packing_location.id})
 
@@ -201,12 +200,16 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         )
         # The batch is closed
         self.assertRecordValues(self.batch, [{"state": "done"}])
-        # The picking with one line should be "done" because we unloaded its line.
-        self.assertRecordValues(self.one_line_picking, [{"state": "done"}])
-        # The other picking has one line being unloaded and one put in a back order
+        for picking in lines_to_unload.picking_id:
+            self.assertRecordValues(
+                picking, [{"state": "done", "batch_id": self.batch.id}]
+            )
+        # The 2 lines picking has one remaining line
         self.assertEqual(len(self.two_lines_picking.move_line_ids), 1)
-        self.assertRecordValues(self.two_lines_picking, [{"state": "done"}])
-        self.new_picking = line_not_processed.picking_id
+        self.assertRecordValues(
+            self.two_lines_picking, [{"state": "assigned", "batch_id": False}]
+        )
+        self.new_picking = self.two_lines_picking.backorder_ids
         self.assertRecordValues(
             self.move_lines,
             [
@@ -221,14 +224,14 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                     "shopfloor_unloaded": True,
                     "qty_done": 10,
                     "state": "done",
-                    "picking_id": self.two_lines_picking.id,
+                    "picking_id": self.new_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
                 {
                     "shopfloor_unloaded": False,
                     "qty_done": 0,
                     "state": "assigned",
-                    "picking_id": self.new_picking.id,
+                    "picking_id": self.two_lines_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
             ],
@@ -237,7 +240,6 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
             response,
             next_state="start",
             message={"body": "Batch Transfer complete", "message_type": "success"},
-            popup=self.ANY,
         )
 
     def test_set_destination_all_picking_unassigned(self):
@@ -267,8 +269,12 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         )
         # The batch should be done with only one picking.
         # The remaining picking has been removed from the current batch
-        self.assertRecordValues(self.one_line_picking, [{"state": "done"}])
-        self.assertRecordValues(self.two_lines_picking, [{"state": "confirmed"}])
+        self.assertRecordValues(
+            self.one_line_picking, [{"state": "done", "batch_id": self.batch.id}]
+        )
+        self.assertRecordValues(
+            self.two_lines_picking, [{"state": "confirmed", "batch_id": False}]
+        )
         self.assertRecordValues(self.batch, [{"state": "done"}])
         self.assertEqual(self.one_line_picking.batch_id, self.batch)
         self.assertFalse(self.two_lines_picking.batch_id)


### PR DESCRIPTION
Backport of:
* https://github.com/OCA/stock-logistics-shopfloor/pull/88

Until now, after unloading because of a full bin (batch not fully picked), the batch is ketp open and the user is invited to keep picking the next line from the batch.
With this change the batch will be closed with the transfer done and the user is redirected to the start of the scenario.

Like in the other scenario, it is now calling validate_move instead of _action_done. Partially processed pickings are now moved to a split order. The picking type backorder strategy is now also respected.