### PR TITLE
[16.0][FIX] shopfloor_reception: Add lot suggestion schema to allow optiona…

### DIFF
--- a/shopfloor_reception/actions/schema.py
+++ b/shopfloor_reception/actions/schema.py
@@ -19,14 +19,15 @@ class ShopfloorSchemaAction(Component):
         )
         return res
 
-    def lot(self):
-        res = super().lot()
+    def lot_suggestion(self):
+        """Schema used to suggest a lot payload before creation.
 
-        # We need to be able to send lot name and expiration date info
-        # for "virtual lot" not yet created -> not yet an id
-        res.update(
-            {
-                "id": {"required": False, "type": "integer"},
-            }
-        )
+        All attributes are optional so the client can progressively complete
+        values before sending a final payload for lot creation.
+        """
+        res = super().lot()
+        for _field, spec in res.items():
+            if isinstance(spec, dict):
+                spec["required"] = False
+                spec.setdefault("nullable", True)
         return res

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -2067,11 +2067,17 @@ class ShopfloorReceptionValidatorResponse(Component):
 
     @property
     def _schema_set_lot(self):
+        # on set lot, we want to suggest a lot to the user if possible,
+        # so we add the suggestion schema since information received from
+        # the client could be partial against the lot model (e.g.
+        # no lot name, no expiration date, ..)
+        move_line_schema = self.schemas.move_line()
+        move_line_schema["lot"]["schema"] = self.schemas.lot_suggestion()
         return {
             "picking": {"type": "dict", "schema": self.schemas.picking()},
             "selected_move_line": {
                 "type": "list",
-                "schema": {"type": "dict", "schema": self.schemas.move_line()},
+                "schema": {"type": "dict", "schema": move_line_schema},
             },
         }
 

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 # pylint: disable=missing-return
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from odoo import fields
 
@@ -436,6 +436,40 @@ class TestSelectLine(CommonCase):
             data={
                 "picking": data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
+            },
+        )
+
+    def test_manual_select_move_to_set_lot(self):
+        # only a peremption date is prefilled, no lot name
+        picking = self._create_picking()
+        # The picking type is configured to create lots,
+        # so the line is prefilled with an expiration date, but no lot name.
+        # This test is a regression test to ensure that
+        # all the information of the lot are optional when the user is
+        # prompted to set a lot.
+        selected_move = picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_a
+        )
+        expiration_date = datetime.now() + timedelta(days=30)
+        line = selected_move.move_line_ids[0]
+        line.expiration_date = expiration_date
+        self.assertTrue(line.expiration_date)
+        response = self.service.dispatch(
+            "manual_select_move",
+            params={"move_id": selected_move.id},
+        )
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda l: l.product_id == self.product_a
+        )
+        data = self.data.picking(picking)
+        self.assert_response(
+            response,
+            next_state="set_lot",
+            data={
+                "picking": data,
+                "selected_move_line": self.data.move_lines(
+                    selected_move_line, lot_expiration_date=expiration_date
+                ),
             },
         )
 


### PR DESCRIPTION
…l attributes

When suggesting lot information during reception, the payload can contain only a partial set of attributes. In that case, some fields are legitimately optional and must not block the suggestion flow.

This is required for partial-information suggestions when creating a lot, where only the data currently known is sent. The schema is therefore relaxed so optional attributes can be omitted without triggering validation errors, while still preserving the expected structure for the values that are provided.