### PR TITLE
[16.0][REF] shopfloor: use msg_store instead of copy pasting messages

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -201,7 +201,7 @@ class MessageAction(Component):
         return {
             "message_type": "warning",
             "body": _(
-                "Confirm location change from %(location_from)s to " "%(location_to)s?"
+                "Confirm location change from %(location_from)s to %(location_to)s?"
             )
             % dict(location_from=from_location.name, location_to=to_location.name),
         }
@@ -277,6 +277,9 @@ class MessageAction(Component):
 
     def wrong_record(self, record):
         return {"message_type": "error", "body": self._wrong_record_msg(record._name)}
+
+    def wrong_bin(self):
+        return {"message_type": "error", "body": _("Wrong bin")}
 
     def no_lot_for_barcode(self, barcode):
         return {
@@ -536,6 +539,15 @@ class MessageAction(Component):
         return {
             "message_type": "error",
             "body": _("Several transfers found, please select a transfer manually."),
+        }
+
+    def multiple_picks_found_scan_pack_or_select_manually(self):
+        return {
+            "message_type": "error",
+            "body": _(
+                "Several transfers found, please scan a package"
+                " or select a transfer manually."
+            ),
         }
 
     def no_transfer_for_packaging(self):
@@ -1030,4 +1042,61 @@ class MessageAction(Component):
         return {
             "message_type": "error",
             "body": body,
+        }
+
+    def negative_quantity_not_allowed(self):
+        return {
+            "body": _("Negative quantity not allowed."),
+            "message_type": "error",
+        }
+
+    def products_processed_as_raw_products(self):
+        return {
+            "message_type": "success",
+            "body": _("Product(s) processed as raw product(s)"),
+        }
+
+    def packaging_changed_on_package(self, pack):
+        return {
+            "message_type": "success",
+            "body": _("Packaging changed on package %s", pack.name),
+        }
+
+    def remaining_raw_product_not_packed(self):
+        return {
+            "message_type": "warning",
+            "body": _("Remaining raw product not packed, proceed anyway?"),
+        }
+
+    def no_more_batch_todo(self):
+        return {
+            "message_type": "info",
+            "body": _("No more work to do, please create a new batch transfer"),
+        }
+
+    def batch_cannot_be_selected(self):
+        return {
+            "message_type": "warning",
+            "body": _("This batch cannot be selected."),
+        }
+
+    def destination_bin_not_empty(self, bin_package):
+        return {
+            "message_type": "error",
+            "body": _(
+                "The destination bin %s is not empty, please take another.",
+                bin_package.name,
+            ),
+        }
+
+    def package_cancelled(self):
+        return {"message_type": "success", "body": _("Package cancelled")}
+
+    def line_cancelled(self):
+        return {"message_type": "success", "body": _("Line cancelled")}
+
+    def location_cant_be_moved_at_once(self):
+        return {
+            "message_type": "error",
+            "body": _("This location content can't be moved at once."),
         }

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -4,7 +4,7 @@
 
 from werkzeug.exceptions import BadRequest
 
-from odoo import _, fields
+from odoo import fields
 
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
@@ -248,13 +248,7 @@ class Checkout(Component):
         pickings = lines.mapped("picking_id")
         if len(pickings) > 1:
             return self._response_for_select_document(
-                message={
-                    "message_type": "error",
-                    "body": _(
-                        "Several transfers found, please scan a package"
-                        " or select a transfer manually."
-                    ),
-                }
+                message=self.msg_store.multiple_picks_found_scan_pack_or_select_manually()
             )
         # Keep track of what has been initially scan, and forward it through kwargs
         kwargs = {**kw, "current_state": "select_document"}
@@ -846,10 +840,7 @@ class Checkout(Component):
         for move_line in move_lines:
             qty_done = quantity_func(move_line)
             if qty_done < 0:
-                message = {
-                    "body": _("Negative quantity not allowed."),
-                    "message_type": "error",
-                }
+                message = self.msg_store.negative_quantity_not_allowed()
             else:
                 new_line = self.env["stock.move.line"]
                 if qty_done > 0:
@@ -1296,10 +1287,7 @@ class Checkout(Component):
             return response
         return self._response_for_select_line(
             picking,
-            message={
-                "message_type": "success",
-                "body": _("Product(s) processed as raw product(s)"),
-            },
+            message=self.msg_store.products_processed_as_raw_products(),
         )
 
     def list_dest_package(self, picking_id, selected_line_ids):
@@ -1464,10 +1452,7 @@ class Checkout(Component):
         package.package_type_id = packaging
         return self._response_for_summary(
             picking,
-            message={
-                "message_type": "success",
-                "body": _("Packaging changed on package {}").format(package.name),
-            },
+            message=self.msg_store.packaging_changed_on_package(package),
         )
 
     def cancel_line(self, picking_id, package_id=None, line_id=None):
@@ -1512,13 +1497,11 @@ class Checkout(Component):
                         "shopfloor_checkout_done": False,
                     }
                 )
-            msg = _("Package cancelled")
+            msg = self.msg_store.package_cancelled()
         if line:
             line.write({"qty_done": 0, "shopfloor_checkout_done": False})
-            msg = _("Line cancelled")
-        return self._response_for_select_line(
-            picking, message={"message_type": "success", "body": msg}
-        )
+            msg = self.msg_store.line_cancelled()
+        return self._response_for_select_line(picking, message=msg)
 
     def done(self, picking_id, confirmation=False):
         """Set the moves as done
@@ -1548,10 +1531,7 @@ class Checkout(Component):
                 return self._response_for_summary(
                     picking,
                     need_confirm=True,
-                    message={
-                        "message_type": "warning",
-                        "body": _("Remaining raw product not packed, proceed anyway?"),
-                    },
+                    message=self.msg_store.remaining_raw_product_not_packed(),
                 )
         lines_done = self._lines_checkout_done(picking)
         dest_location = lines_done.move_id.location_dest_id

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -209,10 +209,7 @@ class ClusterPicking(Component):
             return self._response_for_confirm_start(selected)
         else:
             return self._response_for_start(
-                message={
-                    "message_type": "info",
-                    "body": _("No more work to do, please create a new batch transfer"),
-                },
+                message=self.msg_store.no_more_batch_todo(),
             )
 
     def list_batch(self):
@@ -316,10 +313,7 @@ class ClusterPicking(Component):
         else:
             return self._response(
                 base_response=self.list_batch(),
-                message={
-                    "message_type": "warning",
-                    "body": _("This batch cannot be selected."),
-                },
+                message=self.msg_store.batch_cannot_be_selected(),
             )
 
     def confirm_start(self, picking_batch_id):
@@ -796,12 +790,7 @@ class ClusterPicking(Component):
         if not multi_pick_allowed and (bin_package.quant_ids or different_picking):
             return self._response_for_scan_destination(
                 move_line,
-                message={
-                    "message_type": "error",
-                    "body": _(
-                        "The destination bin {} is not empty, please take another."
-                    ).format(bin_package.name),
-                },
+                message=self.msg_store.destination_bin_not_empty(bin_package),
                 qty_done=quantity,
             )
         move_line.write({"qty_done": quantity, "result_package_id": bin_package.id})
@@ -1274,7 +1263,7 @@ class ClusterPicking(Component):
             return self._response_for_unload_single(
                 batch,
                 package,
-                message={"message_type": "error", "body": _("Wrong bin")},
+                message=self.msg_store.wrong_bin(),
             )
         return self._response_for_unload_set_destination(batch, package)
 

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -2,7 +2,6 @@
 # Copyright 2020-2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import _
 from odoo.fields import first
 
 from odoo.addons.base_rest.components.service import to_int
@@ -355,10 +354,7 @@ class LocationContentTransfer(Component):
             picking_types = move_lines.picking_id.picking_type_id
             if len(picking_types) > 1:
                 return self._response_for_start(
-                    message={
-                        "message_type": "error",
-                        "body": _("This location content can't be moved at once."),
-                    }
+                    message=self.msg_store.location_cant_be_moved_at_once()
                 )
             if picking_types - self.picking_types:
                 return self._response_for_start(
@@ -556,7 +552,7 @@ class LocationContentTransfer(Component):
                 # the correct package, so ask to scan the package.
                 return self._response_for_start_single(
                     move_lines.mapped("picking_id"),
-                    message={"message_type": "error", "body": _("Scan the package")},
+                    message=self.msg_store.scan_the_package(),
                 )
             else:
                 return self._response_for_scan_destination(location, package_level)
@@ -566,7 +562,7 @@ class LocationContentTransfer(Component):
             if lot in other_move_lines.mapped("lot_id"):
                 return self._response_for_start_single(
                     move_lines.mapped("picking_id"),
-                    message={"message_type": "error", "body": _("Scan the package")},
+                    message=self.msg_store.scan_the_package(),
                 )
             else:
                 return self._response_for_scan_destination(location, package_level)

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -87,10 +87,5 @@ class CheckoutCommonCase(CommonCase):
                 "no_package_enabled": True,
                 "package_allowed": True,
             },
-            message={
-                "message_type": "warning",
-                "body": "The quantity scanned for one or more lines cannot be "
-                "higher than the maximum allowed. "
-                f"({line.product_id.name} : {str(line.qty_done)} > {str(line.reserved_uom_qty)})",  # noqa
-            },
+            message=self.msg_store.selected_lines_qty_done_higher_than_allowed(line),
         )

--- a/shopfloor/tests/test_checkout_cancel_line.py
+++ b/shopfloor/tests/test_checkout_cancel_line.py
@@ -129,10 +129,7 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
                 "picking": self._stock_picking_data(self.picking, done=True),
                 "all_processed": False,
             },
-            message={
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            message=self.msg_store.record_not_found(),
         )
 
     def test_cancel_line_error_line_not_found(self):
@@ -147,8 +144,5 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
                 "picking": self._stock_picking_data(self.picking, done=True),
                 "all_processed": False,
             },
-            message={
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            message=self.msg_store.record_not_found(),
         )

--- a/shopfloor/tests/test_checkout_cancel_line.py
+++ b/shopfloor/tests/test_checkout_cancel_line.py
@@ -89,7 +89,7 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
             response,
             next_state="select_line",
             data=self._data_for_select_line(picking),
-            message={"body": "Package cancelled", "message_type": "success"},
+            message=self.msg_store.package_cancelled(),
         )
 
     def test_cancel_line_ok(self):
@@ -114,7 +114,7 @@ class CheckoutRemovePackageCase(CheckoutCommonCase):
             response,
             next_state="select_line",
             data=self._data_for_select_line(picking),
-            message={"body": "Line cancelled", "message_type": "success"},
+            message=self.msg_store.line_cancelled(),
         )
 
     def test_cancel_line_error_package_not_found(self):

--- a/shopfloor/tests/test_checkout_change_packaging.py
+++ b/shopfloor/tests/test_checkout_change_packaging.py
@@ -130,10 +130,7 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
                 "picking": self._stock_picking_data(self.picking, done=True),
                 "all_processed": False,
             },
-            message={
-                "message_type": "success",
-                "body": f"Packaging changed on package {self.package.name}",
-            },
+            message=self.msg_store.packaging_changed_on_package(self.package),
         )
 
     def test_set_packaging_error_package_not_found(self):

--- a/shopfloor/tests/test_checkout_change_packaging.py
+++ b/shopfloor/tests/test_checkout_change_packaging.py
@@ -108,10 +108,7 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
                 "picking": self._stock_picking_data(self.picking, done=True),
                 "all_processed": False,
             },
-            message={
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            message=self.msg_store.record_not_found(),
         )
 
     def test_set_packaging_ok(self):
@@ -155,10 +152,7 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
                 "picking": self._stock_picking_data(self.picking, done=True),
                 "all_processed": False,
             },
-            message={
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            message=self.msg_store.record_not_found(),
         )
 
     def test_set_packaging_error_packaging_not_found(self):
@@ -177,8 +171,5 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
                 "picking": self._stock_picking_data(self.picking, done=True),
                 "all_processed": False,
             },
-            message={
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            message=self.msg_store.record_not_found(),
         )

--- a/shopfloor/tests/test_checkout_done.py
+++ b/shopfloor/tests/test_checkout_done.py
@@ -133,10 +133,7 @@ class CheckoutDoneRawUnpackedCase(CheckoutCommonCase):
             response,
             next_state="confirm_done",
             data={"picking": self._stock_picking_data(self.picking, done=True)},
-            message={
-                "message_type": "warning",
-                "body": "Remaining raw product not packed, proceed anyway?",
-            },
+            message=self.msg_store.remaining_raw_product_not_packed(),
         )
 
     def test_done_partial_confirm(self):

--- a/shopfloor/tests/test_checkout_done.py
+++ b/shopfloor/tests/test_checkout_done.py
@@ -18,10 +18,7 @@ class CheckoutDoneCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "success",
-                "body": f"Transfer {picking.name} done",
-            },
+            message=self.msg_store.transfer_done_success(picking),
             data={"restrict_scan_first": False},
         )
 

--- a/shopfloor/tests/test_checkout_list_package.py
+++ b/shopfloor/tests/test_checkout_list_package.py
@@ -98,7 +98,7 @@ class CheckoutListDestPackageCase(
         self._assert_selected_response(
             response,
             picking.move_line_ids,
-            message={"message_type": "warning", "body": "No valid package to select."},
+            message=self.msg_store.no_valid_package_to_select(),
         )
 
 

--- a/shopfloor/tests/test_checkout_no_package.py
+++ b/shopfloor/tests/test_checkout_no_package.py
@@ -61,10 +61,7 @@ class CheckoutNoPackageCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
             # go pack to the screen to select lines to put in packages
             next_state="select_line",
             data=self._data_for_select_line(self.picking),
-            message={
-                "message_type": "success",
-                "body": "Product(s) processed as raw product(s)",
-            },
+            message=self.msg_store.products_processed_as_raw_products(),
         )
 
     def test_no_package_disabled(self):

--- a/shopfloor/tests/test_checkout_scan.py
+++ b/shopfloor/tests/test_checkout_scan.py
@@ -41,10 +41,7 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "error",
-                "body": "No transfer found for barcode A",
-            },
+            message=self.msg_store.transfer_not_found_for_barcode(barcode),
             data={"restrict_scan_first": True},
         )
 
@@ -59,10 +56,7 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "error",
-                "body": "No transfer found for barcode NOPE",
-            },
+            message=self.msg_store.transfer_not_found_for_barcode("NOPE"),
             data={"restrict_scan_first": False},
         )
 
@@ -82,10 +76,7 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "error",
-                "body": f"Transfer {picking.name} is not available.",
-            },
+            message=self.msg_store.stock_picking_not_available(picking),
             data={"restrict_scan_first": False},
         )
 
@@ -113,7 +104,7 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={"message_type": "error", "body": "Location not allowed here."},
+            message=self.msg_store.location_not_allowed(),
             data={"restrict_scan_first": False},
         )
 
@@ -123,15 +114,10 @@ class CheckoutScanCase(CheckoutCommonCase):
         picking.action_assign()
         barcode = barcode_func(picking)
         response = self.service.dispatch("scan_document", params={"barcode": barcode})
-        picking_name = picking.name
-        type_name = picking.picking_type_id.name
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "error",
-                "body": f"Reserved for {type_name} {picking_name}",
-            },
+            message=self.msg_store.reserved_for_other_picking_type(picking),
             data={"restrict_scan_first": False},
         )
 

--- a/shopfloor/tests/test_checkout_scan.py
+++ b/shopfloor/tests/test_checkout_scan.py
@@ -146,11 +146,7 @@ class CheckoutScanCase(CheckoutCommonCase):
         self.assert_response(
             response,
             next_state="select_document",
-            message={
-                "message_type": "error",
-                "body": "Several transfers found, please scan a package"
-                " or select a transfer manually.",
-            },
+            message=self.msg_store.multiple_picks_found_scan_pack_or_select_manually(),
             data={"restrict_scan_first": False},
         )
 

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -160,7 +160,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             "NOT A BARCODE",
-            {"message_type": "error", "body": "Barcode not found"},
+            self.msg_store.barcode_not_found(),
         )
 
     def test_scan_line_error_package_not_in_picking(self):
@@ -175,10 +175,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             package.name,
-            {
-                "message_type": "error",
-                "body": f"Package {package.name} not found in transfer {picking.name}",  # noqa
-            },
+            self.msg_store.package_not_found_in_picking(package, picking),
         )
 
     def test_scan_line_error_package_reserved_by_another_picking(self):
@@ -192,10 +189,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             package.name,
-            {
-                "message_type": "error",
-                "body": f"Reserved for Checkout {picking2.name}",
-            },
+            self.msg_store.reserved_for_other_picking_type(picking2),
         )
 
     def test_scan_line_error_product_tracked_by_lot(self):
@@ -208,10 +202,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             self.product_a.barcode,
-            {
-                "message_type": "warning",
-                "body": "Product tracked by lot, please scan one.",
-            },
+            self.msg_store.scan_lot_on_product_tracked_by_lot(),
         )
 
     def test_scan_line_error_product_in_two_packages(self):
@@ -226,11 +217,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             self.product_a.barcode,
-            {
-                "message_type": "warning",
-                "body": "This product is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.product_multiple_packages_scan_package(),
         )
 
     def test_scan_line_error_product_in_one_package_and_unit(self):
@@ -247,11 +234,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             self.product_a.barcode,
-            {
-                "message_type": "warning",
-                "body": "This product is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.product_multiple_packages_scan_package(),
         )
 
     def test_scan_line_error_product_not_in_picking(self):
@@ -261,10 +244,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             self.product_b.barcode,
-            {
-                "message_type": "error",
-                "body": "Product Product B is not in the current transfer.",
-            },
+            self.msg_store.product_not_found_in_current_picking(self.product_b),
         )
 
     def test_scan_line_error_product_in_another_picking(self):
@@ -276,10 +256,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             self.product_b.barcode,
-            {
-                "message_type": "error",
-                "body": f"Reserved for Checkout {picking2.name}",
-            },
+            self.msg_store.reserved_for_other_picking_type(picking2),
         )
 
     def test_scan_line_error_lot_different_change_success(self):
@@ -345,11 +322,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             lot.name,
-            {
-                "message_type": "warning",
-                "body": "This lot is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.lot_multiple_packages_scan_package(),
         )
 
     def test_scan_line_error_lot_in_one_package_and_unit(self):
@@ -368,11 +341,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
         self._test_scan_line_error(
             picking,
             lot.name,
-            {
-                "message_type": "warning",
-                "body": "This lot is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.lot_multiple_packages_scan_package(),
         )
 
     def test_scan_line_all_lines_done(self):

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -100,10 +100,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
             move_line,
             # no change as the scan was not valid
             {move_line: origin_qty_done},
-            message={
-                "message_type": "warning",
-                "body": "Product tracked by lot, please scan one.",
-            },
+            message=self.msg_store.scan_lot_on_product_tracked_by_lot(),
         )
 
     def test_scan_package_action_scan_product_error_tracking(self):
@@ -448,7 +445,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
         self._assert_selected_response(
             response,
             selected_line,
-            message={"message_type": "error", "body": "Barcode not found"},
+            message=self.msg_store.barcode_not_found(),
         )
 
     def test_put_in_pack(self):

--- a/shopfloor/tests/test_checkout_select_line.py
+++ b/shopfloor/tests/test_checkout_select_line.py
@@ -89,10 +89,7 @@ class CheckoutSelectLineCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
         selected_lines.unlink()
         self._test_select_line_error(
             {"picking_id": self.picking.id, "package_id": selected_lines[0].id},
-            {
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            self.msg_store.record_not_found(),
         )
 
     def test_select_line_move_line_error_not_found(self):
@@ -100,10 +97,7 @@ class CheckoutSelectLineCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
         selected_lines.unlink()
         self._test_select_line_error(
             {"picking_id": self.picking.id, "move_line_id": selected_lines[0].id},
-            {
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            self.msg_store.record_not_found(),
         )
 
     def test_select_line_all_lines_done(self):

--- a/shopfloor/tests/test_checkout_set_qty.py
+++ b/shopfloor/tests/test_checkout_set_qty.py
@@ -206,10 +206,7 @@ class CheckoutSetCustomQtyCase(CheckoutSetQtyCommonCase):
             response,
             selected_lines,
             {line1: line1.reserved_uom_qty, line2: line2.reserved_uom_qty},
-            message={
-                "body": "Negative quantity not allowed.",
-                "message_type": "error",
-            },
+            message=self.msg_store.negative_quantity_not_allowed(),
         )
 
     def test_set_custom_qty_partial(self):

--- a/shopfloor/tests/test_checkout_set_qty.py
+++ b/shopfloor/tests/test_checkout_set_qty.py
@@ -72,10 +72,7 @@ class CheckoutResetLineQtyCase(CheckoutSetQtyCommonCase):
             response,
             selected_lines,
             {line: line.reserved_uom_qty for line in selected_lines},
-            message={
-                "body": "The record you were working on does not exist anymore.",
-                "message_type": "error",
-            },
+            message=self.msg_store.record_not_found(),
         )
 
 
@@ -120,10 +117,7 @@ class CheckoutSetLineQtyCase(CheckoutSetQtyCommonCase):
             response,
             selected_lines,
             {line: line.reserved_uom_qty for line in selected_lines},
-            message={
-                "body": "The record you were working on does not exist anymore.",
-                "message_type": "error",
-            },
+            message=self.msg_store.record_not_found(),
         )
 
 
@@ -170,10 +164,7 @@ class CheckoutSetCustomQtyCase(CheckoutSetQtyCommonCase):
             response,
             selected_lines,
             {line: line.reserved_uom_qty for line in selected_lines},
-            message={
-                "body": "The record you were working on does not exist anymore.",
-                "message_type": "error",
-            },
+            message=self.msg_store.record_not_found(),
         )
 
     def test_set_custom_qty_above(self):
@@ -195,11 +186,7 @@ class CheckoutSetCustomQtyCase(CheckoutSetQtyCommonCase):
             response,
             selected_lines,
             {line1: line1.reserved_uom_qty + 1, line2: line2.reserved_uom_qty},
-            message={
-                "body": "Please note that the scanned quantity "
-                "is higher than the maximum allowed.",
-                "message_type": "warning",
-            },
+            message=self.msg_store.line_scanned_qty_done_higher_than_allowed(),
         )
 
     def test_set_custom_qty_negative(self):

--- a/shopfloor/tests/test_cluster_picking_is_zero.py
+++ b/shopfloor/tests/test_cluster_picking_is_zero.py
@@ -55,10 +55,9 @@ class ClusterPickingIsZeroCase(ClusterPickingCommonCase):
             response,
             next_state="start_line",
             data=self._line_data(self.next_line),
-            message={
-                "message_type": "success",
-                "body": f"{self.line.qty_done} {self.line.product_id.display_name} put in {self.bin1.name}",  # noqa
-            },
+            message=self.msg_store.x_units_put_in_package(
+                self.line.qty_done, self.line.product_id, self.bin1
+            ),
         )
 
     def test_is_zero_is_not_empty(self):
@@ -83,8 +82,7 @@ class ClusterPickingIsZeroCase(ClusterPickingCommonCase):
             response,
             next_state="start_line",
             data=self._line_data(self.next_line),
-            message={
-                "message_type": "success",
-                "body": f"{self.line.qty_done} {self.line.product_id.display_name} put in {self.bin1.name}",  # noqa
-            },
+            message=self.msg_store.x_units_put_in_package(
+                self.line.qty_done, self.line.product_id, self.bin1
+            ),
         )

--- a/shopfloor/tests/test_cluster_picking_scan_destination.py
+++ b/shopfloor/tests/test_cluster_picking_scan_destination.py
@@ -144,11 +144,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
             response,
             next_state="scan_destination",
             data=self._line_data(line, qty_done=10.0),
-            message={
-                "message_type": "error",
-                "body": f"The destination bin {self.bin1.name} is not empty, "
-                "please take another.",
-            },
+            message=self.msg_store.destination_bin_not_empty(self.bin1),
         )
 
     def test_scan_destination_pack_not_empty_multi_pick_allowed(self):

--- a/shopfloor/tests/test_cluster_picking_scan_destination.py
+++ b/shopfloor/tests/test_cluster_picking_scan_destination.py
@@ -62,10 +62,9 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
             response,
             next_state="start_line",
             data=self._line_data(next_line),
-            message={
-                "message_type": "success",
-                "body": f"{line.qty_done} {line.product_id.display_name} put in {self.bin1.name}",  # noqa
-            },
+            message=self.msg_store.x_units_put_in_package(
+                line.qty_done, line.product_id, self.bin1
+            ),
         )
 
     def test_scan_destination_pack_ok_last_line(self):
@@ -207,10 +206,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
             response,
             next_state="scan_destination",
             data=line_data,
-            message={
-                "message_type": "error",
-                "body": "Bin {} doesn't exist".format("⌿"),
-            },
+            message=self.msg_store.bin_not_found_for_barcode("⌿"),
         )
 
     def test_scan_destination_pack_quantity_more(self):
@@ -229,10 +225,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
             response,
             next_state="scan_destination",
             data=self._line_data(line, qty_done=11.0),
-            message={
-                "message_type": "error",
-                "body": f"You must not pick more than {line.reserved_uom_qty} units.",
-            },
+            message=self.msg_store.unable_to_pick_more(line.reserved_uom_qty),
         )
 
     def test_scan_destination_pack_quantity_less(self):
@@ -265,10 +258,9 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
             response,
             next_state="start_line",
             data=self._line_data(new_line),
-            message={
-                "message_type": "success",
-                "body": f"{line.qty_done} {line.product_id.display_name} put in {self.bin1.name}",  # noqa
-            },
+            message=self.msg_store.x_units_put_in_package(
+                line.qty_done, line.product_id, self.bin1
+            ),
         )
 
         self.assertRecordValues(
@@ -361,8 +353,7 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
             response,
             next_state="start_line",
             data=self._line_data(next_line),
-            message={
-                "message_type": "success",
-                "body": f"{line.qty_done} {line.product_id.display_name} put in {self.bin1.name}",  # noqa
-            },
+            message=self.msg_store.x_units_put_in_package(
+                line.qty_done, line.product_id, self.bin1
+            ),
         )

--- a/shopfloor/tests/test_cluster_picking_scan_line.py
+++ b/shopfloor/tests/test_cluster_picking_scan_line.py
@@ -104,10 +104,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             line.product_id.barcode,
-            {
-                "message_type": "warning",
-                "body": "Product tracked by lot, please scan one.",
-            },
+            self.msg_store.scan_lot_on_product_tracked_by_lot(),
         )
 
     def test_scan_line_lot_ok_only_one_in_location(self):
@@ -135,11 +132,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             move.product_id.barcode,
-            {
-                "message_type": "warning",
-                "body": "This product is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.product_multiple_packages_scan_package(),
         )
 
     def test_scan_line_product_error_in_one_package_and_raw_same_location(self):
@@ -157,11 +150,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             move.product_id.barcode,
-            {
-                "message_type": "warning",
-                "body": "This product is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.product_multiple_packages_scan_package(),
         )
 
     def test_scan_line_product_error_in_one_package_and_raw_different_location(self):
@@ -193,11 +182,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             line.lot_id.name,
-            {
-                "message_type": "warning",
-                "body": "This lot is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.lot_multiple_packages_scan_package(),
         )
 
     def test_scan_line_lot_error_in_one_package_and_unit(self):
@@ -213,11 +198,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             line.lot_id.name,
-            {
-                "message_type": "warning",
-                "body": "This lot is part of multiple"
-                " packages, please scan a package.",
-            },
+            self.msg_store.lot_multiple_packages_scan_package(),
         )
 
     def test_scan_line_location_ok_single_package(self):
@@ -267,10 +248,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             location.barcode,
-            {
-                "message_type": "warning",
-                "body": "Several packages found in Stock, please scan a package.",
-            },
+            self.msg_store.several_packs_in_location(location),
             sublocation=location,
         )
         # scanning the package works
@@ -289,10 +267,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             location.barcode,
-            {
-                "message_type": "warning",
-                "body": "Several products found in Stock, please scan a product.",
-            },
+            self.msg_store.several_products_in_location(location),
             sublocation=location,
         )
         self._scan_line_ok(line, self.product_a.barcode)
@@ -322,10 +297,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             line,
             location.barcode,
-            {
-                "message_type": "warning",
-                "body": "Several lots found in Stock, please scan a lot.",
-            },
+            self.msg_store.several_lots_in_location(location),
             sublocation=location,
         )
         self._scan_line_ok(line, line.lot_id.name)
@@ -337,7 +309,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             self.batch.picking_ids.move_line_ids,
             pack.name,
-            {"message_type": "error", "body": "Wrong pack."},
+            self.msg_store.wrong_record(pack),
         )
 
     def test_scan_line_error_wrong_product(self):
@@ -356,7 +328,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             self.batch.picking_ids.move_line_ids,
             product.barcode,
-            {"message_type": "error", "body": "Wrong product."},
+            self.msg_store.wrong_record(product),
         )
 
     def test_scan_line_error_wrong_lot(self):
@@ -376,7 +348,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             self.batch.picking_ids.move_line_ids,
             lot.name,
-            {"message_type": "error", "body": "Wrong lot."},
+            self.msg_store.wrong_record(lot),
         )
 
     def test_scan_line_error_wrong_location(self):
@@ -395,7 +367,7 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             self.batch.picking_ids.move_line_ids,
             location.barcode,
-            {"message_type": "error", "body": "Wrong location."},
+            self.msg_store.wrong_record(location),
         )
 
     def test_scan_line_error_not_found(self):
@@ -404,5 +376,5 @@ class ClusterPickingScanLineCase(ClusterPickingLineCommonCase):
         self._scan_line_error(
             self.batch.picking_ids.move_line_ids,
             "NO_EXISTING_BARCODE",
-            {"message_type": "error", "body": "Barcode not found"},
+            self.msg_store.barcode_not_found(),
         )

--- a/shopfloor/tests/test_cluster_picking_select.py
+++ b/shopfloor/tests/test_cluster_picking_select.py
@@ -118,10 +118,7 @@ class ClusterPickingSelectionCase(ClusterPickingCommonCase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "info",
-                "body": "No more work to do, please create a new batch transfer",
-            },
+            message=self.msg_store.no_more_batch_todo(),
         )
 
     def test_list_batch(self):
@@ -219,10 +216,7 @@ class ClusterPickingSelectionCase(ClusterPickingCommonCase):
         self.assert_response(
             response,
             next_state="manual_selection",
-            message={
-                "message_type": "warning",
-                "body": "This batch cannot be selected.",
-            },
+            message=self.msg_store.batch_cannot_be_selected(),
             data={"size": 0, "records": []},
         )
 
@@ -239,10 +233,7 @@ class ClusterPickingSelectionCase(ClusterPickingCommonCase):
         self.assert_response(
             response,
             next_state="manual_selection",
-            message={
-                "message_type": "warning",
-                "body": "This batch cannot be selected.",
-            },
+            message=self.msg_store.batch_cannot_be_selected(),
             data={"size": 0, "records": []},
         )
 

--- a/shopfloor/tests/test_cluster_picking_select.py
+++ b/shopfloor/tests/test_cluster_picking_select.py
@@ -357,10 +357,7 @@ class ClusterPickingSelectedCase(ClusterPickingCommonCase):
         )
         self.assert_response(
             response,
-            message={
-                "message_type": "error",
-                "body": "The record you were working on does not exist anymore.",
-            },
+            message=self.msg_store.record_not_found(),
             next_state="start",
         )
 
@@ -381,7 +378,7 @@ class ClusterPickingSelectedCase(ClusterPickingCommonCase):
         self.assert_response(
             response,
             next_state="start",
-            message={"body": "Batch Transfer complete", "message_type": "success"},
+            message=self.msg_store.batch_transfer_complete(),
         )
 
     # TODO: add a test for lines sorting

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -177,7 +177,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         self.assert_response(
             response,
             next_state="start",
-            message={"message_type": "success", "body": "Batch Transfer complete"},
+            message=self.msg_store.batch_transfer_complete(),
         )
 
     def test_set_destination_all_remaining_lines(self):
@@ -265,7 +265,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         self.assert_response(
             response,
             next_state="start",
-            message={"body": "Batch Transfer complete", "message_type": "success"},
+            message=self.msg_store.batch_transfer_complete(),
         )
 
     def test_set_destination_all_picking_unassigned(self):
@@ -349,10 +349,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
             response,
             next_state="unload_all",
             data=data,
-            message={
-                "message_type": "error",
-                "body": "No location found for this barcode.",
-            },
+            message=self.msg_store.no_location_found(),
         )
 
     def test_set_destination_all_error_location_invalid(self):
@@ -378,7 +375,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
             response,
             next_state="unload_all",
             data=data,
-            message={"message_type": "error", "body": "You cannot place it here"},
+            message=self.msg_store.dest_location_not_allowed(),
         )
 
     def test_set_destination_all_error_location_move_invalid(self):
@@ -457,7 +454,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         self.assert_response(
             response,
             next_state="start",
-            message={"message_type": "success", "body": "Batch Transfer complete"},
+            message=self.msg_store.batch_transfer_complete(),
         )
 
     def test_set_destination_all_check_confirmation(self):
@@ -808,7 +805,7 @@ class ClusterPickingUnloadScanDestinationCase(ClusterPickingUnloadingCommonCase)
         self.assert_response(
             response,
             next_state="start",
-            message={"body": "Batch Transfer complete", "message_type": "success"},
+            message=self.msg_store.batch_transfer_complete(),
         )
 
     def test_unload_scan_destination_error_location_not_found(self):
@@ -827,10 +824,7 @@ class ClusterPickingUnloadScanDestinationCase(ClusterPickingUnloadingCommonCase)
             response,
             next_state="unload_set_destination",
             data=data,
-            message={
-                "message_type": "error",
-                "body": "No location found for this barcode.",
-            },
+            message=self.msg_store.no_location_found(),
         )
 
     def test_unload_scan_destination_error_location_invalid(self):
@@ -853,7 +847,7 @@ class ClusterPickingUnloadScanDestinationCase(ClusterPickingUnloadingCommonCase)
             response,
             next_state="unload_set_destination",
             data=data,
-            message={"message_type": "error", "body": "You cannot place it here"},
+            message=self.msg_store.dest_location_not_allowed(),
         )
 
     def test_unload_scan_destination_error_location_move_invalid(self):

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -563,7 +563,7 @@ class ClusterPickingUnloadScanPackCase(ClusterPickingUnloadingCommonCase):
             response,
             next_state="unload_single",
             data=data,
-            message={"message_type": "error", "body": "Wrong bin"},
+            message=self.msg_store.wrong_bin(),
         )
 
 

--- a/shopfloor/tests/test_delivery_scan_deliver.py
+++ b/shopfloor/tests/test_delivery_scan_deliver.py
@@ -487,10 +487,10 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.move_line_ids.package_id = cleanup_package
         params = {"barcode": "CLEANUP_PACKAGE"}
         response = self.service.dispatch("scan_deliver", params=params)
-        type_name = cleanup_picking.picking_type_id.name
-        pick_name = cleanup_picking.name
-        expected_body = f"Reserved for {type_name} {pick_name}"
-        self.assertEqual(response.get("message").get("body"), expected_body)
+        self.assertEqual(
+            response.get("message"),
+            self.msg_store.reserved_for_other_picking_type(cleanup_picking),
+        )
 
     def test_scan_deliver_return_package(self):
         self.picking.action_cancel()
@@ -506,10 +506,10 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.move_line_ids.package_id = cleanup_package
         params = {"barcode": "CLEANUP_PACKAGE"}
         response = self.service.dispatch("scan_deliver", params=params)
-        type_name = cleanup_picking.picking_type_id.name
-        pick_name = cleanup_picking.name
-        expected_body = f"Reserved for {type_name} {pick_name}"
-        self.assertEqual(response.get("message").get("body"), expected_body)
+        self.assertEqual(
+            response.get("message"),
+            self.msg_store.reserved_for_other_picking_type(cleanup_picking),
+        )
 
     def test_scan_deliver_return_product(self):
         self.picking.action_cancel()
@@ -519,10 +519,10 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.action_assign()
         params = {"barcode": self.product_a.barcode}
         response = self.service.dispatch("scan_deliver", params=params)
-        type_name = cleanup_picking.picking_type_id.name
-        pick_name = cleanup_picking.name
-        expected_body = f"Reserved for {type_name} {pick_name}"
-        self.assertEqual(response.get("message").get("body"), expected_body)
+        self.assertEqual(
+            response.get("message"),
+            self.msg_store.reserved_for_other_picking_type(cleanup_picking),
+        )
 
     def test_scan_deliver_return_packaging(self):
         self.picking.action_cancel()
@@ -544,10 +544,10 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         )
         params = {"barcode": "CLEANUP_PACKAGING"}
         response = self.service.dispatch("scan_deliver", params=params)
-        type_name = cleanup_picking.picking_type_id.name
-        pick_name = cleanup_picking.name
-        expected_body = f"Reserved for {type_name} {pick_name}"
-        self.assertEqual(response.get("message").get("body"), expected_body)
+        self.assertEqual(
+            response.get("message"),
+            self.msg_store.reserved_for_other_picking_type(cleanup_picking),
+        )
 
     def test_scan_deliver_return_lot(self):
         self.picking.action_cancel()
@@ -569,10 +569,10 @@ class DeliveryScanDeliverCase(DeliveryCommonCase):
         cleanup_picking.move_line_ids.reserved_uom_qty = 1.0
         params = {"barcode": "CLEANUP_LOT"}
         response = self.service.dispatch("scan_deliver", params=params)
-        type_name = cleanup_picking.picking_type_id.name
-        pick_name = cleanup_picking.name
-        expected_body = f"Reserved for {type_name} {pick_name}"
-        self.assertEqual(response.get("message").get("body"), expected_body)
+        self.assertEqual(
+            response.get("message"),
+            self.msg_store.reserved_for_other_picking_type(cleanup_picking),
+        )
 
     def test_scan_delivery_return_picking(self):
         self.picking.action_cancel()
@@ -665,10 +665,7 @@ class DeliveryScanDeliverSpecialCase(DeliveryCommonCase):
         )
         self.assert_response_deliver(
             response,
-            message={
-                "message_type": "error",
-                "body": f"Reserved for {picking.picking_type_id.name} {picking.name}",
-            },
+            message=self.msg_store.reserved_for_other_picking_type(picking),
         )
 
     def test_scan_deliver_error_picking_unavailable(self):
@@ -678,10 +675,7 @@ class DeliveryScanDeliverSpecialCase(DeliveryCommonCase):
         )
         self.assert_response_deliver(
             response,
-            message={
-                "message_type": "error",
-                "body": f"Transfer {picking.name} is not available.",
-            },
+            message=self.msg_store.stock_picking_not_available(picking),
         )
 
     def test_scan_deliver_error_picking_already_done(self):
@@ -695,5 +689,5 @@ class DeliveryScanDeliverSpecialCase(DeliveryCommonCase):
         )
         self.assert_response_deliver(
             response,
-            message={"message_type": "info", "body": "Operation already processed."},
+            message=self.msg_store.already_done(),
         )

--- a/shopfloor/tests/test_location_content_transfer_single.py
+++ b/shopfloor/tests/test_location_content_transfer_single.py
@@ -122,7 +122,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._scan_package_error(
             self.picking1.move_line_ids.package_level_id,
             pack.name,
-            {"message_type": "error", "body": "Wrong pack."},
+            self.msg_store.wrong_record(pack),
         )
 
     def test_scan_package_error_wrong_product(self):
@@ -140,7 +140,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._scan_package_error(
             self.picking1.move_line_ids.package_level_id,
             product.barcode,
-            {"message_type": "error", "body": "Wrong product."},
+            self.msg_store.wrong_record(product),
         )
 
     def test_scan_package_error_wrong_lot(self):
@@ -159,7 +159,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._scan_package_error(
             self.picking1.move_line_ids.package_level_id,
             lot.name,
-            {"message_type": "error", "body": "Wrong lot."},
+            self.msg_store.wrong_record(lot),
         )
 
     def test_scan_package_barcode_not_found(self):
@@ -167,7 +167,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._scan_package_error(
             self.picking1.move_line_ids.package_level_id,
             "NO_EXISTING_BARCODE",
-            {"message_type": "error", "body": "Barcode not found"},
+            self.msg_store.barcode_not_found(),
         )
 
     def test_scan_package_product_ok(self):
@@ -363,7 +363,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
             self.pickings,
             move_line.id,
             pack.name,
-            {"message_type": "error", "body": "Wrong pack."},
+            self.msg_store.wrong_record(pack),
         )
 
     def test_scan_line_error_wrong_product(self):
@@ -383,7 +383,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
             self.pickings,
             move_line.id,
             product.barcode,
-            {"message_type": "error", "body": "Wrong product."},
+            self.msg_store.wrong_record(product),
         )
 
     def test_scan_line_error_wrong_lot(self):
@@ -404,7 +404,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
             self.pickings,
             move_line.id,
             lot.name,
-            {"message_type": "error", "body": "Wrong lot."},
+            self.msg_store.wrong_record(lot),
         )
 
     def test_scan_line_barcode_not_found(self):
@@ -572,10 +572,9 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         )
         backorder = self.picking3.backorder_ids
         self.assertTrue(backorder)
-        message = {
-            "body": "Content line transferred from Content Location to Shelf 1",
-            "message_type": "success",
-        }
+        message = self.msg_store.location_content_transfer_item_complete(
+            self.content_loc, self.shelf1
+        )
 
         # Check the backorder is proposed to operator
         self.assert_response_start_single(response, backorder, message=message)

--- a/shopfloor/tests/test_location_content_transfer_single.py
+++ b/shopfloor/tests/test_location_content_transfer_single.py
@@ -215,7 +215,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._test_scan_package_nok(
             self.pickings | picking,
             self.product_a.barcode,
-            {"message_type": "error", "body": "Scan the package"},
+            self.msg_store.scan_the_package(),
         )
 
     def test_scan_package_product_nok_different_line(self):
@@ -228,7 +228,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._test_scan_package_nok(
             self.pickings | picking,
             self.product_a.barcode,
-            {"message_type": "error", "body": "Scan the package"},
+            self.msg_store.scan_the_package(),
         )
 
     def test_scan_package_product_nok_product_tracked(self):
@@ -237,7 +237,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._test_scan_package_nok(
             self.pickings,
             self.product_a.barcode,
-            {"message_type": "error", "body": "Scan the package"},
+            self.msg_store.scan_the_package(),
         )
 
     def test_scan_package_lot_nok_different_package(self):
@@ -258,7 +258,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._test_scan_package_nok(
             self.pickings | picking,
             self.product_a.barcode,
-            {"message_type": "error", "body": "Scan the package"},
+            self.msg_store.scan_the_package(),
         )
 
     def test_scan_package_lot_nok_different_line(self):
@@ -279,7 +279,7 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         self._test_scan_package_nok(
             self.pickings | picking,
             self.product_a.barcode,
-            {"message_type": "error", "body": "Scan the package"},
+            self.msg_store.scan_the_package(),
         )
 
     def test_scan_package_package_level_not_exists(self):

--- a/shopfloor/tests/test_location_content_transfer_start.py
+++ b/shopfloor/tests/test_location_content_transfer_start.py
@@ -197,10 +197,7 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
         )
         self.assert_response_start(
             response,
-            message={
-                "message_type": "error",
-                "body": "You cannot move this using this menu.",
-            },
+            message=self.msg_store.cannot_move_something_in_picking_type(),
         )
 
     def test_scan_location_wrong_picking_type_allow_unreserve_ok(self):

--- a/shopfloor/tests/test_location_content_transfer_start.py
+++ b/shopfloor/tests/test_location_content_transfer_start.py
@@ -166,10 +166,7 @@ class TestLocationContentTransferStart(LocationContentTransferCommonCase):
         )
         self.assert_response_start(
             response,
-            message={
-                "message_type": "error",
-                "body": "This location content can't be moved at once.",
-            },
+            message=self.msg_store.location_cant_be_moved_at_once(),
         )
 
 

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -152,10 +152,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "error",
-                "body": f"No pending operation for package {self.pack_a.name}.",
-            },
+            message=self.msg_store.no_pending_operation_for_pack(self.pack_a),
         )
 
     def test_start_no_operation_create(self):
@@ -233,10 +230,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "success",
-                "body": "The pack has been moved, you can scan a new pack.",
-            },
+            message=self.msg_store.confirm_pack_moved(),
         )
 
         self.assertRecordValues(
@@ -277,10 +271,9 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "error",
-                "body": "The package THIS_BARCODE_DOES_NOT_EXIST" " doesn't exist",
-            },
+            message=self.msg_store.package_not_found_for_barcode(
+                "THIS_BARCODE_DOES_NOT_EXIST"
+            ),
         )
 
     def test_start_pack_empty(self):
@@ -355,10 +348,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "error",
-                "body": f"Location {self.shelf2.name} doesn't contain any package.",
-            },
+            message=self.msg_store.no_pack_in_location(self.shelf2),
         )
 
     def test_start_pack_from_location_several_packs(self):
@@ -392,11 +382,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "warning",
-                "body": f"Several packages found in {self.shelf1.name}, "
-                "please scan a package.",
-            },
+            message=self.msg_store.several_packs_in_location(self.shelf1),
         )
 
     def test_start_pack_outside_of_location(self):
@@ -418,12 +404,9 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "error",
-                "body": f"You cannot work on a package ({self.pack_a.name}) "
-                "outside of locations: "
-                f"{self.picking_type.default_location_src_id.name}",
-            },
+            message=self.msg_store.package_not_allowed_in_src_location(
+                self.pack_a.name, self.picking_type
+            ),
         )
 
     def test_start_already_started(self):
@@ -458,11 +441,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "warning",
-                "body": "Operation's already running."
-                " Would you like to take it over?",
-            },
+            message=self.msg_store.already_running_ask_confirmation(),
             data=dict(
                 self._response_package_level_data(package_level),
                 confirmation_required=barcode,
@@ -496,12 +475,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         )
 
         self.assert_response(
-            response,
-            next_state="start",
-            message={
-                "message_type": "success",
-                "body": "The pack has been moved, you can scan a new pack.",
-            },
+            response, next_state="start", message=self.msg_store.confirm_pack_moved()
         )
 
         self.assertRecordValues(
@@ -578,10 +552,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "success",
-                "body": "The pack has been moved, you can scan a new pack.",
-            },
+            message=self.msg_store.confirm_pack_moved(),
         )
         # process the second package
         package_level_b = self._simulate_started(self.pack_b)
@@ -604,10 +575,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
                 "body": f"Last operation of transfer {self.picking.name}. "
                 f"Next operation ({next_picking.name}) is ready to proceed."
             },
-            message={
-                "message_type": "success",
-                "body": "The pack has been moved, you can scan a new pack.",
-            },
+            message=self.msg_store.confirm_pack_moved(),
         )
 
     def test_validate_not_found(self):
@@ -623,12 +591,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         )
 
         self.assert_response(
-            response,
-            next_state="start",
-            message={
-                "message_type": "error",
-                "body": "This operation does not exist anymore.",
-            },
+            response, next_state="start", message=self.msg_store.operation_not_found()
         )
 
     def test_validate_location_not_found(self):
@@ -658,10 +621,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
             response,
             next_state="scan_location",
             data=self.ANY,
-            message={
-                "message_type": "error",
-                "body": "No location found for this barcode.",
-            },
+            message=self.msg_store.no_location_found(),
         )
 
     def test_validate_location_forbidden(self):
@@ -696,7 +656,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
             response,
             next_state="scan_location",
             data=self.ANY,
-            message={"message_type": "error", "body": "You cannot place it here"},
+            message=self.msg_store.dest_location_not_allowed(),
         )
 
     def test_validate_location_move_not_child_of_picking_allowed(self):
@@ -732,10 +692,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "success",
-                "body": "The pack has been moved, you can scan a new pack.",
-            },
+            message=self.msg_store.confirm_pack_moved(),
         )
 
     def test_validate_location_to_confirm(self):
@@ -842,10 +799,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "success",
-                "body": "The pack has been moved, you can scan a new pack.",
-            },
+            message=self.msg_store.confirm_pack_moved(),
         )
 
         self.assertRecordValues(
@@ -892,10 +846,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "success",
-                "body": "Canceled, you can scan a new pack.",
-            },
+            message=self.msg_store.confirm_canceled_scan_next_pack(),
         )
 
     def test_cancel_transfer_created_by_user(self):
@@ -933,10 +884,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "success",
-                "body": "Canceled, you can scan a new pack.",
-            },
+            message=self.msg_store.confirm_canceled_scan_next_pack(),
         )
 
     def test_cancel_already_canceled(self):
@@ -974,10 +922,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "error",
-                "body": "This operation does not exist anymore.",
-            },
+            message=self.msg_store.operation_not_found(),
         )
         package_level_b = self._simulate_started(self.pack_b)
         # keep references for later checks
@@ -1032,7 +977,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={"message_type": "info", "body": "Operation already processed."},
+            message=self.msg_store.already_done(),
         )
 
     def test_cancel_not_found(self):
@@ -1046,10 +991,7 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         self.assert_response(
             response,
             next_state="start",
-            message={
-                "message_type": "error",
-                "body": "This operation does not exist anymore.",
-            },
+            message=self.msg_store.operation_not_found(),
         )
 
 

--- a/shopfloor/tests/test_zone_picking_set_line_destination.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination.py
@@ -565,10 +565,7 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         )
         self.assertEqual(
             response["message"],
-            {
-                "body": "Package FREE_PACKAGE is already used.",
-                "message_type": "warning",
-            },
+            self.msg_store.package_already_used(self.free_package),
         )
         # Now enable `multiple_move_single_pack` and try again
         self.menu.sudo().write(
@@ -625,11 +622,9 @@ class ZonePickingSetLineDestinationCase(ZonePickingCommonCase):
         )
         self.assertEqual(
             response["message"],
-            {
-                "body": "Package FREE_PACKAGE contains already lines"
-                " from a different operation type test.",
-                "message_type": "warning",
-            },
+            self.msg_store.package_different_picking_type(
+                self.free_package, picking_type
+            ),
         )
 
     def test_set_destination_location_zero_quantity(self):

--- a/shopfloor/tests/test_zone_picking_set_line_destination_no_prefill_qty.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination_no_prefill_qty.py
@@ -63,10 +63,7 @@ class ZonePickingSetLineDestinationNoPrefillQtyCase(ZonePickingCommonCase):
             picking_type,
             move_line,
             qty_done=qty_done,
-            message={
-                "body": f"Package {wrong_package.name} is not empty.",
-                "message_type": "warning",
-            },
+            message=self.msg_store.package_not_empty(wrong_package),
         )
 
     def test_set_destination_increment_with_wrong_product(self):
@@ -90,7 +87,9 @@ class ZonePickingSetLineDestinationNoPrefillQtyCase(ZonePickingCommonCase):
             picking_type,
             move_line,
             qty_done=qty_done,
-            message={"body": "The package A doesn't exist", "message_type": "error"},
+            message=self.msg_store.package_not_found_for_barcode(
+                self.product_a.barcode
+            ),
         )
 
     def test_set_destination_increment_with_lot(self):

--- a/shopfloor_reception/tests/test_reception_done.py
+++ b/shopfloor_reception/tests/test_reception_done.py
@@ -20,7 +20,7 @@ class TestReceptionDone(CommonCase):
             response,
             next_state="confirm_done",
             data={"picking": self._data_for_picking_with_moves(picking)},
-            message={"message_type": "warning", "body": "Are you sure?"},
+            message=self.msg_store.need_confirmation(),
         )
         response = self.service.dispatch(
             "done_action", params={"picking_id": picking.id, "confirmation": True}
@@ -31,10 +31,7 @@ class TestReceptionDone(CommonCase):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={
-                "message_type": "success",
-                "body": f"Transfer {picking.name} done",
-            },
+            message=self.msg_store.transfer_done_success(picking),
         )
 
     def test_set_done_no_qty_processed(self):
@@ -46,10 +43,7 @@ class TestReceptionDone(CommonCase):
             response,
             next_state="select_move",
             data=self._data_for_select_move(picking),
-            message={
-                "message_type": "warning",
-                "body": "No quantity has been processed, unable to complete the transfer.",
-            },
+            message=self.msg_store.transfer_no_qty_done(),
         )
 
     def test_set_done_with_backorder(self):
@@ -68,13 +62,7 @@ class TestReceptionDone(CommonCase):
             response,
             next_state="confirm_done",
             data={"picking": self._data_for_picking_with_moves(picking)},
-            message={
-                "message_type": "warning",
-                "body": (
-                    "Not all lines have been processed with full quantity. "
-                    "Do you confirm partial operation?"
-                ),
-            },
+            message=self.msg_store.transfer_confirm_done(),
         )
         response = self.service.dispatch(
             "done_action", params={"picking_id": picking.id, "confirmation": True}
@@ -86,8 +74,5 @@ class TestReceptionDone(CommonCase):
             response,
             next_state="select_document",
             data={"pickings": self._data_for_pickings(picking_due_today)},
-            message={
-                "message_type": "success",
-                "body": f"Transfer {picking.name} done",
-            },
+            message=self.msg_store.transfer_done_success(picking),
         )

--- a/shopfloor_reception/tests/test_recover.py
+++ b/shopfloor_reception/tests/test_recover.py
@@ -11,10 +11,6 @@ class TestRecover(CommonCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.recover_msg = {
-            "message_type": "info",
-            "body": "Recovered previous session.",
-        }
 
     def test_recover(self):
         # here, product isn't tracked by lot, but the move has a move
@@ -61,7 +57,7 @@ class TestRecover(CommonCase):
                 "selected_move_line": move_line_data,
                 "confirmation_required": None,
             },
-            message=self.recover_msg,
+            message=self.msg_store.recovered_previous_session(),
         )
         # Set qty_done to 5/10 on the move line, we should recover it
         selected_move_line.qty_done = 5
@@ -79,7 +75,7 @@ class TestRecover(CommonCase):
                 "selected_move_line": move_line_data,
                 "confirmation_required": None,
             },
-            message=self.recover_msg,
+            message=self.msg_store.recovered_previous_session(),
         )
         # If the goods were put in a pack, we move to set destination
         response = self.service.dispatch(
@@ -119,7 +115,7 @@ class TestRecover(CommonCase):
                 "selected_move_line": move_line_data,
                 "confirmation": None,
             },
-            message=self.recover_msg,
+            message=self.msg_store.recovered_previous_session(),
         )
 
     def test_recover_tracking_by_lot(self):
@@ -156,7 +152,7 @@ class TestRecover(CommonCase):
                 "picking": picking_data,
                 "selected_move_line": move_line_data,
             },
-            message=self.recover_msg,
+            message=self.msg_store.recovered_previous_session(),
         )
         # Set a lot to the move line, we recover again, but straight to set quantity.
         selected_move_line.lot_id = self._create_lot()
@@ -173,6 +169,6 @@ class TestRecover(CommonCase):
                 "selected_move_line": move_line_data,
                 "confirmation_required": None,
             },
-            message=self.recover_msg,
+            message=self.msg_store.recovered_previous_session(),
         )
         # The rest is all the same as test_recover

--- a/shopfloor_reception/tests/test_return_reception_done.py
+++ b/shopfloor_reception/tests/test_return_reception_done.py
@@ -50,10 +50,7 @@ class TestReturn(CommonCaseReturn):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={
-                "message_type": "success",
-                "body": f"Transfer {self.return_picking.name} done",
-            },
+            message=self.msg_store.transfer_done_success(self.return_picking),
         )
 
     def test_set_done_partial_qty_done(self):
@@ -70,10 +67,7 @@ class TestReturn(CommonCaseReturn):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={
-                "message_type": "success",
-                "body": f"Transfer {self.return_picking.name} done",
-            },
+            message=self.msg_store.transfer_done_success(self.return_picking),
         )
         # Now, since we still have returned 10 units out of ten, try to return
         # the next ones
@@ -100,10 +94,7 @@ class TestReturn(CommonCaseReturn):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={
-                "message_type": "success",
-                "body": f"Transfer {return_picking_2.name} done",
-            },
+            message=self.msg_store.transfer_done_success(return_picking_2),
         )
 
     def test_already_returned(self):
@@ -120,10 +111,7 @@ class TestReturn(CommonCaseReturn):
             "scan_line",
             params={"picking_id": second_return_picking.id, "barcode": product.barcode},
         )
-        expected_message = {
-            "message_type": "error",
-            "body": "The product/packaging you selected has already been returned.",
-        }
+        expected_message = self.msg_store.move_already_returned()
         self.assert_response(
             response,
             next_state="select_move",

--- a/shopfloor_reception/tests/test_return_scan_document.py
+++ b/shopfloor_reception/tests/test_return_scan_document.py
@@ -16,7 +16,7 @@ class TestScanDocumentReturn(CommonCaseReturn):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={"message_type": "error", "body": "Barcode not found"},
+            message=self.msg_store.barcode_not_found(),
         )
 
     def test_scan_document_no_default_location(self):
@@ -33,13 +33,7 @@ class TestScanDocumentReturn(CommonCaseReturn):
         )
         return_picking = self.get_new_pickings()
         self.assertFalse(return_picking)
-        message = {
-            "message_type": "error",
-            "body": (
-                "Operation types for this menu are missing "
-                "default source and destination locations."
-            ),
-        }
+        message = self.msg_store.no_default_location_on_picking_type()
         self.assert_response(
             response,
             next_state="select_document",
@@ -60,10 +54,7 @@ class TestScanDocumentReturn(CommonCaseReturn):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={
-                "message_type": "error",
-                "body": "Barcode not found",
-            },
+            message=self.msg_store.barcode_not_found(),
         )
 
     def test_scan_delivered_order(self):
@@ -80,7 +71,7 @@ class TestScanDocumentReturn(CommonCaseReturn):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={"message_type": "error", "body": "Barcode not found"},
+            message=self.msg_store.barcode_not_found(),
         )
         # Now, enable `allow_return`
         self._enable_allow_return()

--- a/shopfloor_reception/tests/test_return_scan_line.py
+++ b/shopfloor_reception/tests/test_return_scan_line.py
@@ -20,10 +20,7 @@ class TestScanLineReturn(CommonCaseReturn):
             response,
             next_state="select_move",
             data={"picking": self._data_for_picking_with_moves(return_picking)},
-            message={
-                "message_type": "error",
-                "body": f"Product {wrong_product.name} is not in the current transfer.",
-            },
+            message=self.msg_store.product_not_found_in_current_picking(wrong_product),
         )
 
     def test_scan_product_in_delivery(self):
@@ -69,10 +66,7 @@ class TestScanLineReturn(CommonCaseReturn):
             response,
             next_state="select_move",
             data={"picking": self._data_for_picking_with_moves(return_picking)},
-            message={
-                "message_type": "warning",
-                "body": "Packaging not found in the current transfer.",
-            },
+            message=self.msg_store.packaging_not_found_in_picking(),
         )
 
     def test_scan_packaging_in_delivery(self):

--- a/shopfloor_reception/tests/test_return_set_quantity.py
+++ b/shopfloor_reception/tests/test_return_set_quantity.py
@@ -53,10 +53,7 @@ class TestSetQuantityReturn(CommonCaseReturn):
         response = self._dispatch(quantity=21.0)
         # Qty done has been kept as it was
         self.assertEqual(self.selected_move_line.qty_done, 20.0)
-        message = {
-            "message_type": "error",
-            "body": "You cannot return more quantity than what was initially sent.",
-        }
+        message = self.msg_store.return_line_invalid_qty()
         self.assert_response(
             response,
             next_state="set_quantity",
@@ -81,10 +78,7 @@ class TestSetQuantityReturn(CommonCaseReturn):
         response = self._dispatch(barcode=self.product.barcode)
         # We are not allowed to set qty_done 21.0, since the origin move's qty was 10.0
         self.assertEqual(self.selected_move_line.qty_done, 20.0)
-        message = {
-            "message_type": "error",
-            "body": "You cannot return more quantity than what was initially sent.",
-        }
+        message = self.msg_store.return_line_invalid_qty()
         self.assert_response(
             response,
             next_state="set_quantity",
@@ -103,10 +97,7 @@ class TestSetQuantityReturn(CommonCaseReturn):
         # Therefore, qty isn't increased, and an error is returned
         response = self._dispatch(barcode=packaging.barcode)
         self.assertEqual(self.selected_move_line.qty_done, 11.0)
-        message = {
-            "message_type": "error",
-            "body": "You cannot return more quantity than what was initially sent.",
-        }
+        message = self.msg_store.return_line_invalid_qty()
         self.assert_response(
             response,
             next_state="set_quantity",

--- a/shopfloor_reception/tests/test_select_dest_package.py
+++ b/shopfloor_reception/tests/test_select_dest_package.py
@@ -39,10 +39,7 @@ class TestSelectDestPackage(CommonCase):
                 "selected_move_line": self.data.move_lines(selected_move_line),
                 "new_package_name": "FooBar",
             },
-            message={
-                "message_type": "warning",
-                "body": ("Create new PACK FooBar? " "Scan it again to confirm."),
-            },
+            message=self.msg_store.create_new_pack_ask_confirmation("FooBar"),
         )
         # Try again with confirmation = True
         response = self.service.dispatch(
@@ -98,10 +95,7 @@ class TestSelectDestPackage(CommonCase):
                 "packages": package_data,
                 "selected_move_line": self.data.move_lines(selected_move_line),
             },
-            message={
-                "message_type": "warning",
-                "body": "Package FOO is not empty.",
-            },
+            message=self.msg_store.package_not_empty(self.package),
         )
 
     def test_scan_existing_package(self):

--- a/shopfloor_reception/tests/test_select_document.py
+++ b/shopfloor_reception/tests/test_select_document.py
@@ -26,7 +26,7 @@ class TestSelectDocument(CommonCase):
             response,
             next_state="select_document",
             data={"pickings": []},
-            message={"message_type": "error", "body": "Barcode not found"},
+            message=self.msg_store.barcode_not_found(),
         )
 
     def test_scan_picking_name(self):
@@ -51,17 +51,11 @@ class TestSelectDocument(CommonCase):
         response = self.service.dispatch(
             "scan_document", params={"barcode": "Somewhere together"}
         )
-        message = (
-            "This source document is part of multiple transfers, please scan a package."
-        )
         self.assert_response(
             response,
             next_state="select_document",
             data={"pickings": self._data_for_pickings(pickings)},
-            message={
-                "message_type": "warning",
-                "body": message,
-            },
+            message=self.msg_store.source_document_multiple_pickings_scan_package(),
         )
 
     @freeze_time(_TODAY)
@@ -133,12 +127,11 @@ class TestSelectDocument(CommonCase):
         response = self.service.dispatch(
             "scan_document", params={"barcode": self.product_a_packaging.barcode}
         )
-        body = "Several transfers found, please select a transfer manually."
         self.assert_response(
             response,
             next_state="select_document",
             data={"pickings": self._data_for_pickings(p1 | p2)},
-            message={"message_type": "error", "body": body},
+            message=self.msg_store.multiple_picks_found_select_manually(),
         )
 
     def test_scan_product_multiple_pickings(self):
@@ -148,12 +141,11 @@ class TestSelectDocument(CommonCase):
         response = self.service.dispatch(
             "scan_document", params={"barcode": self.product_a.barcode}
         )
-        body = "Several transfers found, please select a transfer manually."
         self.assert_response(
             response,
             next_state="select_document",
             data={"pickings": self._data_for_pickings(p1 | p2)},
-            message={"message_type": "error", "body": body},
+            message=self.msg_store.multiple_picks_found_select_manually(),
         )
 
     def test_scan_product_one_picking(self):

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -23,7 +23,7 @@ class TestSelectLine(CommonCase):
             response,
             next_state="select_move",
             data=self._data_for_select_move(picking),
-            message={"message_type": "error", "body": "Barcode not found"},
+            message=self.msg_store.barcode_not_found(),
         )
 
     def test_scan_product(self):
@@ -271,12 +271,11 @@ class TestSelectLine(CommonCase):
             "scan_line",
             params={"picking_id": picking.id, "barcode": self.product_c.barcode},
         )
-        error_msg = "Product not found in the current transfer or already in a package."
         self.assert_response(
             response,
             next_state="select_move",
             data=self._data_for_select_move(picking),
-            message={"message_type": "warning", "body": error_msg},
+            message=self.msg_store.x_not_found_or_already_in_dest_package("Product"),
         )
 
     def test_scan_packaging_not_found(self):
@@ -289,14 +288,11 @@ class TestSelectLine(CommonCase):
                 "barcode": self.product_c_packaging.barcode,
             },
         )
-        error_msg = (
-            "Packaging not found in the current transfer or already in a package."
-        )
         self.assert_response(
             response,
             next_state="select_move",
             data=self._data_for_select_move(picking),
-            message={"message_type": "warning", "body": error_msg},
+            message=self.msg_store.x_not_found_or_already_in_dest_package("Packaging"),
         )
 
     def test_assign_shopfloor_user_to_line(self):
@@ -390,7 +386,7 @@ class TestSelectLine(CommonCase):
             response,
             next_state="confirm_done",
             data=data,
-            message={"message_type": "warning", "body": "Are you sure?"},
+            message=self.msg_store.need_confirmation(),
         )
         # Confirm the package is done.
         response = self.service.dispatch(
@@ -409,12 +405,11 @@ class TestSelectLine(CommonCase):
             ],
             order="scheduled_date ASC, id ASC",
         )
-        message = "Transfer {} done".format(picking.name)
         self.assert_response(
             response,
             next_state="select_document",
             data={"pickings": self._data_for_pickings(pickings)},
-            message={"message_type": "success", "body": message},
+            message=self.msg_store.transfer_done_success(picking),
         )
 
     def test_manual_select_move(self):

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -127,7 +127,7 @@ class TestSetDestination(CommonCase):
                 "selected_move_line": self.data.move_lines(selected_move_line),
                 "confirmation": None,
             },
-            message={"message_type": "error", "body": "You cannot place it here"},
+            message=self.msg_store.dest_location_not_allowed(),
         )
 
     def test_auto_posting_partial(self):

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -101,10 +101,7 @@ class TestSetQuantity(CommonCase):
         )
         self.assertEqual(selected_move_line.qty_done, 10.0)
         data = self.data.picking(picking)
-        message = {
-            "message_type": "warning",
-            "body": "Create new PACK 4? Scan it again to confirm.",
-        }
+        message = self.msg_store.create_new_pack_ask_confirmation("4")
         self.assert_response(
             response,
             next_state="set_quantity",
@@ -279,7 +276,7 @@ class TestSetQuantity(CommonCase):
                 "selected_move_line": self.data.move_lines(selected_move_line),
                 "confirmation_required": None,
             },
-            message={"message_type": "error", "body": "You cannot place it here"},
+            message=self.msg_store.dest_location_not_allowed(),
         )
 
     def test_scan_package_without_location(self):
@@ -353,7 +350,7 @@ class TestSetQuantity(CommonCase):
                 "selected_move_line": self.data.move_lines(selected_move_line),
                 "confirmation_required": None,
             },
-            message={"message_type": "error", "body": "You cannot place it here"},
+            message=self.msg_store.dest_location_not_allowed(),
         )
 
     def test_scan_location_view_usage(self):
@@ -381,7 +378,7 @@ class TestSetQuantity(CommonCase):
                 "selected_move_line": self.data.move_lines(selected_move_line),
                 "confirmation_required": None,
             },
-            message={"message_type": "error", "body": "You cannot place it here"},
+            message=self.msg_store.dest_location_not_allowed(),
         )
 
     def test_scan_new_package(self):
@@ -408,10 +405,7 @@ class TestSetQuantity(CommonCase):
                 "selected_move_line": self.data.move_lines(selected_move_line),
                 "confirmation_required": "FooBar",
             },
-            message={
-                "message_type": "warning",
-                "body": "Create new PACK FooBar? Scan it again to confirm.",
-            },
+            message=self.msg_store.create_new_pack_ask_confirmation("FooBar"),
         )
         response = self.service.dispatch(
             "set_quantity",

--- a/shopfloor_single_product_transfer/tests/test_scan_location_or_package.py
+++ b/shopfloor_single_product_transfer/tests/test_scan_location_or_package.py
@@ -9,15 +9,11 @@ class TestScanLocation(CommonCase):
         response = self.service.dispatch(
             "scan_location_or_package", params={"barcode": "NOPE"}
         )
-        expected_message = {
-            "message_type": "error",
-            "body": "Barcode not found",
-        }
         self.assert_response(
             response,
             next_state="select_location_or_package",
             data={},
-            message=expected_message,
+            message=self.msg_store.barcode_not_found(),
         )
 
     def test_scan_wrong_location(self):
@@ -25,18 +21,11 @@ class TestScanLocation(CommonCase):
         response = self.service.dispatch(
             "scan_location_or_package", params={"barcode": location.name}
         )
-        expected_message = {
-            "message_type": "error",
-            "body": (
-                f"The content of {location.name} cannot be "
-                "transferred with this scenario."
-            ),
-        }
         self.assert_response(
             response,
             next_state="select_location_or_package",
             data={},
-            message=expected_message,
+            message=self.msg_store.location_content_unable_to_transfer(location),
         )
 
     def test_scan_empty_location(self):
@@ -44,15 +33,11 @@ class TestScanLocation(CommonCase):
         response = self.service.dispatch(
             "scan_location_or_package", params={"barcode": location.name}
         )
-        expected_message = {
-            "message_type": "error",
-            "body": f"Location {location.name} empty",
-        }
         self.assert_response(
             response,
             next_state="select_location_or_package",
             data={},
-            message=expected_message,
+            message=self.msg_store.location_empty(location),
         )
 
     def test_scan_location_ok(self):
@@ -77,15 +62,11 @@ class TestScanLocation(CommonCase):
         response = self.service.dispatch(
             "scan_location_or_package", params={"barcode": location.name}
         )
-        expected_message = {
-            "message_type": "warning",
-            "body": "This location only contains packages, please scan one of them.",
-        }
         self.assert_response(
             response,
             next_state="select_location_or_package",
             data={},
-            message=expected_message,
+            message=self.msg_store.location_contains_only_packages_scan_one(),
         )
 
     def test_scan_location_only_lines_with_package(self):
@@ -100,15 +81,11 @@ class TestScanLocation(CommonCase):
         response = self.service.dispatch(
             "scan_location_or_package", params={"barcode": location.name}
         )
-        expected_message = {
-            "message_type": "warning",
-            "body": "This location only contains packages, please scan one of them.",
-        }
         self.assert_response(
             response,
             next_state="select_location_or_package",
             data={},
-            message=expected_message,
+            message=self.msg_store.location_contains_only_packages_scan_one(),
         )
 
         # Scan a package.

--- a/shopfloor_single_product_transfer/tests/test_scan_product.py
+++ b/shopfloor_single_product_transfer/tests/test_scan_product.py
@@ -32,10 +32,12 @@ class TestScanProduct(CommonCase):
         response = self.service.dispatch(
             "scan_product", params={"location_id": location.id, "barcode": "NOPE"}
         )
-        expected_message = {"message_type": "error", "body": "Barcode not found"}
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.barcode_not_found(),
+            data=data,
         )
 
     def test_scan_tracked_product(self):
@@ -49,13 +51,12 @@ class TestScanProduct(CommonCase):
                 params={"location_id": location.id, "barcode": product.barcode},
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
-        expected_message = {
-            "message_type": "warning",
-            "body": "Product tracked by lot, please scan one.",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.scan_lot_on_product_tracked_by_lot(),
+            data=data,
         )
 
     def test_scan_product_multiple_lines_in_picking_no_prefill_qty_enabled(self):
@@ -92,13 +93,12 @@ class TestScanProduct(CommonCase):
                 params={"location_id": location.id, "barcode": product.barcode},
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
-        expected_message = {
-            "message_type": "error",
-            "body": "No operation found for this menu and profile.",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.no_operation_found(),
+            data=data,
         )
 
     def test_scan_product_with_move_line(self):
@@ -136,13 +136,12 @@ class TestScanProduct(CommonCase):
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
         self.assertFalse(self.get_new_move_line())
-        expected_message = {
-            "message_type": "error",
-            "body": "No operation found for this menu and profile.",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.no_operation_found(),
+            data=data,
         )
 
     def test_scan_product_with_stock_create_move_enabled(self):
@@ -180,13 +179,12 @@ class TestScanProduct(CommonCase):
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
         self.assertFalse(self.get_new_move_line())
-        expected_message = {
-            "message_type": "error",
-            "body": "No operation found for this menu and profile.",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.no_operation_found(),
+            data=data,
         )
 
     def test_scan_product_with_reserved_stock_unreserve_move_disabled(self):
@@ -208,13 +206,12 @@ class TestScanProduct(CommonCase):
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
         self.assertFalse(self.get_new_move_line())
-        expected_message = {
-            "message_type": "error",
-            "body": f"Reserved for {self.other_picking_type.name} {other_picking.name}",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.reserved_for_other_picking_type(other_picking),
+            data=data,
         )
 
     def test_scan_product_with_reserved_stock_unreserve_move_enabled(self):
@@ -256,13 +253,12 @@ class TestScanProduct(CommonCase):
                 "scan_product", params={"location_id": location.id, "barcode": lot.name}
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
-        expected_message = {
-            "message_type": "error",
-            "body": "Barcode not found",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.barcode_not_found(),
+            data=data,
         )
 
     def test_scan_lot_with_move_line(self):
@@ -306,13 +302,12 @@ class TestScanProduct(CommonCase):
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
         self.assertFalse(self.get_new_move_line())
-        expected_message = {
-            "message_type": "error",
-            "body": "No operation found for this menu and profile.",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.no_operation_found(),
+            data=data,
         )
 
     def test_scan_lot_with_stock_create_move_enabled(self):
@@ -354,13 +349,12 @@ class TestScanProduct(CommonCase):
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
         self.assertFalse(self.get_new_move_line())
-        expected_message = {
-            "message_type": "error",
-            "body": f"Reserved for {self.other_picking_type.name} {other_picking.name}",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response,
+            next_state="select_product",
+            message=self.msg_store.reserved_for_other_picking_type(other_picking),
+            data=data,
         )
 
     def test_scan_lot_with_reserved_stock_unreserve_move_enabled(self):
@@ -406,13 +400,12 @@ class TestScanProduct(CommonCase):
             )
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
         self.assertFalse(self.get_new_move_line())
-        expected_message = {
-            "message_type": "error",
-            "body": "No putaway destination is available.",
-        }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", data=data, message=expected_message
+            response,
+            next_state="select_product",
+            data=data,
+            message=self.msg_store.no_putaway_destination_available(),
         )
 
     def test_scan_product_no_putaway_ignore_no_putaway_disabled(self):

--- a/shopfloor_single_product_transfer/tests/test_set_quantity.py
+++ b/shopfloor_single_product_transfer/tests/test_set_quantity.py
@@ -54,13 +54,15 @@ class TestSetQuantity(CommonCase):
                 "barcode": "NOPE",
             },
         )
-        expected_message = {"message_type": "error", "body": "Barcode not found"}
         data = {
             "move_line": self._data_for_move_line(move_line),
             "asking_confirmation": None,
         }
         self.assert_response(
-            response, next_state="set_quantity", message=expected_message, data=data
+            response,
+            next_state="set_quantity",
+            message=self.msg_store.barcode_not_found(),
+            data=data,
         )
 
     def test_set_quantity_line_done(self):
@@ -140,12 +142,11 @@ class TestSetQuantity(CommonCase):
             "move_line": self._data_for_move_line(move_line),
             "asking_confirmation": None,
         }
-        expected_message = {
-            "message_type": "error",
-            "body": f"You must not pick more than {move_line.reserved_uom_qty} units.",
-        }
         self.assert_response(
-            response, next_state="set_quantity", message=expected_message, data=data
+            response,
+            next_state="set_quantity",
+            message=self.msg_store.unable_to_pick_more(move_line.reserved_uom_qty),
+            data=data,
         )
 
     def test_set_quantity_scan_product_prefill_qty_enabled(self):
@@ -202,12 +203,11 @@ class TestSetQuantity(CommonCase):
             "move_line": self._data_for_move_line(move_line),
             "asking_confirmation": None,
         }
-        expected_message = {
-            "message_type": "error",
-            "body": f"You must not pick more than {move_line.reserved_uom_qty} units.",
-        }
         self.assert_response(
-            response, next_state="set_quantity", message=expected_message, data=data
+            response,
+            next_state="set_quantity",
+            message=self.msg_store.unable_to_pick_more(move_line.reserved_uom_qty),
+            data=data,
         )
 
     def test_set_picker_quantity(self):
@@ -504,13 +504,15 @@ class TestSetQuantity(CommonCase):
                 "barcode": wrong_location.barcode,
             },
         )
-        expected_message = {"message_type": "error", "body": "You cannot place it here"}
         data = {
             "move_line": self._data_for_move_line(move_line),
             "asking_confirmation": None,
         }
         self.assert_response(
-            response, next_state="set_quantity", message=expected_message, data=data
+            response,
+            next_state="set_quantity",
+            message=self.msg_store.dest_location_not_allowed(),
+            data=data,
         )
 
     def test_set_quantity_menu_default_location(self):
@@ -531,19 +533,17 @@ class TestSetQuantity(CommonCase):
             "barcode": self.dispatch_location.barcode,
         }
         response = self.service.dispatch("set_quantity", params=params)
-        expected_message = {
-            "message_type": "warning",
-            "body": (
-                f"Confirm location change from {move_line.location_dest_id.name} "
-                f"to {self.dispatch_location.name}?"
-            ),
-        }
         data = {
             "move_line": self._data_for_move_line(move_line),
             "asking_confirmation": self.dispatch_location.barcode,
         }
         self.assert_response(
-            response, next_state="set_quantity", message=expected_message, data=data
+            response,
+            next_state="set_quantity",
+            message=self.msg_store.confirm_location_changed(
+                move_line.location_dest_id, self.dispatch_location
+            ),
+            data=data,
         )
         # Now, calling the same endpoint with the confirmation set is ok
         params["confirmation"] = self.dispatch_location.barcode

--- a/shopfloor_single_product_transfer/tests/test_start.py
+++ b/shopfloor_single_product_transfer/tests/test_start.py
@@ -23,10 +23,9 @@ class TestStart(CommonCase):
             "move_line": self._data_for_move_line(move_line),
             "asking_confirmation": None,
         }
-        message = {
-            "message_type": "info",
-            "body": "Recovered previous session.",
-        }
         self.assert_response(
-            response, next_state="set_quantity", data=data, message=message
+            response,
+            next_state="set_quantity",
+            data=data,
+            message=self.msg_store.recovered_previous_session(),
         )

--- a/shopfloor_workstation/__init__.py
+++ b/shopfloor_workstation/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import services
+from . import actions

--- a/shopfloor_workstation/actions/__init__.py
+++ b/shopfloor_workstation/actions/__init__.py
@@ -1,0 +1,1 @@
+from . import message

--- a/shopfloor_workstation/actions/message.py
+++ b/shopfloor_workstation/actions/message.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Acsone SA/NV
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
+from odoo import _
+
+from odoo.addons.component.core import Component
+
+_logger = logging.getLogger(__name__)
+
+
+class MessageAction(Component):
+    _inherit = "shopfloor.message.action"
+
+    def default_workstation_set_to(self, workstation):
+        return {
+            "message_type": "info",
+            "body": _("Default workstation set to %s", workstation.name),
+        }
+
+    def workstation_not_found(self):
+        return {
+            "message_type": "error",
+            "body": _("Workstation not found"),
+        }

--- a/shopfloor_workstation/services/workstation.py
+++ b/shopfloor_workstation/services/workstation.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import _
 
 from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
@@ -26,15 +25,9 @@ class ShopfloorWorkstation(Component):
         ws = self.env["shopfloor.workstation"].search([("barcode", "=", barcode)])
         if ws:
             ws.set_as_default_on_user(self.env.user)
-            message = {
-                "message_type": "info",
-                "body": _("Default workstation set to {}").format(ws.name),
-            }
+            message = self.msg_store.default_workstation_set_to(ws)
         else:
-            message = {
-                "message_type": "error",
-                "body": _("Workstation not found"),
-            }
+            message = self.msg_store.workstation_not_found()
         return self._response(
             message=message,
             data=self._convert_one_record(ws) if ws else {},

--- a/shopfloor_workstation/tests/test_shopfloor_workstation.py
+++ b/shopfloor_workstation/tests/test_shopfloor_workstation.py
@@ -40,7 +40,7 @@ class ShopfloorWorkstationCase(CommonCase):
         res = self.service.dispatch("setdefault", params={"barcode": "bc-???"})
         self.assert_response(
             res,
-            message={"body": "Workstation not found", "message_type": "error"},
+            message=self.msg_store.workstation_not_found(),
             data={},
         )
 
@@ -49,10 +49,7 @@ class ShopfloorWorkstationCase(CommonCase):
         res = self.service.dispatch("setdefault", params={"barcode": "ws-1"})
         self.assert_response(
             res,
-            message={
-                "body": "Default workstation set to Pollux",
-                "message_type": "info",
-            },
+            message=self.msg_store.default_workstation_set_to(self.ws1),
             data={
                 "id": self.ws1.id,
                 "name": "Pollux",


### PR DESCRIPTION
There has been this bad practice for a while in Shopfloor unit tests to copy paste the expected messages instead of using the `msg_store` to call the message functions.

This leads to a codebase that is less maintainable since changes in the wording now needs to be performed in multiple places (does not respect DRY principle).