### PR TITLE
[14.0][FIX] shopfloor: propagate args for message handling

### DIFF
--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -302,7 +302,9 @@ class Checkout(Component):
         # where qty >= packaging.qty, since it doesn't makes sense
         # to select a move line which have less qty than the packaging
         line_domain = [("product_uom_qty", ">=", packaging.qty)]
-        return self._select_document_from_product(product, line_domain=line_domain)
+        return self._select_document_from_product(
+            product, line_domain=line_domain, **kw
+        )
 
     def _select_document_from_none(self, *args, barcode=None, **kwargs):
         """Handle result when no record is found."""

--- a/shopfloor/tests/test_checkout_scan.py
+++ b/shopfloor/tests/test_checkout_scan.py
@@ -54,6 +54,20 @@ class CheckoutScanCase(CheckoutCommonCase):
             in_package=False,
         )
 
+    def test_scan_document_error_packaging_without_transfer(self):
+        response = self.service.dispatch(
+            "scan_document", params={"barcode": self.product_c_packaging.barcode}
+        )
+        self.assert_response(
+            response,
+            next_state="select_document",
+            message={
+                "message_type": "error",
+                "body": "No transfer found for packaging Box",
+            },
+            data={"restrict_scan_first": False},
+        )
+
     def test_scan_document_error_not_found(self):
         response = self.service.dispatch("scan_document", params={"barcode": "NOPE"})
         self.assert_response(


### PR DESCRIPTION
On the checkout step, the product can be found, but no proper transfer to put in; without propagating args, no proper message can be generated; instead, an error is raised

`Traceback (most recent call last):
  File "<console>", line 2, in <module>
  File "/odoo/addons_OCA/rest-framework/base_rest/restapi.py", line 104, in response_wrap
    response = f(*args, **kw)
  File "/odoo/addons_OCA/wms/shopfloor/services/checkout.py", line 234, in scan_document
    return handler(search_result.record, **kwargs)
  File "/odoo/addons_OCA/wms/shopfloor/services/checkout.py", line 306, in _select_document_from_packaging
    return self._select_document_from_product(product, line_domain=line_domain)
  File "/odoo/addons_OCA/wms/shopfloor/services/checkout.py", line 297, in _select_document_from_product
    return self._select_document_from_picking(picking, **kwargs)
  File "/odoo/addons_OCA/wms/shopfloor/services/checkout.py", line 321, in _select_document_from_picking
    message = self.msg_store.transfer_not_found_for_record(scanned_record)
  File "/odoo/addons_OCA/wms/shopfloor/actions/message.py", line 466, in transfer_not_found_for_record
    model_name = model_mapping.get(record._name)
AttributeError: 'NoneType' object has no attribute '_name'
`