### PR TITLE
[16.0][FIX] shopfloor: cluster picking - invalid translate function

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1230,7 +1230,7 @@ class ClusterPicking(Component):
 
         if batch.state != "done":
             # As processed pickings are already done, the batch should now be done
-            raise UserError(self.env._("Internal Error: Batch not properly done."))
+            raise UserError(_("Internal Error: Batch not properly done."))
 
         return self._response_for_start(
             message=self.msg_store.batch_transfer_complete(),


### PR DESCRIPTION
`self.env._` is the way to do it in v18, not in v16.

Error coming from this backport: https://github.com/OCA/wms/pull/1218

cc @jbaudoux 