### PR TITLE
[16.0][FIX] shopfloor_mobile_base: replace "?." syntax for legacy webviews

### DIFF
--- a/shopfloor_mobile_base/static/wms/src/components/datepicker/date_picker.js
+++ b/shopfloor_mobile_base/static/wms/src/components/datepicker/date_picker.js
@@ -38,7 +38,7 @@ export var DatePicker = Vue.component("date-picker-input", {
     },
     computed: {
         userLocale: function () {
-            const lang = this.$root.user?.lang || "en-US";
+            const lang = (this.$root.user && this.$root.user.lang) || "en-US";
             return lang.replace("_", "-").toLowerCase();
         },
         dateFormatter: function () {


### PR DESCRIPTION
If you use a version of chrome < 80 in your scanner hardware (such as the Zebra MC330K that is shipped with chromium 77), the [JS syntax "?." is not supported](https://developer.chrome.com/blog/new-in-chrome-80#opt-chaining) and will lead to JS errors and thus components not rendering.

cc @jbaudoux 