### PR TITLE
[14.0][IMP] shopfloor, picking batch parser: use `display_name` instead of `name`

### DIFF
--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -335,7 +335,13 @@ class DataAction(Component):
 
     @property
     def _picking_batch_parser(self):
-        return ["id", "name", "picking_count", "move_line_count", "total_weight:weight"]
+        return [
+            "id",
+            "display_name:name",
+            "picking_count",
+            "move_line_count",
+            "total_weight:weight",
+        ]
 
     @ensure_model("stock.picking.type")
     def picking_type(self, record, **kw):


### PR DESCRIPTION
This allows to inject useful informations in the list of batches for users in the cluster picking scenario for instance, without introducing new overrides and dependencies on Shopfloor.

Our use case is to display a shipping address field we added on the batch and injected in its `display_name` if there is one.

<img width="1021" height="259" alt="image" src="https://github.com/user-attachments/assets/b58241a4-8a60-423a-ae07-c729e7b43291" />

<img width="1132" height="550" alt="image" src="https://github.com/user-attachments/assets/3635d8dc-6bb7-4451-99ec-b00b76ebdfe0" />
