### PR TITLE
[FIX] shopfloor: cluster_picking set_destination_all: skip batch sanity check

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -130,10 +130,13 @@ class StockMove(models.Model):
                 if line.package_id == line.result_package_id:
                     line.result_package_id = False
 
-        # The batch cannot be set during copy as the moves have to be first
-        # extracted to the new picking in order to have a non draft state that
-        # will succeed the batch sanity check
-        new_picking.batch_id = picking.batch_id
+        # We skip the sanity check on the batch assignment to the new picking because in
+        # some cases, the batch may contain done pickings, which would make the sanity check
+        # fail. This could be the case when using the cluster_picking set_destination_all
+        # method, when the batch contains lines partially processed from different pickings.
+        new_picking.with_context(
+            skip_batch_sanity_check=True
+        ).batch_id = picking.batch_id
         return new_picking
 
     def extract_and_action_done(self):

--- a/shopfloor/models/stock_picking_batch.py
+++ b/shopfloor/models/stock_picking_batch.py
@@ -39,3 +39,8 @@ class StockPickingBatch(models.Model):
 
     def _calc_weight(self, pickings):
         return sum(pickings.mapped("total_weight"))
+
+    def _sanity_check(self):
+        if self.env.context.get("skip_batch_sanity_check"):
+            return
+        return super()._sanity_check()

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -182,6 +182,32 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
 
     def test_set_destination_all_remaining_lines(self):
         """Set destination on all lines for a part of the batch"""
+
+        # force the order to ensure the opposite behaviour of the next test
+        # (That should not matter since by default the order is based on the move line id,
+        # and the two lines picking has a lower id than the one line picking,
+        # but we want to be sure)
+        self.one_line_picking.move_line_ids.shopfloor_priority = 20
+        self.two_lines_picking.move_line_ids.shopfloor_priority = 5
+
+        self._test_set_destination_all_remaining_lines()
+
+    def test_set_destination_all_remaining_lines_two_lines_picking_higher_priority(
+        self,
+    ):
+        """Same outcome when the two lines picking has a higher priority value
+        than the one line picking.
+
+        This is a regression test to ensure that when a split order is created for
+        the remaining lines and added to a cluster picking already containing a
+        picking done (the one line picking), no exception is raised by the sanity
+        check of the batch picking from the odoo base module stock_picking_batch
+        """
+        self.one_line_picking.move_line_ids.shopfloor_priority = 5
+        self.two_lines_picking.move_line_ids.shopfloor_priority = 20
+        self._test_set_destination_all_remaining_lines()
+
+    def _test_set_destination_all_remaining_lines(self):
         # Put destination packages, the whole quantity on lines and a similar
         # destination (when /set_destination_all is called, all the lines to
         # unload must have the same destination).


### PR DESCRIPTION
When set_destination_all splits the remaining lines into a new picking
and re-attaches it to the batch, the batch may already contain a done
picking (the one processed first). Assigning batch_id then triggers
stock_picking_batch's sanity check, which raises because the batch
mixes a done picking with a draft/assigned one.

Skip the sanity check for this specific assignment via a context key,
since the new picking is a legitimate split of a batch already in
progress, not an inconsistent manual assignment.