### PR TITLE
[16.0][FIX] shopfloor_reception: prevent response validation error on lot data without name 

### DIFF
--- a/shopfloor_reception/actions/data.py
+++ b/shopfloor_reception/actions/data.py
@@ -43,9 +43,10 @@ class DataAction(Component):
                 lot_expiration_date := kw.get("lot_expiration_date")
             ):
                 lot_data["expiration_date"] = lot_expiration_date.isoformat()
-        else:
-            if lot_name := kw.get("lot_name"):
-                lot_data["name"] = lot_name
+        elif lot_name := kw.get("lot_name"):
+            lot_data["name"] = lot_name
+            # NB: name is required when returning a lot
+            # so if there is an expiration date on the line but no lot_name -> discard
             if lot_expiration_date := kw.get("lot_expiration_date"):
                 lot_data["expiration_date"] = lot_expiration_date.isoformat()
 


### PR DESCRIPTION
### The error

<img width="402" height="704" alt="image" src="https://github.com/user-attachments/assets/55b2b39f-888a-446c-bf0d-189ab59c7a54" />

`SystemError: Invalid Response {'data': [{'set_lot': [{'selected_move_line': [{0: [{'lot': [{'name': ['required field']}]}]}]}]}]}`

@jbaudoux 