### PR TITLE
[16.0][FIX] shopfloor_gs1: parse all AI items regardless of registered search handlers

### DIFF
--- a/shopfloor_gs1/actions/barcode_parser.py
+++ b/shopfloor_gs1/actions/barcode_parser.py
@@ -41,13 +41,11 @@ class BarcodeParser(Component):
             return result
 
         parsed = GS1Barcode.parse(barcode)
-        if parsed:
-            for barcode_type in self.search_action._barcode_type_handler.keys():
-                for parsed_item in parsed:
-                    if parsed_item.ai in MAPPING_TYPE_TO_AI.get(barcode_type, tuple()):
-                        result[barcode_type] = BarcodeResult(
-                            type=barcode_type,
-                            value=parsed_item.value,
-                            raw=parsed_item.raw_value,
-                        )
+        for parsed_item in parsed:
+            if _type := MAPPING_AI_TO_TYPE.get(parsed_item.ai):
+                result[_type] = BarcodeResult(
+                    type=_type,
+                    value=parsed_item.value,
+                    raw=parsed_item.raw_value,
+                )
         return result

--- a/shopfloor_gs1/tests/__init__.py
+++ b/shopfloor_gs1/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_utils
 from . import test_action_search
 from . import test_scan_anything
 from . import test_action_search_hri
+from . import test_parse

--- a/shopfloor_gs1/tests/test_parse.py
+++ b/shopfloor_gs1/tests/test_parse.py
@@ -1,0 +1,27 @@
+# Copyright 2026 ACSONE SA/NV def parse(self, barcode):
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.shopfloor.tests.test_actions_search import TestSearchBaseCase
+
+from .common import DATE, LOT1, PROD_GTIN14
+
+
+class TestParse(TestSearchBaseCase):
+    def test_parse_gs1(self):
+        parser = self.search.parser
+        barcode = f"(01){PROD_GTIN14}(17){DATE}(10){LOT1}"
+        parsed_result = parser.parse(barcode)
+
+        self.assertSetEqual(
+            set(parsed_result.keys()),
+            {
+                "unknown",
+                "product",
+                "lot",
+                "expiration_date",
+            },
+        )
+        self.assertEqual(parsed_result["product"].raw, PROD_GTIN14)
+        self.assertEqual(parsed_result["lot"].raw, LOT1)
+        self.assertEqual(parsed_result["expiration_date"].raw, DATE)


### PR DESCRIPTION
Following https://github.com/OCA/wms/pull/1174

Previously, the GS1 parser filtered parsed Application Identifiers (AIs)
against the keys present in `self.search_action._barcode_type_handler`.

This tight coupling caused the parser to skip valid AI items if they were not
explicitly handled at the search layer.

---

### Example of real bug because of this

If you scan a GS1 for a new lot  in the 'set_lot' screen (a lot you do not have yet in odoo), the date will not be completed in the screen because the GS1 parser would drop it...

cc @jbaudoux 