### PR TITLE
[FIX] shopfloor: location content transfer: add & migrate test for destination as package

### DIFF
--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -59,6 +59,7 @@ from . import test_location_content_transfer_get_work
 from . import test_location_content_transfer_set_destination_all
 from . import test_location_content_transfer_scan_location
 from . import test_location_content_transfer_single
+from . import test_location_content_transfer_set_destination_as_package
 from . import test_location_content_transfer_set_destination_package_or_line
 from . import test_location_content_transfer_putaway
 from . import test_location_content_transfer_mix

--- a/shopfloor/tests/test_location_content_transfer_set_destination_as_package.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_as_package.py
@@ -29,9 +29,9 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
         )
         cls.pickings = picking1 | picking2
         cls._fill_stock_for_moves(
-            picking1.move_lines, in_package=True, location=cls.content_loc
+            picking1.move_ids, in_package=True, location=cls.content_loc
         )
-        cls._fill_stock_for_moves(picking2.move_lines, location=cls.content_loc)
+        cls._fill_stock_for_moves(picking2.move_ids, location=cls.content_loc)
         cls.pickings.action_assign()
         cls._simulate_pickings_selected(cls.pickings)
         cls.sub_shelf1 = (
@@ -101,7 +101,7 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
             params={
                 "location_id": self.content_loc.id,
                 "move_line_id": move_line.id,
-                "quantity": move_line.product_uom_qty,
+                "quantity": move_line.reserved_uom_qty,
                 "barcode": self.location_package.name,
             },
         )
@@ -119,7 +119,7 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.sub_shelf1
+                self.content_loc, self.sub_shelf1
             ),
         )
         self.assertRecordValues(
@@ -154,7 +154,7 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.sub_shelf1
+                self.content_loc, self.sub_shelf1
             ),
         )
         for move in package_level.move_line_ids.mapped("move_id"):
@@ -205,7 +205,7 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
             params={
                 "location_id": self.content_loc.id,
                 "move_line_id": move_line.id,
-                "quantity": move_line.product_uom_qty,
+                "quantity": move_line.reserved_uom_qty,
                 "barcode": self.empty_package.name,
             },
         )
@@ -223,7 +223,7 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
             params={
                 "location_id": self.content_loc.id,
                 "move_line_id": move_line.id,
-                "quantity": move_line.product_uom_qty,
+                "quantity": move_line.reserved_uom_qty,
                 "barcode": self.sub_shelf1.barcode,
                 "package_id": self.empty_package.id,
             },
@@ -242,7 +242,7 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.sub_shelf1
+                self.content_loc, self.sub_shelf1
             ),
         )
         # Check the correct package has been assigned
@@ -291,7 +291,7 @@ class LocationContentTransferSetDestinationAsPackage(LocationContentTransferComm
             response,
             move_lines.mapped("picking_id"),
             message=self.service.msg_store.location_content_transfer_item_complete(
-                self.sub_shelf1
+                self.content_loc, self.sub_shelf1
             ),
         )
         for move in package_level.move_line_ids.mapped("move_id"):


### PR DESCRIPTION
Add missing new test file in __init__.py and migrate to 16.0

@sebalix The test file was not declared