### PR TITLE
[16.0][FIX] stock_available_to_promise_release_dynamic_routing: fix code smells

### DIFF
--- a/stock_available_to_promise_release/models/stock_move.py
+++ b/stock_available_to_promise_release/models/stock_move.py
@@ -875,7 +875,6 @@ class StockMove(models.Model):
             # restore the procure_method overwritten by _action_cancel()
             move.procure_method = procure_method
         self._return_quantity_in_stock(qty_to_return_per_move)
-        moves_to_unrelease.write({"need_release": True})
         for picking, moves in itertools.groupby(
             moves_to_unrelease, lambda m: m.picking_id
         ):

--- a/stock_available_to_promise_release_dynamic_routing/models/stock_move.py
+++ b/stock_available_to_promise_release_dynamic_routing/models/stock_move.py
@@ -12,8 +12,6 @@ class StockMove(models.Model):
     def _after_release_assign_moves(self):
         # Trigger the dynamic routing
         moves = super()._after_release_assign_moves()
-        if self.env.context.get("in_merge_mode"):
-            return moves
         # Check if moves can be merged. We do this after the call to
         # _action_assign in super as this could delete some records in self
         sorted_moves_by_rule = sorted(moves, key=lambda m: m.picking_id.id)


### PR DESCRIPTION
- Remove duplicate line `moves_to_unrelease.write({"need_release": True})` inside `unrelease`
- Remove stale code using "in_merge_mode" context var that is nowhere to be found in current codebase

cc @jbaudoux 