### PR TITLE
[16.0][IMP] shopfloor: replace raw HTML links with _get_html_link()

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -107,11 +107,10 @@ class StockMove(models.Model):
         }
         data.update(dict(default or []))
         new_picking = picking.copy(data)
-        link = '<a href="#" data-oe-model="stock.picking" data-oe-id="%d">%s</a>' % (
-            new_picking.id,
-            new_picking.name,
+        message = _(
+            "The split order %s has been created.",
+            picking._get_html_link(title=picking.name),
         )
-        message = (_("The split order {} has been created.")).format(link)
         picking.message_post(body=message)
         self.picking_id = new_picking.id
         self.move_line_ids.picking_id = new_picking.id

--- a/shopfloor/models/stock_picking.py
+++ b/shopfloor/models/stock_picking.py
@@ -106,10 +106,9 @@ class StockPicking(models.Model):
             }
         )
         message = _(
-            'The backorder <a href="#" '
-            'data-oe-model="stock.picking" '
-            'data-oe-id="%(new_picking_id)d">%(new_picking_name)s</a> has been created.'
-        ) % dict(new_picking_id=new_picking.id, new_picking_name=new_picking.name)
+            "The backorder %s has been created",
+            new_picking._get_html_link(title=new_picking.name),
+        )
         self.message_post(body=message)
         assigned_moves.write({"picking_id": new_picking.id})
         assigned_moves.mapped("move_line_ids").write({"picking_id": new_picking.id})


### PR DESCRIPTION
Use Odoo standard `_get_html_link()` helper method on recordsets when posting
chatter messages in `stock.move` and `stock.picking`. This removes hardcoded
HTML string formatting and ensures consistent link generation.

@jbaudoux 