### PR TITLE
[16.0][IMP] shopfloor: make menu form less cluttered

### DIFF
--- a/shopfloor/views/shopfloor_menu.xml
+++ b/shopfloor/views/shopfloor_menu.xml
@@ -4,7 +4,7 @@
         <field name="model">shopfloor.menu</field>
         <field name="inherit_id" ref="shopfloor_base.shopfloor_menu_form_view" />
         <field name="arch" type="xml">
-            <field name="profile_id" position="after">
+            <group name="main" position="after">
                 <field name="picking_type_ids">
                     <tree editable="bottom" create="0">
                         <field name="company_id" invisible="1" />
@@ -15,7 +15,7 @@
                         <field name="shopfloor_zero_check" optional="show" />
                     </tree>
                 </field>
-            </field>
+            </group>
             <group name="options" position="inside">
                 <group
                     name="quantity_exceeding_demand"


### PR DESCRIPTION
Following https://github.com/OCA/wms/pull/1199

Remove redundant label on the picking types.

| Before | After |
|--------|--------|
| <img width="1404" height="692" alt="2026-07-24_08-57" src="https://github.com/user-attachments/assets/a7968667-aa30-456c-8308-e807ed80d425" /> | <img width="1407" height="686" alt="image" src="https://github.com/user-attachments/assets/6843d50f-447b-47a2-8d8f-0b8053dcc056" /> |


cc @jbaudoux
