### PR TITLE
[16.0][FIX] shopfloor: cluster picking: unload partialy processed

### DIFF
--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -17,9 +17,11 @@ class StockMoveLine(models.Model):
     _inherit = ["stock.move.line", "shopfloor.priority.postpone.mixin"]
 
     # TODO use a serialized field
-    shopfloor_unloaded = fields.Boolean(default=False)
-    shopfloor_checkout_done = fields.Boolean(default=False)
-    shopfloor_user_id = fields.Many2one(comodel_name="res.users", index=True)
+    shopfloor_unloaded = fields.Boolean(default=False, copy=False)
+    shopfloor_checkout_done = fields.Boolean(default=False, copy=False)
+    shopfloor_user_id = fields.Many2one(
+        comodel_name="res.users", index=True, copy=False
+    )
 
     date_planned = fields.Datetime(related="move_id.date", store=True, index=True)
 

--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -34,6 +34,10 @@ class StockMoveLine(models.Model):
     picking_id = fields.Many2one(auto_join=True)
 
     @property
+    def qty_picked(self):
+        return self.qty_done
+
+    @property
     def picked(self):
         """:return: True if there is a quantity picked."""
         self.ensure_one()
@@ -44,19 +48,6 @@ class StockMoveLine(models.Model):
                 precision_rounding=self.product_uom_id.rounding,
             )
             > 0
-        )
-
-    @property
-    def is_fully_picked(self):
-        """:return: True if the quantity picked >= quantity reserved."""
-        self.ensure_one()
-        return (
-            float_compare(
-                self.qty_done,
-                self.reserved_uom_qty,
-                precision_rounding=self.product_uom_id.rounding,
-            )
-            >= 0
         )
 
     @property
@@ -215,14 +206,17 @@ class StockMoveLine(models.Model):
             return (new_line, "lesser")
         return (new_line, "full")
 
-    def _split_partial_quantity_to_be_done(self, quantity_done, split_default_vals):
+    def _split_partial_quantity_to_be_done(
+        self, quantity_done, split_default_vals=None
+    ):
         """Create a new move line with the remaining quantity to process."""
         # split the move line which will be processed later (maybe the user
         # has to pick some goods from another place because the location
         # contained less items than expected)
         remaining = self.reserved_uom_qty - quantity_done
         vals = {"reserved_uom_qty": remaining, "qty_done": 0}
-        vals.update(split_default_vals)
+        if split_default_vals:
+            vals.update(split_default_vals)
         new_line = self.copy(vals)
         # if we didn't bypass reservation update, the quant reservation
         # would be reduced as much as the deduced quantity, which is wrong

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1172,21 +1172,16 @@ class ClusterPicking(Component):
         if picking.state == "done":
             return
         for ml in picking.move_line_ids:
+            if ml.picked and not ml.shopfloor_unloaded:
+                # A picked move line is not unloaded, exit
+                return
+        for ml in picking.move_line_ids:
             if not ml.picked or not ml.has_quantity_reserved:
                 continue
-            # Ensure the quantity picked >= quantity reserved.
-            # At this stage, the move line should have already been split
-            # when setting the destination package.
-            if not ml.is_fully_picked:
-                raise UserError(
-                    _(
-                        "Internal Error: The move line %s is not fully picked",
-                        ml.display_name,
-                    )
-                )
-            if not ml.shopfloor_unloaded:
-                # A move line is not unloaded, exit
-                return
+            # Normally at this stage everything should have been fully picked
+            # but it can happen the reservation of a partially available move
+            # increases. In this case, we split the partially picked move line.
+            ml._split_partial_quantity_to_be_done(ml.qty_picked)
         stock = self._actions_for("stock")
         for move in picking.move_ids:
             move.split_other_move_lines(

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -320,6 +320,91 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
             message=self.service.msg_store.batch_transfer_complete(),
         )
 
+    def test_set_destination_all_picking_partial(self):
+        """Set destination on lines partially processed for one transfer.
+
+        Process a partially available move line.
+        Increase the stock after picking causing a line partially processed.
+        Check a backorder is created.
+        """
+        self.one_line_picking.do_unreserve()
+        location = self.one_line_picking.location_id
+        move = self.one_line_picking.move_ids
+        product = move.product_id
+        qty = move.product_uom_qty
+        # note: there are 2 move lines => qty * 2
+        self._update_qty_in_location(location, product, qty * 2 - 2)
+        self.one_line_picking.action_assign()
+        self.assertEqual(move.state, "partially_available")
+        # Process all lines
+        move_lines = self.batch.picking_ids.move_line_ids
+        self._set_dest_package_and_done(move_lines, self.bin1)
+        # Increase quantity available
+        self._update_qty_in_location(location, product, qty * 2)
+        self.one_line_picking.action_assign()
+        self.assertEqual(move.state, "assigned")
+        # Finalize
+        move_lines.write({"location_dest_id": self.packing_location.id})
+
+        response = self.service.dispatch(
+            "set_destination_all",
+            params={
+                "picking_batch_id": self.batch.id,
+                "barcode": self.packing_location.barcode,
+            },
+        )
+        self.assert_response(
+            response,
+            next_state="start",
+            message=self.service.msg_store.batch_transfer_complete(),
+        )
+        # since the whole batch is complete, we expect the batch and all
+        # pickings to be 'done'
+        self.assertRecordValues(
+            move_lines.mapped("picking_id"), [{"state": "done"}, {"state": "done"}]
+        )
+        self.assertRecordValues(
+            move_lines.sorted("qty_done"),
+            [
+                {
+                    "shopfloor_unloaded": True,
+                    "qty_done": 8,
+                    "state": "done",
+                    "location_dest_id": self.packing_location.id,
+                },
+                {
+                    "shopfloor_unloaded": True,
+                    "qty_done": 10,
+                    "state": "done",
+                    "location_dest_id": self.packing_location.id,
+                },
+                {
+                    "shopfloor_unloaded": True,
+                    "qty_done": 10,
+                    "state": "done",
+                    "location_dest_id": self.packing_location.id,
+                },
+            ],
+        )
+        # There was a split order, the initial one line picking contains what
+        # still remains to do
+        self.assertRecordValues(
+            self.one_line_picking, [{"state": "assigned", "batch_id": False}]
+        )
+        self.assertRecordValues(
+            self.one_line_picking.move_line_ids,
+            [
+                {
+                    "shopfloor_unloaded": False,
+                    "shopfloor_user_id": False,
+                    "reserved_uom_qty": 2,
+                    "qty_done": 0,
+                    "state": "assigned",
+                    "location_dest_id": self.packing_location.id,
+                },
+            ],
+        )
+
     def test_set_destination_all_but_different_dest(self):
         """Endpoint was called but destinations are different"""
         move_lines = self.move_lines


### PR DESCRIPTION
Follow-up of the full bin improvement.

Special use case:
A partially available line gets its availability increased after being picked.
Currently, the cluster picking scenario always assumed that all move lines are fully picked. If it wasn't the case, the move line was split during the processing of the line.
When the move line reservation is modified after being picked, we need to split the move line and it will be processed in a backorder.

Warning: I also removed the copy=True from the move lines shopfloor flags

cc @lmignon @TDu @sebalix 