### PR TITLE
[16.0][IMP]shopfloor_reception_mobile:  better ui logic in "set_lot"

### DIFF
--- a/shopfloor_reception_mobile/static/src/scenario/reception.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.js
@@ -478,6 +478,14 @@ const Reception = {
             let lot_name = this.line_being_handled.lot.name;
             if (!lot_name) return false;
 
+            let product = this.line_being_handled.product;
+            if (
+                product.use_expiration_date &&
+                (!this.line_being_handled.lot ||
+                    !this.line_being_handled.lot.expiration_date)
+            )
+                return false;
+
             return true;
         },
         move_card_color: function (move) {

--- a/shopfloor_reception_mobile/static/src/scenario/reception_states.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception_states.js
@@ -129,14 +129,30 @@ export const reception_states = function () {
                 scan_placeholder: "Scan lot",
                 scan_input_placeholder_expiry: "Scan expiration date",
             },
-            on_scan: (barcode) => {
-                this.wait_call(
+            on_scan: async (barcode) => {
+                const lot = this.line_being_handled && this.line_being_handled.lot;
+                const previous_expiration_date = lot && lot.expiration_date;
+                await this.wait_call(
                     this.odoo.call("scan_lot", {
                         picking_id: this.state.data.picking.id,
                         selected_line_id: this.line_being_handled.id,
                         barcode: barcode.text,
                     })
                 );
+                // Preserve local draft expiration date in case backend did not find a
+                // matching lot in db and thus returned an empty expiration date
+                if (
+                    previous_expiration_date &&
+                    this.line_being_handled &&
+                    this.line_being_handled.lot &&
+                    !this.line_being_handled.lot.expiration_date
+                ) {
+                    this.$set(
+                        this.line_being_handled.lot,
+                        "expiration_date",
+                        previous_expiration_date
+                    );
+                }
             },
             on_date_change: (expiration_date) => {
                 if (!expiration_date) return;


### PR DESCRIPTION
This PR improves the user experience during the "set_lot"  step in Shopfloor Reception by preventing missing expiration date submissions and preserving draft input state when scanning barcodes.

### Key Changes
1. Preserve draft expiration date on lot scan
2. Disable lot confirmation button when date expiration date is not entered but expected.

@jbaudoux
