### PR TITLE
[16.0][FIX] shopfloor: Cluster Picking - Incorrect picking stale state after split

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -162,8 +162,9 @@ class StockMove(models.Model):
             # a new transfer to validate. All remaining moves stay in the
             # current transfer.
             else:
-                new_picking = moves_todo._extract_in_split_order()
-                assert new_picking.state == "assigned"
+                new_picking = moves_todo._extract_in_split_order(
+                    default={"printed": True}
+                )
             new_picking._action_done()
             new_backorders |= new_picking.backorder_ids - existing_backorders
         return new_backorders

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1164,6 +1164,9 @@ class ClusterPicking(Component):
         for picking in lines.picking_id:
             self._unload_set_picking_to_done(picking)
 
+    def _clear_batch_and_assignment(self, pickings):
+        pickings.write({"batch_id": False, "user_id": False, "printed": False})
+
     def _unload_set_picking_to_done(self, picking):
         """Set picking to done when all picked move lines have been unloaded"""
         if picking.state == "done":
@@ -1196,7 +1199,7 @@ class ClusterPicking(Component):
         stock.validate_moves(moves_to_validate)
         if picking.state not in ("cancel", "done"):
             # A split order has been created, remove picking from batch
-            picking.batch_id = False
+            self._clear_batch_and_assignment(picking)
 
     def _unload_end(self, batch, completion_info_popup=None):
         """Remove unprocessed pickings from batch to close it.
@@ -1220,7 +1223,7 @@ class ClusterPicking(Component):
                     Markup(", ").join(p._get_html_link() for p in empty_pickings),
                 )
             )
-            empty_pickings.batch_id = False
+            self._clear_batch_and_assignment(empty_pickings)
 
         if batch.state != "done":
             # As processed pickings are already done, the batch should now be done

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1217,13 +1217,7 @@ class ClusterPicking(Component):
                 body=Markup("<b>%s:</b> %s")
                 % (
                     _("Unprocessed transfer removed from batch"),
-                    ", ".join(
-                        Markup(
-                            "<a href=#id=%s&view_type=form&model=stock.picking>%s</a>"
-                        )
-                        % (p.id, p.name)
-                        for p in empty_pickings
-                    ),
+                    Markup(", ").join(p._get_html_link() for p in empty_pickings),
                 )
             )
             empty_pickings.batch_id = False

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -233,7 +233,15 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         # The 2 lines picking has one remaining line
         self.assertEqual(len(self.two_lines_picking.move_line_ids), 1)
         self.assertRecordValues(
-            self.two_lines_picking, [{"state": "assigned", "batch_id": False}]
+            self.two_lines_picking,
+            [
+                {
+                    "state": "assigned",
+                    "batch_id": False,
+                    "user_id": False,
+                    "printed": False,
+                }
+            ],
         )
         self.new_picking = self.two_lines_picking.backorder_ids
         self.assertRecordValues(

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -244,6 +244,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
             ],
         )
         self.new_picking = self.two_lines_picking.backorder_ids
+        self.assertTrue(self.new_picking.printed)
         self.assertRecordValues(
             self.move_lines,
             [


### PR DESCRIPTION
Fixes data sanitization and display issues during Shopfloor cluster picking unloading.

**Before this change:**
- Unprocessed or split pickings removed from a batch retained stale `user_id` and `printed` flags from the previous session, preventing them from being cleanly reassigned or re-printed.
- Unprocessed transfer notifications in chatter rendered broken raw HTML links.
- Split transfers marked as done during unload validation lacked the `printed` flag.

cc @jbaudoux 