### PR TITLE
[16.0][FIX] shopfloor: add unique parameter to product image URL

### DIFF
--- a/shopfloor/actions/data_detail.py
+++ b/shopfloor/actions/data_detail.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import hashlib
 from collections import defaultdict
+from datetime import datetime
 
 from odoo.tools.float_utils import float_round
 
@@ -212,7 +214,9 @@ class DataDetailAction(Component):
     def _product_image_url(self, record, field_name):
         if not record[field_name]:
             return None
-        return f"/web/image/product.product/{record.id}/{field_name}"
+        write_date = record.write_date or datetime.now()
+        sha = hashlib.sha512(str(write_date).encode("utf-8")).hexdigest()[:7]
+        return f"/web/image/product.product/{record.id}/{field_name}?unique={sha}"
 
     @property
     def _product_supplierinfo_parser(self):

--- a/shopfloor/tests/test_actions_data_base.py
+++ b/shopfloor/tests/test_actions_data_base.py
@@ -246,7 +246,7 @@ class ActionsDataDetailCaseBase(ActionsDataCaseBase):
         if kw.get("full"):
             detail.update(
                 {
-                    "image": f"/web/image/product.product/{record.id}/image_128"
+                    "image": self.data_detail._product_image_url(record, "image_128")
                     if record.image_128
                     else None,
                     "locations": locations_info,


### PR DESCRIPTION
The change adds a unique parameter to the product image URL, which is generated using a SHA-512 hash of the product's last update timestamp. This ensures that when a product image is updated, the URL will change, preventing caching issues and ensuring that users always see the most recent image.