### PR TITLE
[16.0][FIX] shopfloor_gs1: prevent parsing when barcode is not a valid GS1

### DIFF
--- a/shopfloor_gs1/config.py
+++ b/shopfloor_gs1/config.py
@@ -16,8 +16,10 @@ MAPPING_TYPE_TO_AI = {
     "serial": ("21",),
     "manuf_product_code": ("240",),
     "location": ("254",),
+    "package": ("00",),
 }
 MAPPING_AI_TO_TYPE = {
+    "00": "package",
     "01": "product",
     "10": "lot",
     "11": "production_date",

--- a/shopfloor_gs1/tests/test_utils.py
+++ b/shopfloor_gs1/tests/test_utils.py
@@ -73,8 +73,23 @@ class TestUtils(BaseCase):
 
         self.assertEqual(str(res[0]), "<GS1Barcode: ai=01>")
 
-    def test_do_not_parse_invalid_gs1(self):
-        code = "10LOT"
+    def test_parse_single_sscc(self):
+        code = "(00)354123450000000014"
         res = GS1Barcode.parse(code)
-        # we should not parse this plain (non-GS1) barcode into "LOT"
+        self.assertEqual(len(res), 1, res)
+        item = [x for x in res if x.ai == "00"][0]
+        self.assertEqual(item.code, code)
+        self.assertEqual(item.value, "354123450000000014")
+        self.assertEqual(item.raw_value, "354123450000000014")
+
+    def test_do_not_parse_invalid_gs1(self):
+        # Do not parse if no primary AI
+        code = "(10)LOT"
+        res = GS1Barcode.parse(code)
+        self.assertFalse(res)
+
+        # Do not parse if invalid GS1 format
+        # 00 AI should be of the form (\d{18}), see https://ref.gs1.org/ai/00
+        code = "(00)PACK1"
+        res = GS1Barcode.parse(code)
         self.assertFalse(res)

--- a/shopfloor_gs1/tests/test_utils.py
+++ b/shopfloor_gs1/tests/test_utils.py
@@ -72,3 +72,9 @@ class TestUtils(BaseCase):
         self.assertFalse(GS1Barcode())
 
         self.assertEqual(str(res[0]), "<GS1Barcode: ai=01>")
+
+    def test_do_not_parse_invalid_gs1(self):
+        code = "10LOT"
+        res = GS1Barcode.parse(code)
+        # we should not parse this plain (non-GS1) barcode into "LOT"
+        self.assertFalse(res)

--- a/shopfloor_gs1/utils.py
+++ b/shopfloor_gs1/utils.py
@@ -13,7 +13,7 @@ DEFAULT_AI_WHITELIST = tuple(MAPPING_AI_TO_TYPE.keys())
 class GS1Barcode:
     """GS1 barcode parser and wrapper."""
 
-    PRIMARY_AIS = ("01", "240")
+    PRIMARY_AIS = ("00", "01", "02", "240")
 
     __slots__ = ("ai", "code", "value", "raw_value")
 

--- a/shopfloor_gs1/utils.py
+++ b/shopfloor_gs1/utils.py
@@ -13,6 +13,8 @@ DEFAULT_AI_WHITELIST = tuple(MAPPING_AI_TO_TYPE.keys())
 class GS1Barcode:
     """GS1 barcode parser and wrapper."""
 
+    PRIMARY_AIS = ("01", "240")
+
     __slots__ = ("ai", "code", "value", "raw_value")
 
     def __init__(self, **kw) -> None:
@@ -51,6 +53,14 @@ class GS1Barcode:
         return value
 
     @classmethod
+    def _is_valid_gs1(cls, parsed):
+        # Standalone secondary AIs (e.g. lot '10LOT') without primary keys
+        # prefixes are ambiguous and usually false positive plain barcodes.
+        return any(
+            element.ai.ai in cls.PRIMARY_AIS for element in parsed.element_strings
+        )
+
+    @classmethod
     def parse(cls, barcode, ai_whitelist=None, safe=True):
         """Parse given barcode
 
@@ -71,7 +81,7 @@ class GS1Barcode:
                 if not safe:
                     raise
                 parsed = None
-        if not parsed:
+        if not parsed or not cls._is_valid_gs1(parsed):
             return res
         # Use whitelist if given, to respect a specific order
         ai_whitelist = ai_whitelist or DEFAULT_AI_WHITELIST


### PR DESCRIPTION
### The problem

If we scan a lot named `10D9T`, shopfloor fails to find the given lot and returns a "barcode not found". This is because the gs1 module parses this barcode into `D9T` (`10` is the AI for "lot" in GS1).

See https://ref.gs1.org/ai/

@jbaudoux 