### PR TITLE
[16.0][FIX] shopfloor_reception: persist parsed lot data on move line to survive multi-step transitions

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -295,11 +295,10 @@ class Reception(Component):
             # Destination package is set, go to set_destination
             return self._response_for_set_destination(picking, line, message=message)
 
-        return self._set_lot(
+        return self._prepare_set_lot(
             picking,
             line,
             message=message,
-            lot_name=line.lot_name,
             default_qty=default_qty,
         )
 
@@ -307,7 +306,7 @@ class Reception(Component):
         stock = self._actions_for("stock")
         stock.mark_move_line_as_picked(line, quantity=qty_done, split=False)
 
-        return self._set_lot(picking, line, lot_name=line.lot_name)
+        return self._prepare_set_lot(picking, line)
 
     def _select_line__filter_lines_by_packaging__return(self, lines, packaging):
         return_line = fields.first(
@@ -818,30 +817,41 @@ class Reception(Component):
         data = {"pickings": self._data_for_stock_pickings(pickings, with_lines=False)}
         return self._response(next_state="manual_selection", data=data)
 
-    def _response_for_set_lot(self, picking, line, message=None, **kw):
+    def _response_for_set_lot(
+        self, picking, line, message=None, lot_name=None, lot_expiration_date=None, **kw
+    ):
         # ↓ In case "lot_name" is pre-filled on the line in odoo, pre-fill
         # shpofloor screen
-        if kw.get("lot_name") and not kw.get("lot_expiration_date") and not message:
+        if lot_name and not lot_expiration_date and not message:
             lot = (
                 self._actions_for("search")
                 .for_products(line.product_id)
                 .lot_from_scan(kw.get("lot_name"))
             )
-            kw["lot_expiration_date"] = lot.expiration_date
+            lot_expiration_date = lot.expiration_date
 
         return self._response(
             next_state="set_lot",
             data={
-                "selected_move_line": self._data_for_move_lines(line, **kw),
+                "selected_move_line": self._data_for_move_lines(
+                    line,
+                    lot_name=lot_name,
+                    lot_expiration_date=lot_expiration_date,
+                    **kw,
+                ),
                 "picking": self.data.picking(picking),
             },
             message=message,
         )
 
-    def _set_lot(self, picking, line, message=None, **kw):
+    def _before_state__set_lot(
+        self,
+        picking,
+        line,
+        message=None,
+        default_qty=None,
+    ):
         if not self._move_line_needs_lot(line):
-            # If no qty_done, set default qty_done
-            default_qty = kw.get("default_qty")
             rounding = line.product_uom_id.rounding
             if default_qty and float_is_zero(
                 line.qty_done, precision_rounding=rounding
@@ -850,40 +860,76 @@ class Reception(Component):
 
             return self._before_state__set_quantity(picking, line, message)
 
-        # Bypass "set_lot" screen and send lot info to endpoint directly if
-        # lot info have been found when parsing
-        if response := self._set_lot_from_parse(picking, line):
-            return response
-        return self._response_for_set_lot(picking, line, message, **kw)
+        # Try Bypass "set_lot" screen and send lot info to endpoint directly
+        # if lot already exists in odoo
+        search = self._actions_for("search")
+        if line.lot_name and search.lot_from_scan(line.lot_name, line.product_id):
+            expiration_date = line.expiration_date or None
+            return self.set_lot_confirm_action(
+                picking.id, line.id, line.lot_name, expiration_date
+            )
 
-    def _set_lot_from_parse(self, picking, line):
+        return self._response_for_set_lot(
+            picking,
+            line,
+            message,
+            lot_name=line.lot_name or None,
+            lot_expiration_date=line.expiration_date or None,
+        )
+
+    def _prefill_lot_data(self, line):
+        """
+        Pre-fill lot data on the line so that later RPC calls can access what
+        has been found/parsed in the first scan.
+        """
         parse_result = self.search_result.parse_result
         if not parse_result:
             return
 
-        lot_result = parse_result.get("lot")
-        if lot_result:
-            if self.search_result.type == "lot" and self.search_result.record:
-                lot_name = self.search_result.record.name
-            else:
-                lot_name = lot_result.value
+        lot_name = expiration_date = False
 
-            expiration_date = None
-            exp_result = parse_result.get("expiration_date")
-            if exp_result and line.product_id.use_expiration_date:
-                expiration_date = self._locale_date_to_datetime_utc(exp_result.value)
-
-            return self.set_lot_confirm_action(
-                picking.id, line.id, lot_name, expiration_date
-            )
-
+        if lot_result := self.search_result.parse_result.get("lot"):
+            lot_name = lot_result.value
         # We could have found a lot, but with result type "unknow"
         # Put this afterwards to favor multi-attribute barcode parsing
         # logic first
-        if self.search_result.record and self.search_result.record._name == "stock.lot":
-            return self.set_lot_confirm_action(
-                picking.id, line.id, lot_name=self.search_result.record.name
-            )
+        elif (
+            self.search_result.record and self.search_result.record._name == "stock.lot"
+        ):
+            lot_name = self.search_result.record.name
+
+        # ↓ Remove pre-existing expiration_date on new lot scan
+        if lot_name:
+            expiration_date = False
+
+        if exp_date_result := self.search_result.parse_result.get("expiration_date"):
+            expiration_date = self._locale_date_to_datetime_utc(
+                exp_date_result.value
+            ).replace(tzinfo=None)
+
+        line.write(
+            {
+                "lot_name": lot_name,
+                "expiration_date": expiration_date,
+            }
+        )
+
+    def _prepare_set_lot(
+        self,
+        picking,
+        line,
+        message=None,
+        default_qty=None,
+    ):
+        if self._move_line_needs_lot(line):
+            self._prefill_lot_data(line)
+
+        return self._before_state__set_lot(
+            picking,
+            line,
+            message,
+            default_qty=default_qty,
+        )
 
     def _align_display_product_uom_qty(self, line, response):
         # This method aligns product uom qties on move lines.

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 # pylint: disable=missing-return
+from datetime import datetime
+
 from odoo import fields
 
 from .common import CommonCase
@@ -439,7 +441,6 @@ class TestSelectLine(CommonCase):
 
     def test_select_move_to_set_lot_prefills_lot_name(self):
         picking = self._create_picking()
-
         self.product_a.tracking = "lot"
         self.product_b.tracking = "lot"
 
@@ -453,12 +454,9 @@ class TestSelectLine(CommonCase):
         move_line_b = picking.move_line_ids.filtered(
             lambda l: l.product_id == self.product_b
         )
-        lot = self._create_lot(
-            product_id=self.product_b.id,
-            name="Pre-Configured Lot Name",
-            expiration_date="2020-02-02 12:00:00",
-        )
-        move_line_b.lot_name = lot.name
+        lot_name = "Pre-Configured Lot Name"
+        expiration_date = datetime(2020, 2, 2, 12)
+        move_line_b.write({"lot_name": lot_name, "expiration_date": expiration_date})
 
         # There is already a lot -> we skip "set_lot"
         response_a = self.service.dispatch(
@@ -467,7 +465,7 @@ class TestSelectLine(CommonCase):
         )
         self.assertEqual(response_a.get("next_state"), "set_quantity")
 
-        # There is a lot name but no lot record -> enter "set_lot"
+        # There is a lot name but lot does not exist yet in odoo -> enter "set_lot"
         response_b = self.service.dispatch(
             "manual_select_move",
             params={"move_id": move_b.id},
@@ -477,7 +475,7 @@ class TestSelectLine(CommonCase):
         # The UI should receive the lot metadata so as to be able to prefill
         self.assertEqual(
             response_b["data"]["set_lot"]["selected_move_line"][0]["lot"]["name"],
-            lot.name,
+            lot_name,
         )
         self.assertEqual(
             response_b["data"]["set_lot"]["selected_move_line"][0]["lot"][

--- a/shopfloor_reception_packaging_dimension/services/reception.py
+++ b/shopfloor_reception_packaging_dimension/services/reception.py
@@ -17,13 +17,13 @@ class Reception(Component):
 
     def _set_lot(self, picking, line, message=None, **kw):
         """Show the packaging dimension screen before 'set lot' screen."""
-        if not self.work.menu.set_packaging_dimension or self.packaging_update_done:
-            return super()._set_lot(
-                picking, line, message=message, lot_name=line.lot_name
+        if (
+            not self.work.menu.set_packaging_dimension
+            or self.packaging_update_done
+            or not (
+                packaging := self._get_next_packaging_to_set_dimension(line.product_id)
             )
-
-        packaging = self._get_next_packaging_to_set_dimension(line.product_id)
-        if not packaging:
+        ):
             return super()._set_lot(
                 picking, line, message=message, lot_name=line.lot_name
             )

--- a/shopfloor_reception_packaging_dimension/services/reception.py
+++ b/shopfloor_reception_packaging_dimension/services/reception.py
@@ -15,7 +15,13 @@ class Reception(Component):
         super().__init__(work_context)
         self.packaging_update_done = False
 
-    def _set_lot(self, picking, line, message=None, **kw):
+    def _before_state__set_lot(
+        self,
+        picking,
+        line,
+        message=None,
+        default_qty=None,
+    ):
         """Show the packaging dimension screen before 'set lot' screen."""
         if (
             not self.work.menu.set_packaging_dimension
@@ -24,8 +30,11 @@ class Reception(Component):
                 packaging := self._get_next_packaging_to_set_dimension(line.product_id)
             )
         ):
-            return super()._set_lot(
-                picking, line, message=message, lot_name=line.lot_name
+            return super()._before_state__set_lot(
+                picking,
+                line,
+                message=message,
+                default_qty=default_qty,
             )
 
         return self._response_for_set_packaging_dimension(
@@ -112,7 +121,7 @@ class Reception(Component):
         packaging = self.env["product.packaging"].sudo().browse(packaging_id)
 
         if not packaging:
-            return self._set_lot(
+            return self._before_state__set_lot(
                 picking, selected_line, message=self.msg_store.record_not_found()
             )
 
@@ -131,7 +140,7 @@ class Reception(Component):
             )
 
         self.packaging_update_done = True
-        return self._set_lot(picking, selected_line, message=message)
+        return self._before_state__set_lot(picking, selected_line, message=message)
 
     def _check_dimension_to_update(self, dimensions):
         """Check if the Shopfloor payload contains data for a packaging update."""

--- a/shopfloor_reception_product_barcode/services/reception.py
+++ b/shopfloor_reception_product_barcode/services/reception.py
@@ -13,7 +13,13 @@ class Reception(Component):
 
     product_barcode_update_done = False
 
-    def _set_lot(self, picking, line, message=None, **kw):
+    def _before_state__set_lot(
+        self,
+        picking,
+        line,
+        message=None,
+        default_qty=None,
+    ):
         """
         Check if product needs its barcode before 'set_lot'
         """
@@ -23,7 +29,12 @@ class Reception(Component):
                 return self._response_for_set_product_barcode(
                     picking, line, message=message
                 )
-        return super()._set_lot(picking, line, message=message, **kw)
+        return super()._before_state__set_lot(
+            picking,
+            line,
+            message=message,
+            default_qty=default_qty,
+        )
 
     def _get_domain_product_needs_barcode(self):
         """
@@ -95,7 +106,7 @@ class Reception(Component):
             self._update_product_barcode(product, barcode)
             message = self.msg_store.product_barcode_updated(product)
         self.product_barcode_update_done = True
-        return super()._set_lot(picking, selected_line, message=message)
+        return super()._before_state__set_lot(picking, selected_line, message=message)
 
     def _update_product_barcode(self, product, barcode) -> None:
         """Update barcode on the product."""


### PR DESCRIPTION
When scanning multi-attribute barcodes, parsed lot and expiration data was
kept in the transient `search_result` context manager. If a sub-module
(such as `shopfloor_reception_packaging_dimension` or
`shopfloor_reception_product_barcode`) intercepted the transition to insert
an intermediate UI state before `set_lot`, the HTTP request completed, the
component was discarded, and the in-memory `search_result` was lost for
subsequent calls.

### Steps to Reproduce / Broken Behavior

1. Enable **"Set packaging dimension"** on the Shopfloor reception menu configuration.
2. Scan a GS1 multi-attribute barcode containing lot/expiration data from the **"select_move"** screen.
   - *Expected:* The parsed lot information should be preserved, automatically skipping or pre-filling the `set_lot` screen.
   - *Actual:* The flow is correctly intercepted by the `set_packaging_dimension` screen. However, upon completing or skipping the packaging dimensions step, the user is landed on the `set_lot` screen with **all previously scanned GS1 lot/expiration information lost**, forcing them to re-enter or re-scan the data.

cc @jbaudoux 