### PR TITLE
[16.0][FIX] shopfloor_mobile: pass remaining quantity across packaging loop iterations

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.esm.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.esm.js
@@ -89,11 +89,15 @@ export var PackagingQtyPickerMixin = {
         _product_qty_by_packaging: function (pkg_by_qty, qty) {
             const self = this;
             const res = {};
+            let _remaining_qty = qty;
             // Const min_unit = _.last(pkg_by_qty);
             pkg_by_qty.forEach(function (pkg) {
-                const [_qty_per_pkg, _qty] = self._qty_by_pkg(pkg.qty, qty);
+                const [_qty_per_pkg, _remaining_qty] = self._qty_by_pkg(
+                    pkg.qty,
+                    _remaining_qty
+                );
                 res[pkg.id] = _qty_per_pkg;
-                if (!_qty) return;
+                if (!_remaining_qty) return;
             });
             return res;
         },


### PR DESCRIPTION
Bug introduced in https://github.com/OCA/wms/pull/1088

When calculating quantities per packaging in `_product_qty_by_packaging`, the initial `qty` parameter was passed to `_qty_by_pkg` at every packaging level without updating the remaining unallocated quantity.

As a result, smaller packaging units calculated their required quantity against the full initial amount rather than the remainder left by larger packaging units. This inflated the total calculated in `compute_qty()`, triggering a reactive watcher feedback loop that compounded the total on every tick until overflowing to `NaN`.

### How to reproduce the error

<img width="855" height="844" alt="image" src="https://github.com/user-attachments/assets/f0099c3f-53e3-4195-8c75-47e47ff1ad9b" />


- Enter a shopfloor screen with the "packaging-qty-picker" inside
- _(Optional)_ Ensure you only have one `product.packaging` for this product
- Input something ">=" to the qty of the given packaging

cc @jbaudoux @lmignon 